### PR TITLE
Add ci lifecycle logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.4"
+version = "0.2.5"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -101,13 +101,16 @@ class OpenShellBackend(Backend):
 
     def _upload_credentials(self):
         adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
-        if not os.path.isfile(adc):
+        if os.path.isfile(adc):
+            source = "default ADC file"
+        else:
             adc = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+            source = "GOOGLE_APPLICATION_CREDENTIALS file"
         if not adc or not os.path.isfile(adc):
             print("--- No credentials found to upload ---", flush=True)
             return
 
-        print(f"--- Uploading credentials ({adc}) ---", flush=True)
+        print(f"--- Uploading credentials ({source}) ---", flush=True)
 
         staging = tempfile.mkdtemp(prefix="agentic-ci-creds-")
         try:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -37,10 +37,10 @@ class OpenShellBackend(Backend):
             flag_path=self.policy_path,
             workdir=self.workdir,
         )
-        print(f"--- Creating sandbox (policy: {resolved_policy}) ---", flush=True)
+        image_info = f", image: {self.image}" if self.image else ""
+        print(f"--- Creating sandbox (policy: {resolved_policy}{image_info}) ---", flush=True)
         sandbox.create(image=self.image, policy_path=resolved_policy)
 
-        print("--- Uploading credentials ---", flush=True)
         self._upload_credentials()
 
     def stop(self):
@@ -104,7 +104,10 @@ class OpenShellBackend(Backend):
         if not os.path.isfile(adc):
             adc = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
         if not adc or not os.path.isfile(adc):
+            print("--- No credentials found to upload ---", flush=True)
             return
+
+        print(f"--- Uploading credentials ({adc}) ---", flush=True)
 
         staging = tempfile.mkdtemp(prefix="agentic-ci-creds-")
         try:

--- a/src/agentic_ci/backends/openshell/gateway.py
+++ b/src/agentic_ci/backends/openshell/gateway.py
@@ -36,12 +36,12 @@ def start():
     time.sleep(1)
 
     secret = os.urandom(16).hex()
