### PR TITLE
Improve cli output

### DIFF
--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -1,9 +1,11 @@
 """Abstract base class for sandbox backends."""
 
 import os
+import sys
 import time
 from abc import ABC, abstractmethod
 
+from agentic_ci import log
 from agentic_ci.stream import StreamProcessor
 
 
@@ -74,7 +76,9 @@ class Backend(ABC):
                     stream_complete = True
                     break
         else:
-            proc.stdout.read()
+            for line in proc.stdout:
+                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
 
         try:
             proc.kill()
@@ -84,10 +88,7 @@ class Backend(ABC):
         rc = proc.returncode
 
         if stream_complete and rc != 0:
-            print(
-                f"--- stream processor detected run complete (rc={rc}), treating as success ---",
-                flush=True,
-            )
+            log.info(f"stream processor detected run complete (rc={rc}), treating as success")
             rc = 0
 
         return rc

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -5,6 +5,7 @@ import shlex
 import shutil
 import tempfile
 
+from agentic_ci import log
 from agentic_ci.backend import Backend
 from agentic_ci.backends.openshell import gateway, policy, sandbox
 
@@ -24,13 +25,13 @@ class OpenShellBackend(Backend):
 
     def setup(self):
         if not gateway.is_running():
-            print("--- Starting OpenShell gateway ---", flush=True)
+            log.section("Starting OpenShell gateway")
             gateway.start()
         else:
-            print("--- OpenShell gateway already running ---", flush=True)
+            log.section("OpenShell gateway already running")
 
         if sandbox.exists():
-            print("--- Sandbox already exists ---", flush=True)
+            log.section("Sandbox already exists")
             return
 
         resolved_policy = policy.resolve(
@@ -38,18 +39,18 @@ class OpenShellBackend(Backend):
             workdir=self.workdir,
         )
         image_info = f", image: {self.image}" if self.image else ""
-        print(f"--- Creating sandbox (policy: {resolved_policy}{image_info}) ---", flush=True)
+        log.section(f"Creating sandbox (policy: {resolved_policy}{image_info})")
         sandbox.create(image=self.image, policy_path=resolved_policy)
 
         self._upload_credentials()
 
     def stop(self):
         if not sandbox.exists():
-            print("--- No sandbox to stop ---", flush=True)
+            log.section("No sandbox to stop")
             return
 
         sandbox.delete()
-        print("--- Sandbox deleted ---", flush=True)
+        log.section("Sandbox deleted")
 
     def run(
         self,
@@ -107,10 +108,10 @@ class OpenShellBackend(Backend):
             adc = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
             source = "GOOGLE_APPLICATION_CREDENTIALS file"
         if not adc or not os.path.isfile(adc):
-            print("--- No credentials found to upload ---", flush=True)
+            log.section("No credentials found to upload")
             return
 
-        print(f"--- Uploading credentials ({source}) ---", flush=True)
+        log.section(f"Uploading credentials ({source})")
 
         staging = tempfile.mkdtemp(prefix="agentic-ci-creds-")
         try:

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import tempfile
 
+from agentic_ci import log
 from agentic_ci.backend import Backend
 
 CONTAINER_NAME = "agentic-ci"
@@ -31,19 +32,19 @@ class PodmanBackend(Backend):
         self._resolve_credentials()
 
         if self.is_running():
-            print("--- Podman container already running ---", flush=True)
+            log.section("Podman container already running")
             return
 
         subprocess.run(["podman", "rm", "-f", CONTAINER_NAME], capture_output=True)
 
         if os.getuid() == 0:
-            print("  Container user: root (chown workdir)", flush=True)
+            log.detail("Container user", "root (chown workdir)")
             subprocess.run(
                 ["chown", "-R", "1000:1000", self.workdir],
                 capture_output=True,
             )
         else:
-            print("  Container user: rootless (userns keep-id)", flush=True)
+            log.detail("Container user", "rootless (userns keep-id)")
 
         env_args = self._build_env_args()
         vol_args = self._build_vol_args()
@@ -52,6 +53,18 @@ class PodmanBackend(Backend):
             ["--user", "1000:1000"] if os.getuid() == 0 else ["--userns=keep-id:uid=1000,gid=1000"]
         )
 
