### PR TITLE
Add PyPI trusted publishing workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ jobs:
   tox:
     name: Run Tox
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Run all envs
-        uses: fedora-python/tox-github-action@main
+        uses: fedora-python/tox-github-action@ef3bf5f921db3dbf26adf106f8015a7abf485445 # main
         with:
           tox_env: ${{ matrix.tox_env }}
     strategy:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    if: ${{ github.repository_owner == 'opendatahub-io' }}
+
+    runs-on: ubuntu-latest
+    environment: release
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    - name: Build sdist and wheel
+      run: uv build
+    - name: Publish to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,11 +21,11 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
     - name: Build sdist and wheel
       run: uv build
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/russellb/agentic-ci"
-Repository = "https://github.com/russellb/agentic-ci"
-Issues = "https://github.com/russellb/agentic-ci/issues"
+Homepage = "https://github.com/opendatahub-io/agentic-ci"
+Repository = "https://github.com/opendatahub-io/agentic-ci"
+Issues = "https://github.com/opendatahub-io/agentic-ci/issues"
 
 [project.scripts]
 agentic-ci = "agentic_ci.cli:main"


### PR DESCRIPTION
Add a GitHub Actions workflow that publishes to PyPI via OIDC trusted publishing when a version tag is pushed. Fix project URLs to point to the opendatahub-io org.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated release publishing workflow to PyPI

* **Chores**
  * Updated project repository URLs in package metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->