+    supervisor_image = os.environ.get("OPENSHELL_SUPERVISOR_IMAGE", "openshell/supervisor:dev")
+    print(f"  Supervisor image: {supervisor_image}", flush=True)
     env = {
         **os.environ,
         "OPENSHELL_SSH_HANDSHAKE_SECRET": secret,
-        "OPENSHELL_SUPERVISOR_IMAGE": os.environ.get(
-            "OPENSHELL_SUPERVISOR_IMAGE", "openshell/supervisor:dev"
-        ),
+        "OPENSHELL_SUPERVISOR_IMAGE": supervisor_image,
     }
 
     subprocess.Popen(

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -96,13 +96,18 @@ def resolve(flag_path=None, workdir="."):
     Returns the absolute path to the policy file.
     """
     if flag_path:
-        return os.path.abspath(flag_path)
+        resolved = os.path.abspath(flag_path)
+        print(f"  Policy source: --policy flag ({resolved})", flush=True)
+        return resolved
 
     repo_policy = os.path.join(workdir, REPO_POLICY_PATH)
     if os.path.isfile(repo_policy):
-        return os.path.abspath(repo_policy)
+        resolved = os.path.abspath(repo_policy)
+        print(f"  Policy source: repo ({resolved})", flush=True)
+        return resolved
 
     fd, path = tempfile.mkstemp(suffix=".yml", prefix="agentic-ci-policy-")
     with os.fdopen(fd, "w") as f:
         f.write(DEFAULT_POLICY)
+    print("  Policy source: built-in default", flush=True)
     return path

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -181,12 +181,15 @@ class PodmanBackend(Backend):
 
         adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
         ga_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
-        for path in [adc, ga_creds]:
+        for path, label in [
+            (adc, "default ADC file"),
+            (ga_creds, "GOOGLE_APPLICATION_CREDENTIALS file"),
+        ]:
             if path and os.path.isfile(path):
                 with open(path) as f:
                     content = f.read()
                 if self._is_valid_json(content):
-                    return content, path
+                    return content, label
 
         raise RuntimeError(
             "No GCP credentials found. Set GCLOUD_CREDENTIALS, "

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -36,10 +36,13 @@ class PodmanBackend(Backend):
         subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
 
         if os.getuid() == 0:
+            print("  Container user: root (chown workdir)", flush=True)
             subprocess.run(
                 ["chown", "-R", "1000:1000", self.workdir],
                 capture_output=True,
             )
+        else:
+            print("  Container user: rootless (userns keep-id)", flush=True)
 
         env_args = self._build_env_args()
         vol_args = self._build_vol_args()
@@ -84,6 +87,7 @@ class PodmanBackend(Backend):
         if not self.is_running():
             self.setup()
 
+        print("--- Executing Claude in container ---", flush=True)
         otel_env = self._build_otel_exec_env(otel_port)
         claude_args = self._build_claude_args(prompt, model, extra_args)
 
@@ -129,6 +133,7 @@ class PodmanBackend(Backend):
                 raise RuntimeError(
                     "No container image specified. Use --image or set CLAUDE_CONTAINER_IMAGE."
                 )
+        print(f"  Image: {self.image}", flush=True)
 
     def _resolve_credentials(self):
         if self._config_dir is not None:
@@ -147,31 +152,31 @@ class PodmanBackend(Backend):
         with open(config_path, "w") as f:
             f.write(f"[core]\nproject = {vertex_project}\ndisable_prompts = true\n")
 
-        creds_json = self._find_credentials()
+        creds_json, creds_source = self._find_credentials()
         adc_path = os.path.join(
             self._config_dir, ".config", "gcloud", "application_default_credentials.json"
         )
         with open(adc_path, "w") as f:
             f.write(creds_json)
 
-        print("--- Credentials staged ---", flush=True)
+        print(f"--- Credentials staged ({creds_source}) ---", flush=True)
 
     def _find_credentials(self):
-        """Locate and validate gcloud credentials. Returns raw JSON string."""
+        """Locate and validate gcloud credentials. Returns (json_string, source_label)."""
         raw = os.environ.get("GCLOUD_CREDENTIALS", "")
         if raw:
             if self._is_valid_json(raw):
-                return raw
+                return raw, "GCLOUD_CREDENTIALS env var"
             decoded = self._try_base64_decode(raw)
             if decoded and self._is_valid_json(decoded):
-                return decoded
+                return decoded, "GCLOUD_CREDENTIALS env var (base64)"
             raise RuntimeError("GCLOUD_CREDENTIALS is not valid JSON or base64-encoded JSON")
 
         sa_key = os.environ.get("GCP_SERVICE_ACCOUNT_KEY", "")
         if sa_key:
             decoded = self._try_base64_decode(sa_key)
             if decoded and self._is_valid_json(decoded):
-                return decoded
+                return decoded, "GCP_SERVICE_ACCOUNT_KEY env var"
             raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid base64-encoded JSON")
 
         adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
@@ -181,7 +186,7 @@ class PodmanBackend(Backend):
                 with open(path) as f:
                     content = f.read()
                 if self._is_valid_json(content):
-                    return content
+                    return content, path
 
         raise RuntimeError(
             "No GCP credentials found. Set GCLOUD_CREDENTIALS, "

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -52,7 +52,16 @@ def cmd_run(args, backend):
 
     backend.setup()
 
-    model = args.model or os.environ.get("CLAUDE_MODEL", "claude-opus-4-6")
+    if args.model:
+        model = args.model
+        model_source = "--model flag"
+    elif os.environ.get("CLAUDE_MODEL"):
+        model = os.environ["CLAUDE_MODEL"]
+        model_source = "CLAUDE_MODEL env var"
+    else:
+        model = "claude-opus-4-6"
+        model_source = "default"
+    print(f"  Model: {model} (from {model_source})", flush=True)
 
     run_dir = tempfile.mkdtemp(prefix="agentic-ci-run.")
 
@@ -184,6 +193,7 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    print(f"--- Backend: {args.backend} | Workdir: {os.path.abspath(args.workdir)} ---", flush=True)
     backend = create_backend(
         args.backend,
         workdir=args.workdir,

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -14,8 +14,9 @@ def test_find_credentials_from_gcloud_credentials_json(monkeypatch, tmp_path):
     monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
 
     backend = PodmanBackend(workdir=str(tmp_path))
-    result = backend._find_credentials()
+    result, source = backend._find_credentials()
     assert json.loads(result)["client_id"] == "test"
+    assert source == "GCLOUD_CREDENTIALS env var"
 
 
 def test_find_credentials_from_base64(monkeypatch, tmp_path):
@@ -24,8 +25,9 @@ def test_find_credentials_from_base64(monkeypatch, tmp_path):
     monkeypatch.setenv("GCLOUD_CREDENTIALS", encoded)
 
     backend = PodmanBackend(workdir=str(tmp_path))
-    result = backend._find_credentials()
+    result, source = backend._find_credentials()
     assert json.loads(result)["project_id"] == "test"
+    assert source == "GCLOUD_CREDENTIALS env var (base64)"
 
 
 def test_find_credentials_from_service_account_key(monkeypatch, tmp_path):
@@ -35,8 +37,9 @@ def test_find_credentials_from_service_account_key(monkeypatch, tmp_path):
     monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", encoded)
 
     backend = PodmanBackend(workdir=str(tmp_path))
-    result = backend._find_credentials()
+    result, source = backend._find_credentials()
     assert json.loads(result)["project_id"] == "sa-test"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY env var"
 
 
 def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
@@ -49,8 +52,9 @@ def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
     monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
 
     backend = PodmanBackend(workdir=str(tmp_path))
-    result = backend._find_credentials()
+    result, source = backend._find_credentials()
     assert json.loads(result)["client_id"] == "file-test"
+    assert source == str(adc_path)
 
 
 def test_find_credentials_raises_when_missing(monkeypatch, tmp_path):

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -54,7 +54,7 @@ def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
     backend = PodmanBackend(workdir=str(tmp_path))
     result, source = backend._find_credentials()
     assert json.loads(result)["client_id"] == "file-test"
-    assert source == str(adc_path)
+    assert source == "GOOGLE_APPLICATION_CREDENTIALS file"
 
 
 def test_find_credentials_raises_when_missing(monkeypatch, tmp_path):


### PR DESCRIPTION
Surface key events during setup/run/stop so CI operators can see exactly which container image, credential source, policy, and model are in use without exposing sensitive values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced logging transparency throughout setup and execution, displaying resolved container images, policy resolution sources, selected models, and credential sources
  * Added status banners for backend and workspace information

* **Chores**
  * Version updated to 0.2.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->