+        log.section("Pulling image")
+        proc = subprocess.Popen(
+            ["podman", "pull", self.image],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        )
+        for line in proc.stdout:
+            log.info(line.decode("utf-8", errors="replace").rstrip())
+        rc = proc.wait()
+        if rc != 0:
+            raise subprocess.CalledProcessError(rc, ["podman", "pull", self.image])
+
         cmd = [
             "podman",
             "run",
@@ -59,7 +72,7 @@ class PodmanBackend(Backend):
             "--name",
             CONTAINER_NAME,
             "--pull",
-            "newer",
+            "never",
             "--network",
             "host",
             *user_args,
@@ -74,7 +87,7 @@ class PodmanBackend(Backend):
         ]
 
         subprocess.run(cmd, check=True, capture_output=True)
-        print("--- Podman container started ---", flush=True)
+        log.section("Podman container started")
 
     def run(
         self,
@@ -88,7 +101,7 @@ class PodmanBackend(Backend):
         if not self.is_running():
             self.setup()
 
-        print("--- Executing Claude in container ---", flush=True)
+        log.section("Executing Claude in container")
         otel_env = self._build_otel_exec_env(otel_port)
         claude_args = self._build_claude_args(prompt, model, extra_args)
 
@@ -108,9 +121,9 @@ class PodmanBackend(Backend):
             capture_output=True,
         )
         if result.returncode == 0:
-            print("--- Podman container stopped ---", flush=True)
+            log.section("Podman container stopped")
         else:
