### PR TITLE
Fix push branch auto detect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.3"
+version = "0.2.4"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -227,9 +227,24 @@ def push_branch(repo_dir: Path, remote: str = "origin", branch: str | None = Non
     if branch and not _validate_ref(branch):
         log.error("push_branch: invalid branch name: %s", branch)
         return False
-    cmd = ["git", "push", "--set-upstream", remote]
-    if branch:
-        cmd.append(branch)
+    if not branch:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=str(repo_dir),
+                check=True,
+                capture_output=True,
+                text=True,
+                stdin=_DEVNULL,
+            )
+            branch = result.stdout.strip()
+        except subprocess.CalledProcessError:
+            log.error("push_branch: could not detect current branch")
+            return False
+        if not _validate_ref(branch):
+            log.error("push_branch: detected invalid branch name: %s", branch)
+            return False
+    cmd = ["git", "push", "--set-upstream", remote, branch]
     try:
         subprocess.run(
             cmd,


### PR DESCRIPTION
git push --set-upstream origin without a branch name fails under
push.default=simple for new branches. Detect the current branch via
git rev-parse --abbrev-ref HEAD so callers don't need to pass it
explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `push_branch` to automatically detect and use the current branch when no branch is explicitly specified.

* **Chores**
  * Updated package version to 0.2.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->