### PR TITLE
git clone shouldn't use stdin

### DIFF
--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -23,11 +23,7 @@ GIT_CLONE_TIMEOUT = int(os.environ.get("GIT_CLONE_TIMEOUT", "300"))
 GIT_PUSH_TIMEOUT = int(os.environ.get("GIT_PUSH_TIMEOUT", "120"))
 
 
-def _git_env() -> dict[str, str]:
-    """Return env dict with GIT_TERMINAL_PROMPT=0 to prevent credential prompts."""
-    env = os.environ.copy()
-    env["GIT_TERMINAL_PROMPT"] = "0"
-    return env
+_DEVNULL = subprocess.DEVNULL
 
 
 _GITLAB_URL_RE = re.compile(
@@ -182,7 +178,7 @@ def clone_repo(url: str, dest: Path, branch: str | None = None, depth: int | Non
             capture_output=True,
             text=True,
             timeout=GIT_CLONE_TIMEOUT,
-            env=_git_env(),
+            stdin=_DEVNULL,
         )
         return True
     except subprocess.TimeoutExpired:
@@ -237,7 +233,7 @@ def push_branch(repo_dir: Path, remote: str = "origin", branch: str | None = Non
             capture_output=True,
             text=True,
             timeout=GIT_PUSH_TIMEOUT,
-            env=_git_env(),
+            stdin=_DEVNULL,
         )
         return True
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
GIT_TERMINAL_PROMPT=0 on older git versions (pre-2.34, common on CI base images) disables all credential prompting, including GIT_ASKPASS and credential helpers -- not just terminal prompts. The GitLab CI runner injects credentials via these mechanisms (CI_JOB_TOKEN through insteadOf or GIT_ASKPASS), so blocking them causes a "could not read Username" failure.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved git subprocess handling to ensure reliable repository operations in non-interactive environments during clone and push operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->