### PR TITLE
the work directory needs to be marked as safe for podman ownership

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.2"
+version = "0.2.3"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/gates.py
+++ b/src/agentic_ci/gates.py
@@ -166,7 +166,16 @@ def gitleaks_scan(repo_dir: Path, compare_ref: str = "origin/HEAD") -> list[str]
 
     try:
         count_output = subprocess.run(
-            ["git", "-C", str(repo_dir), "rev-list", "--count", f"{compare_ref}..HEAD"],
+            [
+                "git",
+                "-c",
+                "safe.directory=*",
+                "-C",
+                str(repo_dir),
+                "rev-list",
+                "--count",
+                f"{compare_ref}..HEAD",
+            ],
             capture_output=True,
             text=True,
             check=True,

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -222,7 +222,7 @@ def push_branch(repo_dir: Path, remote: str = "origin", branch: str | None = Non
     if branch and not _validate_ref(branch):
         log.error("push_branch: invalid branch name: %s", branch)
         return False
-    cmd = ["git", "push", "--set-upstream", remote]
+    cmd = ["git", "-c", "safe.directory=*", "push", "--set-upstream", remote]
     if branch:
         cmd.append(branch)
     try:
@@ -281,7 +281,7 @@ def get_commit_info(repo_dir: Path) -> dict:
     """Get the latest commit info (author, email, message, sha)."""
     fmt = "%H%n%ae%n%an%n%s"
     result = subprocess.run(
-        ["git", "log", "-1", f"--format={fmt}"],
+        ["git", "-c", "safe.directory=*", "log", "-1", f"--format={fmt}"],
         cwd=str(repo_dir),
         capture_output=True,
         text=True,
@@ -306,7 +306,7 @@ def get_changed_files(repo_dir: Path, base_ref: str = "HEAD~1") -> list[str]:
         raise GitDiffError(f"Invalid ref name: {base_ref}")
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", base_ref],
+            ["git", "-c", "safe.directory=*", "diff", "--name-only", base_ref],
             cwd=str(repo_dir),
             capture_output=True,
             text=True,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Since Git 2.35.2 (April 2022), git has a security feature called safe.directory. It refuses to operate on a repository if the directory is owned by a different user than the process running git. This prevents a class of attacks where a malicious user could plant a .git/config with hooks that execute when an unsuspecting user (especially root) runs git in that directory.

In our CI pipeline, the ownership mismatch occurs because:

- The CI runner process is root (uid 0)
- PodmanBackend.setup() runs chown -R 1000:1000 on the cloned repo so the container can write to it
- After the container exits, the post-agent gates (still running as root) try to run git log, git diff, git push on that same directory
- Git sees: "I'm uid 0, but this repo is owned by uid 1000 — refusing"

The -c safe.directory=* flag is a per-command override that tells git "trust this directory regardless of ownership." It's safe in this context because:

- We cloned the repo ourselves moments earlier
- The only modifications came from our own container
- It's an ephemeral CI workspace that's discarded after the job

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
