### PR TITLE
Mark cloned repos as safe.directory for container UID mismatches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.1"
+version = "0.2.2"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -180,6 +180,11 @@ def clone_repo(url: str, dest: Path, branch: str | None = None, depth: int | Non
             timeout=GIT_CLONE_TIMEOUT,
             stdin=_DEVNULL,
         )
+        subprocess.run(
+            ["git", "config", "--global", "--add", "safe.directory", str(dest.resolve())],
+            capture_output=True,
+            text=True,
+        )
         return True
     except subprocess.TimeoutExpired:
         log.error("git clone timed out after %ds for %s", GIT_CLONE_TIMEOUT, url)


### PR DESCRIPTION
When a repo cloned by agentic-ci is later mounted into a container, files may be modified as a different UID. Post-agent git commands on the host then fail with "dubious ownership". Adding the clone destination to safe.directory at clone time prevents this.