-            print("--- No container to stop ---", flush=True)
+            log.section("No container to stop")
 
     def is_running(self):
         result = subprocess.run(
@@ -134,7 +147,7 @@ class PodmanBackend(Backend):
                 raise RuntimeError(
                     "No container image specified. Use --image or set CLAUDE_CONTAINER_IMAGE."
                 )
-        print(f"  Image: {self.image}", flush=True)
+        log.detail("Image", self.image)
 
     def _resolve_credentials(self):
         if self._config_dir is not None:
@@ -160,7 +173,7 @@ class PodmanBackend(Backend):
         with open(adc_path, "w") as f:
             f.write(creds_json)
 
-        print(f"--- Credentials staged ({creds_source}) ---", flush=True)
+        log.section(f"Credentials staged ({creds_source})")
 
     def _find_credentials(self):
         """Locate and validate gcloud credentials. Returns (json_string, source_label)."""

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -123,7 +123,13 @@ class PodmanBackend(Backend):
         if result.returncode == 0:
             log.section("Podman container stopped")
         else:
-            log.section("No container to stop")
+            stderr = (result.stderr or b"").decode("utf-8", errors="replace")
+            if "no such container" in stderr.lower():
+                log.section("No container to stop")
+            else:
+                raise subprocess.CalledProcessError(
+                    result.returncode, ["podman", "rm", "-f", CONTAINER_NAME], stderr=result.stderr
+                )
 
     def is_running(self):
         result = subprocess.run(

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -6,7 +6,7 @@ import shutil
 import sys
 import tempfile
 
-from agentic_ci import otel
+from agentic_ci import log, otel
 from agentic_ci.backends import create_backend
 from agentic_ci.gates import resolve_gates, validate_gate_env
 
@@ -20,7 +20,7 @@ def _parse_gate_list(value: str | None) -> list[str]:
 
 def cmd_setup(args, backend):
     backend.setup()
-    print("--- Setup complete ---", flush=True)
+    log.section("Setup complete")
 
 
 def cmd_stop(args, backend):
@@ -40,7 +40,7 @@ def cmd_run(args, backend):
         validate_gate_env(all_gates)
 
     if pre_gate_names:
-        print("--- Running pre-gates ---", flush=True)
+        log.section("Running pre-gates")
         pre_specs = resolve_gates(pre_gate_names)
         for gate in pre_specs:
             errors = gate.fn(workdir=args.workdir)
@@ -48,7 +48,7 @@ def cmd_run(args, backend):
                 for err in errors:
                     print(f"Pre-gate {gate.name} blocked: {err}", flush=True)
                 sys.exit(0)
-            print(f"  {gate.name}: passed", flush=True)
+            log.info(f"{gate.name}: passed")
 
     backend.setup()
 
@@ -61,7 +61,7 @@ def cmd_run(args, backend):
     else:
         model = "claude-opus-4-6"
         model_source = "default"
-    print(f"  Model: {model} (from {model_source})", flush=True)
+    log.detail("Model", f"{model} (from {model_source})")
 
     run_dir = tempfile.mkdtemp(prefix="agentic-ci-run.")
 
@@ -71,14 +71,12 @@ def cmd_run(args, backend):
     otel_proc = None
 
     if not args.no_otel:
-        print("--- Starting OTEL collector ---", flush=True)
+        log.section("Starting OTEL collector")
         otel_proc, otel_port, otel_log, otel_rate = otel.start_collector(run_dir)
-        print(
-            f"--- OTEL collector started (pid {otel_proc.pid}, port {otel_port}) ---",
-            flush=True,
-        )
+        log.detail("pid", str(otel_proc.pid))
+        log.detail("port", str(otel_port))
 
-    print(f"--- Running Claude ({model}) via {args.backend} backend ---", flush=True)
+    log.section(f"Running Claude ({model}) via {args.backend} backend")
     rc = backend.run(
         prompt=args.prompt,
         model=model,
@@ -90,14 +88,16 @@ def cmd_run(args, backend):
 
     if otel_proc:
         otel.stop_collector(otel_proc)
-        print(f"\n--- Claude exit code: {rc} ---", flush=True)
-        print("--- OTEL Token/Cost Summary ---", flush=True)
+        print(flush=True)
+        log.section(f"Claude exit code: {rc}")
+        log.section("Token/Cost Summary (OpenTelemetry)")
         otel.print_summary(otel_log)
     else:
-        print(f"\n--- Claude exit code: {rc} ---", flush=True)
+        print(flush=True)
+        log.section(f"Claude exit code: {rc}")
 
     if rc == 0 and post_gate_names:
-        print("--- Running post-gates ---", flush=True)
+        log.section("Running post-gates")
         post_specs = resolve_gates(post_gate_names)
         gate_errors: list[str] = []
         for gate in post_specs:
@@ -107,7 +107,7 @@ def cmd_run(args, backend):
                 for err in errors:
                     print(f"  {gate.name}: FAILED - {err}", file=sys.stderr, flush=True)
             else:
-                print(f"  {gate.name}: passed", flush=True)
+                log.info(f"{gate.name}: passed")
         if gate_errors:
             rc = 1
 
@@ -193,7 +193,8 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    print(f"--- Backend: {args.backend} | Workdir: {os.path.abspath(args.workdir)} ---", flush=True)
+    log.section(f"Backend: {args.backend}")
+    log.detail("Workdir", os.path.abspath(args.workdir))
     backend = create_backend(
         args.backend,
         workdir=args.workdir,

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -118,6 +118,9 @@ def cmd_run(args, backend):
         except (OSError, FileNotFoundError):
             pass
 
+    if not args.keep:
+        backend.stop()
+
     sys.exit(rc)
 
 
@@ -164,6 +167,11 @@ def main():
         "--no-streaming", action="store_true", help="Disable pretty-printed stream output"
     )
     p_run.add_argument("--no-otel", action="store_true", help="Disable OTEL telemetry collection")
+    p_run.add_argument(
+        "--keep",
+        action="store_true",
+        help="Keep the sandbox environment running after the run completes",
+    )
     p_run.add_argument(
         "--model",
         default=None,

--- a/src/agentic_ci/log.py
+++ b/src/agentic_ci/log.py
@@ -1,0 +1,26 @@
+"""Colored CLI output helpers for agentic-ci."""
+
+import os
+import sys
+
+
+def _use_color() -> bool:
+    return not os.environ.get("NO_COLOR") and hasattr(sys.stdout, "isatty") and sys.stdout.isatty()
+
+
+def section(msg: str) -> None:
+    """Print a section header: ▶ msg"""
+    if _use_color():
+        print(f"\033[1;36m▶ {msg}\033[0m", flush=True)
+    else:
+        print(f"▶ {msg}", flush=True)
+
+
+def detail(label: str, value: str) -> None:
+    """Print an indented detail line: '  label: value'."""
+    print(f"  {label}: {value}", flush=True)
+
+
+def info(msg: str) -> None:
+    """Print an indented info line."""
+    print(f"  {msg}", flush=True)

--- a/src/agentic_ci/otel.py
+++ b/src/agentic_ci/otel.py
@@ -112,6 +112,7 @@ def start_collector(run_dir):
     proc = subprocess.Popen(
         [sys.executable, "-m", "agentic_ci.otel"],
         env=env,
+        stderr=subprocess.DEVNULL,
     )
 
     for _ in range(50):
@@ -217,10 +218,6 @@ def print_summary(log_file):
 
     token_totals, cost_totals, api_requests, active_time = parse_metrics(records)
 
-    print("=" * 60)
-    print("  CLAUDE TOKEN & COST SUMMARY (OpenTelemetry)")
-    print("=" * 60)
-
     if token_totals:
         models = sorted(set(m for m, _ in token_totals.keys()))
         for model in models:
@@ -256,8 +253,6 @@ def print_summary(log_file):
         total_duration = sum(float(r.get("duration_ms", 0)) for r in api_requests)
         if total_duration:
             print(f"  Total API time: {total_duration / 1000:.1f}s")
-
-    print("=" * 60)
 
 
 def main():

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -7,6 +7,8 @@ import signal
 import sys
 import time
 
+from agentic_ci import log
+
 
 def _format_tool(name, params):
     """Return a compact one-line summary for known tools."""
@@ -138,6 +140,49 @@ class StreamProcessor:
             self._tool_name = None
             self._tool_json = ""
 
+    def _format_init(self, msg):
+        version = msg.get("claude_code_version", "unknown")
+        model = msg.get("model", "unknown")
+        perms = msg.get("permissionMode", "unknown")
+        tools = msg.get("tools", [])
+        mcp = msg.get("mcp_servers", [])
+        agents = msg.get("agents", [])
+        plugins = msg.get("plugins", [])
+        log.section(f"Claude Code v{version}")
+        log.detail("Model", model)
+        log.detail("Permissions", perms)
+        log.detail("Tools", f"{len(tools)} available")
+        if mcp:
+            log.detail(
+                "MCP servers",
+                ", ".join(s.get("name", s) if isinstance(s, dict) else s for s in mcp),
+            )
+        else:
+            log.detail("MCP servers", "none")
+        log.detail("Agents", f"{len(agents)} available")
+        if plugins:
+            log.detail(
+                "Plugins",
+                ", ".join(p.get("name", str(p)) if isinstance(p, dict) else p for p in plugins),
+            )
+
+    def _format_result(self, msg):
+        subtype = msg.get("subtype", "unknown")
+        stop = msg.get("stop_reason", "")
+        duration_ms = msg.get("duration_ms", 0)
+        api_ms = msg.get("duration_api_ms", 0)
+        ttft_ms = msg.get("ttft_ms", 0)
+        turns = msg.get("num_turns", 0)
+        cost = msg.get("total_cost_usd", 0)
+        label = f"{subtype} ({stop})" if stop else subtype
+        log.section(f"Result: {label}")
+        log.detail(
+            "Duration",
+            f"{duration_ms / 1000:.1f}s (API: {api_ms / 1000:.1f}s, TTFT: {ttft_ms / 1000:.1f}s)",
+        )
+        log.detail("Turns", str(turns))
+        log.detail("Cost", f"${cost:.4f}")
+
     def process_line(self, line):
         """Process a single line of stream-json. Returns True if run is complete."""
         line = line.strip()
@@ -153,14 +198,16 @@ class StreamProcessor:
 
         if msg_type == "system":
             subtype = msg.get("subtype", "")
-            if subtype == "api_retry":
+            if subtype == "init":
+                self._format_init(msg)
+            elif subtype == "api_retry":
                 attempt = msg.get("attempt", "?")
                 max_retries = msg.get("max_retries", "?")
                 delay = msg.get("retry_delay_ms", "?")
                 error = msg.get("error", "unknown")
                 self._last_block_type = "system"
                 print(
-                    f"{self.YELLOW}\U0001f504 Retry {attempt}/{max_retries}{self.RESET} "
+                    f"  {self.YELLOW}\U0001f504 Retry {attempt}/{max_retries}{self.RESET} "
                     f"{error} — retrying in {delay}ms",
                     flush=True,
                 )
@@ -173,15 +220,14 @@ class StreamProcessor:
                     if isinstance(content, str) and "FULL RUN COMPLETE" in content:
                         self._end_block()
                         if self.claude_pid:
-                            print(
-                                "--- FULL RUN COMPLETE detected, terminating Claude ---", flush=True
-                            )
+                            log.section("FULL RUN COMPLETE detected, terminating Claude")
                             os.kill(self.claude_pid, signal.SIGTERM)
                         return True
             return False
 
         if msg_type == "result":
             self._end_block()
+            self._format_result(msg)
             return True
 
         if msg_type != "stream_event":
@@ -195,11 +241,11 @@ class StreamProcessor:
             block_type = block.get("type")
             if block_type == "text":
                 self._last_block_type = "text"
-                print(f"{self.CLAUDE}\U0001f4ac Claude ", end="", flush=True)
+                print(f"  {self.CLAUDE}\U0001f4ac Claude ", end="", flush=True)
                 self._in_text = True
             elif block_type == "thinking":
                 self._last_block_type = "thinking"
-                print(f"{self.THINK}\U0001f9e0 Thinking ", end="", flush=True)
+                print(f"  {self.THINK}\U0001f9e0 Thinking ", end="", flush=True)
                 self._in_thinking = True
             elif block_type in ("tool_use", "server_tool_use"):
                 self._tool_name = block.get("name", "unknown")
@@ -269,7 +315,7 @@ class StreamProcessor:
             error_msg = error.get("message", "")
             self._last_block_type = "error"
             print(
-                f"{self.RED}❌ Error: {error_type}: {error_msg}{self.RESET}",
+                f"  {self.RED}❌ Error: {error_type}: {error_msg}{self.RESET}",
                 flush=True,
             )
 

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -221,7 +221,10 @@ class StreamProcessor:
                         self._end_block()
                         if self.claude_pid:
                             log.section("FULL RUN COMPLETE detected, terminating Claude")
-                            os.kill(self.claude_pid, signal.SIGTERM)
+                            try:
+                                os.kill(self.claude_pid, signal.SIGTERM)
+                            except ProcessLookupError:
+                                pass
                         return True
             return False
 


### PR DESCRIPTION
## Description

Improve CLI output formatting and system message display: more information is displayed in a more readable way.

Container is automatically cleaned up when using `agentic-ci run`, but can be kept running with `--keep`.

## How Has This Been Tested?

Locally with:

```
uv run --with . agentic-ci run --model "haiku" --image ghcr.io/opendatahub-io/ai-helpers:latest "say hello"
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--keep` option to retain backend state after a run.
  * New lightweight CLI logging helpers for consistent, colored section/detail/info output.

* **Refactor**
  * Replaced ad-hoc prints with structured logging across setup, run, container/back-end lifecycle, streaming output, and OTEL reporting.
  * Stream output now shows clearer init/result summaries and improved completion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->