### PR TITLE
Add harness abstraction for multi-agent support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Two **harnesses** define which agent CLI to run:
 
 ## Architecture
 
-```
+```text
 src/agentic_ci/
     cli.py              # Entry point, backend/harness selection, OTEL orchestration
     backend.py          # Backend ABC + shared stream processing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,22 @@
 # Agentic CI
 
-agentic-ci runs Claude Code in sandboxed CI environments with pluggable backends. Users run `agentic-ci run "prompt"` to execute Claude in an isolated environment with streaming output and OTEL telemetry.
+agentic-ci runs AI coding agents in sandboxed CI environments with pluggable backends and harnesses. Users run `agentic-ci run "prompt"` to execute an agent in an isolated environment with streaming output and OTEL telemetry.
 
-Two backends are available:
-- **Podman** (default): Runs Claude in a Podman container. Simple, widely available.
-- **OpenShell**: Runs Claude in an [OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with network policy enforcement and filesystem isolation.
+Two **backends** provide execution environments:
+- **Podman** (default): Runs the agent in a Podman container. Simple, widely available.
+- **OpenShell**: Runs the agent in an [OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with network policy enforcement and filesystem isolation.
+
+Two **harnesses** define which agent CLI to run:
+- **claude-code** (default): [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `stream-json` output format.
+- **opencode**: [OpenCode](https://github.com/anomalyco/opencode) with JSON event output format.
 
 ## Architecture
 
 ```
 src/agentic_ci/
-    cli.py              # Entry point, backend selection, OTEL orchestration
+    cli.py              # Entry point, backend/harness selection, OTEL orchestration
     backend.py          # Backend ABC + shared stream processing
+    harness.py          # Harness ABC + ClaudeCode/OpenCode implementations
     backends/
         __init__.py     # Backend factory (create_backend)
         podman.py       # PodmanBackend — container execution
@@ -20,27 +25,28 @@ src/agentic_ci/
             gateway.py  # OpenShell gateway lifecycle
             sandbox.py  # OpenShell sandbox lifecycle
             policy.py   # Policy resolution + built-in default
-    stream.py           # Stream-json parser, pretty-printing
+    stream.py           # Stream parsers for Claude Code and OpenCode output
     otel.py             # OTLP collector + token/cost summary
 ```
 
-- **`cli.py`**: Argparse entry point with `setup`, `run`, and `stop` subcommands plus `--backend` flag. Delegates to backend for setup/execution, handles OTEL lifecycle.
+- **`cli.py`**: Argparse entry point with `setup`, `run`, and `stop` subcommands plus `--backend` and `--harness` flags. Creates harness and backend, handles OTEL lifecycle.
 
-- **`backend.py`**: Abstract `Backend` class with `setup()` and `run()` methods. Shared `_process_stream()` helper reads stream-json from a subprocess through `StreamProcessor`.
+- **`backend.py`**: Abstract `Backend` class with `setup()` and `run()` methods. Shared `_process_stream()` helper reads output from a subprocess through the harness's stream processor.
 
-- **`backends/podman.py`**: `PodmanBackend` — runs Claude in a `podman run --rm` container. Mounts workdir and gcloud credentials as volumes. Uses `--network host` when OTEL is enabled.
+- **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`.
 
-- **`backends/openshell/`**: `OpenShellBackend` — runs Claude in an OpenShell sandbox. Manages gateway lifecycle, sandbox creation with network policy, and credential upload. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
+- **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Mounts workdir and gcloud credentials as volumes. Uses `--network host` when OTEL is enabled.
 
-- **`stream.py`**: Parses Claude's stream-json output into human-readable CI logs with colored ANSI output, tool call summaries, and token rate display.
+- **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Manages gateway lifecycle, sandbox creation with network policy, and credential upload. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
+
+- **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. Both produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
 
 - **`otel.py`**: Lightweight OTLP HTTP/JSON receiver (stdlib `http.server`) that logs payloads to JSONL, tracks token usage over a sliding window, and prints a token/cost summary.
 
 ### Key
 
-- **Claude Code only** for now. Other agents can be added later.
 - **Vertex AI** for Claude API access. Credentials are staged via gcloud ADC files.
-- **OTEL collector runs on the host**, not inside the sandbox/container.
+- **OTEL collector runs on the host**, not inside the sandbox/container. Currently only Claude Code emits OTEL metrics; OpenCode provides token/cost data via its JSON output.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # agentic-ci
 
-Run Claude Code in sandboxed CI environments with streaming output and
-telemetry. Supports multiple isolation backends so you can choose the
-right tradeoff between simplicity and security.
+Run AI coding agents in sandboxed CI environments with streaming output
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and isolation backends so you can choose the right tradeoff between
+simplicity and security.
 
 ## Backends
 
 ### Podman (default)
 
-Runs Claude inside a Podman container. Each `run` creates a fresh
+Runs the agent inside a Podman container. Each `run` creates a fresh
 container that auto-deletes on exit. The work directory is mounted
 into the container and gcloud credentials are mounted read-only.
 
@@ -21,12 +22,12 @@ backend if you need stronger security controls.
 Good for: local development, CI runners that already have Podman,
 quick one-off runs in trusted environments.
 
-Requires: `podman`, a container image with Claude Code installed
+Requires: `podman`, a container image with the agent CLI installed
 (e.g. `ghcr.io/opendatahub-io/ai-helpers:latest`).
 
 ### OpenShell
 
-Runs Claude inside an [OpenShell](https://github.com/NVIDIA/OpenShell)
+Runs the agent inside an [OpenShell](https://github.com/NVIDIA/OpenShell)
 sandbox with network policy enforcement, Landlock-based filesystem
 access control, and fine-grained endpoint restrictions. Network
 policies limit which hosts the agent can reach (e.g. only Vertex AI,
@@ -69,12 +70,14 @@ down. `run` auto-calls `setup` if the sandbox isn't already running.
 # Start the sandbox
 agentic-ci setup --image ghcr.io/opendatahub-io/ai-helpers:latest
 
-# Run multiple prompts in the same sandbox
-agentic-ci run "Fix the flaky test" --image ghcr.io/opendatahub-io/ai-helpers:latest
-agentic-ci run "Update the changelog" --image ghcr.io/opendatahub-io/ai-helpers:latest
+# Run multiple prompts in the same sandbox (use --keep to prevent auto-teardown)
+agentic-ci run "Fix the flaky test" --keep \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest
+agentic-ci run "Update the changelog" \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest
 
 # Tear down the sandbox
-agentic-ci stop --image ghcr.io/opendatahub-io/ai-helpers:latest
+agentic-ci stop
 ```
 
 ### Options
@@ -86,10 +89,12 @@ agentic-ci [--backend {podman,openshell}] {setup,run,stop} [options]
 | Flag | Default | Description |
 |---|---|---|
 | `--backend` | `podman` | Sandbox backend to use |
+| `--harness` | `claude-code` | Agent harness (`claude-code` or `opencode`) |
 | `--workdir PATH` | `.` | Working directory to mount |
 | `--image IMAGE` | — | Container or sandbox base image |
-| `--model MODEL` | `claude-opus-4-6` | Claude model (`run` only) |
-| `--no-streaming` | off | Disable pretty-printed stream output (`run` only) |
+| `--model MODEL` | harness-dependent | Agent model (`run` only). Defaults to `claude-opus-4-6` for Claude Code, `google-vertex/claude-opus-4-6@default` for OpenCode |
+| `--keep` | off | Keep the sandbox running after the run completes (`run` only) |
+| `--no-streaming` | off | Disable parsed stream output; agent output is printed raw (`run` only) |
 | `--no-otel` | off | Disable OTEL telemetry collection (`run` only) |
 | `--pre-gates GATES` | — | Comma-separated pre-agent gates (`run` only) |
 | `--post-gates GATES` | — | Comma-separated post-agent gates (`run` only) |
@@ -106,7 +111,7 @@ agentic-ci run "Update the changelog" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
     --model claude-sonnet-4-6
 
-# Disable streaming for raw output
+# Disable parsed stream output (prints raw agent output)
 agentic-ci run "Run the test suite" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
     --no-streaming
@@ -147,6 +152,9 @@ changes. Gates read their configuration from environment variables.
 | `commit-message-key` | `TICKET_KEY` | Verify ticket key appears in commit message |
 | `gitleaks` | — | Scan new commits for secrets using gitleaks |
 
+Pre-agent gates are supported via `--pre-gates` with custom
+implementations (e.g. filtering by comment domain or author).
+
 All required environment variables are validated before any gate runs.
 If any are missing, the CLI exits immediately with a clear error listing
 every missing variable and which gate needs it.
@@ -171,39 +179,57 @@ The **openshell** backend uploads the local ADC file
 
 | Variable | Default | Description |
 |---|---|---|
-| `CLAUDE_MODEL` | `claude-opus-4-6` | Default model (overridden by `--model`) |
-| `CLAUDE_CONTAINER_IMAGE` | — | Default container image for podman backend |
+| `CLAUDE_MODEL` | `claude-opus-4-6` | Default model for Claude Code harness (overridden by `--model`) |
+| `CLAUDE_CONTAINER_IMAGE` | — | Default container image for Claude Code harness |
+| `OPENCODE_MODEL` | `google-vertex/claude-opus-4-6@default` | Default model for OpenCode harness (overridden by `--model`) |
+| `OPENCODE_CONTAINER_IMAGE` | — | Default container image for OpenCode harness |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | — | Vertex AI project ID |
 | `GCP_PROJECT_ID` | — | Fallback for `ANTHROPIC_VERTEX_PROJECT_ID` |
+| `GOOGLE_CLOUD_PROJECT` | — | GCP project ID (OpenCode uses this before falling back to `ANTHROPIC_VERTEX_PROJECT_ID`) |
 | `CLOUD_ML_REGION` | `global` | Vertex AI region |
+| `VERTEX_LOCATION` | — | Vertex AI region (OpenCode uses this before falling back to `CLOUD_ML_REGION`) |
 | `GCLOUD_CREDENTIALS` | — | Raw JSON or base64 gcloud credentials |
 | `GCP_SERVICE_ACCOUNT_KEY` | — | Base64-encoded service account key |
 | `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to ADC credentials file |
-| `OPENSHELL_SUPERVISOR_IMAGE` | `openshell/supervisor:dev` | OpenShell supervisor image (openshell backend only) |
+| `OPENSHELL_SUPERVISOR_IMAGE` | `openshell/supervisor:dev` | OpenShell supervisor image (`openshell` backend only) |
 
 ## Streaming Output
 
-By default, Claude's stream-json output is parsed into human-readable
-CI logs with:
+By default, agent output is parsed into human-readable CI logs with:
 
 - Colored ANSI output (thinking in red, tool calls in gray)
 - Tool call summaries (bash commands, file paths, agent dispatches)
 - Token count display with throughput rate
 - OTEL token/cost summary at completion
 
-Disable with `--no-streaming` for raw output or `--no-otel` to skip
-the summary.
+Disable with `--no-streaming` to skip the parsed output and print raw
+agent output, or `--no-otel` to skip the token/cost summary.
 
 ## Python API
 
 ```python
 from agentic_ci.backends import create_backend
+from agentic_ci.harness import create_harness
 
-backend = create_backend("podman", workdir="/path/to/repo", image="my-image:latest")
+harness = create_harness("claude-code")
+backend = create_backend("podman", harness=harness, workdir="/path/to/repo", image="my-image:latest")
 backend.setup()
 rc = backend.run(prompt="Fix the bug", model="claude-sonnet-4-6")
 backend.stop()
 ```
+
+## Additional Modules
+
+The package includes several library modules used by downstream
+pipelines:
+
+- **`agentic_ci.jira`** — Jira REST API client with `acli` delegation,
+  ADF (Atlassian Document Format) conversion, and rate limiting.
+- **`agentic_ci.git`** — Git operations (clone, branch, push, diff,
+  commit info extraction) with security hardening.
+- **`agentic_ci.pipeline`** — GitLab child pipeline YAML generation
+  with hash-based slot distribution.
+- **`agentic_ci.verdict`** — Structured verdict JSON schema validation.
 
 ## Building a Pipeline with the Generic Skill Runner
 

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -1,12 +1,17 @@
 """Abstract base class for sandbox backends."""
 
+from __future__ import annotations
+
 import os
 import sys
 import time
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from agentic_ci import log
-from agentic_ci.stream import StreamProcessor
+
+if TYPE_CHECKING:
+    from agentic_ci.harness import Harness
 
 
 class Backend(ABC):
@@ -16,13 +21,14 @@ class Backend(ABC):
     execution environments (OpenShell sandbox, Podman container, etc.).
     """
 
-    def __init__(self, workdir=".", image=None):
+    def __init__(self, workdir=".", image=None, harness: Harness | None = None):
         self.workdir = os.path.abspath(workdir)
         self.image = image
+        self.harness = harness
 
     @abstractmethod
     def setup(self):
-        """Prepare the backend for running Claude. Idempotent."""
+        """Prepare the backend. Idempotent."""
 
     @abstractmethod
     def stop(self):
@@ -38,30 +44,10 @@ class Backend(ABC):
         otel_rate_file=None,
         extra_args=None,
     ) -> int:
-        """Execute Claude with the given prompt. Returns the exit code."""
-
-    @staticmethod
-    def _build_claude_args(prompt, model, extra_args=None):
-        """Build the Claude CLI argument list."""
-        args = [
-            "claude",
-            "--permission-mode",
-            "bypassPermissions",
-            "--model",
-            model,
-            "--output-format",
-            "stream-json",
-            "--include-partial-messages",
-            "--verbose",
-            "-p",
-            prompt,
-        ]
-        if extra_args:
-            args.extend(extra_args)
-        return args
+        """Execute the agent with the given prompt. Returns the exit code."""
 
     def _process_stream(self, proc, streaming):
-        """Read stream-json from proc.stdout through StreamProcessor.
+        """Read output from proc.stdout through the harness stream processor.
 
         Returns the exit code, treating stream-complete as success even
         if the process exit code is non-zero.
@@ -69,7 +55,7 @@ class Backend(ABC):
         stream_complete = False
 
         if streaming:
-            processor = StreamProcessor(claude_pid=proc.pid)
+            processor = self.harness.create_stream_processor(pid=proc.pid)
             for line in proc.stdout:
                 text = line.decode("utf-8", errors="replace")
                 if processor.process_line(text):

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -21,7 +21,7 @@ class Backend(ABC):
     execution environments (OpenShell sandbox, Podman container, etc.).
     """
 
-    def __init__(self, workdir=".", image=None, harness: Harness | None = None):
+    def __init__(self, workdir=".", image=None, *, harness: Harness):
         self.workdir = os.path.abspath(workdir)
         self.image = image
         self.harness = harness

--- a/src/agentic_ci/backends/__init__.py
+++ b/src/agentic_ci/backends/__init__.py
@@ -1,14 +1,23 @@
 """Backend registry and factory."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
 
+if TYPE_CHECKING:
+    from agentic_ci.backend import Backend
+    from agentic_ci.harness import Harness
 
-def create_backend(name, **kwargs):
+
+def create_backend(name: str, *, harness: Harness, **kwargs) -> Backend:
     """Create a backend instance by name.
 
     Args:
         name: Backend name ("podman" or "openshell").
+        harness: Agent harness instance.
         **kwargs: Backend-specific arguments (workdir, image, policy, timeout, etc.).
 
     Returns:
@@ -19,12 +28,14 @@ def create_backend(name, **kwargs):
             workdir=kwargs.get("workdir", "."),
             image=kwargs.get("image"),
             timeout=kwargs.get("timeout", 1200),
+            harness=harness,
         )
     elif name == "openshell":
         return OpenShellBackend(
             workdir=kwargs.get("workdir", "."),
             image=kwargs.get("image"),
             policy=kwargs.get("policy"),
+            harness=harness,
         )
     else:
         raise ValueError(f"Unknown backend: {name!r}. Choose 'podman' or 'openshell'.")

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -24,7 +24,7 @@ class OpenShellBackend(Backend):
 
     _ENV_SCRIPT = "/tmp/.agentic-ci-env.sh"
 
-    def __init__(self, workdir=".", image=None, policy=None, harness: Harness | None = None):
+    def __init__(self, workdir=".", image=None, policy=None, *, harness: Harness):
         super().__init__(workdir=workdir, image=image, harness=harness)
         self.policy_path = policy
 

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -1,17 +1,22 @@
 """OpenShell sandbox backend for agentic-ci."""
 
+from __future__ import annotations
+
 import os
-import shlex
 import shutil
 import tempfile
+from typing import TYPE_CHECKING
 
 from agentic_ci import log
 from agentic_ci.backend import Backend
 from agentic_ci.backends.openshell import gateway, policy, sandbox
 
+if TYPE_CHECKING:
+    from agentic_ci.harness import Harness
+
 
 class OpenShellBackend(Backend):
-    """Runs Claude Code inside an OpenShell sandbox.
+    """Runs an AI agent inside an OpenShell sandbox.
 
     OpenShell provides security-focused sandboxing with network policy
     enforcement, filesystem isolation, and Landlock-based access control.
@@ -19,8 +24,8 @@ class OpenShellBackend(Backend):
 
     _ENV_SCRIPT = "/tmp/.agentic-ci-env.sh"
 
-    def __init__(self, workdir=".", image=None, policy=None):
-        super().__init__(workdir=workdir, image=image)
+    def __init__(self, workdir=".", image=None, policy=None, harness: Harness | None = None):
+        super().__init__(workdir=workdir, image=image, harness=harness)
         self.policy_path = policy
 
     def setup(self):
@@ -62,9 +67,9 @@ class OpenShellBackend(Backend):
         extra_args=None,
     ):
         self._write_env_script(otel_port, otel_rate_file)
-        claude_args = self._build_claude_args(prompt, model, extra_args)
+        agent_args = self.harness.build_args(prompt, model, extra_args)
 
-        cmd = ["bash", "-c", f'. {self._ENV_SCRIPT} && exec "$@"', "--", *claude_args]
+        cmd = ["bash", "-c", f'. {self._ENV_SCRIPT} && exec "$@"', "--", *agent_args]
         proc = sandbox.exec_cmd_streaming(cmd)
 
         rc = self._process_stream(proc, streaming)
@@ -72,31 +77,8 @@ class OpenShellBackend(Backend):
         return rc
 
     def _write_env_script(self, otel_port=None, otel_rate_file=None):
-        """Write env vars to a script inside the sandbox, sourced before Claude runs."""
-        vertex_project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
-        cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
-        lines = [
-            "export CLAUDE_CODE_USE_VERTEX=1",
-            f"export CLOUD_ML_REGION={shlex.quote(cloud_region)}",
-            f"export ANTHROPIC_VERTEX_PROJECT_ID={shlex.quote(vertex_project)}",
-            "export DISABLE_AUTOUPDATER=1",
-            "export GOOGLE_APPLICATION_CREDENTIALS="
-            '"$HOME/.config/gcloud/application_default_credentials.json"',
-        ]
-        if otel_port:
-            lines.extend(
-                [
-                    "export CLAUDE_CODE_ENABLE_TELEMETRY=1",
-                    "export OTEL_METRICS_EXPORTER=otlp",
-                    "export OTEL_LOGS_EXPORTER=otlp",
-                    "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
-                    f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://10.200.0.1:{otel_port}",
-                    "export OTEL_METRIC_EXPORT_INTERVAL=10000",
-                ]
-            )
-            if otel_rate_file:
-                lines.append(f"export OTEL_RATE_FILE={otel_rate_file}")
-
+        """Write env vars to a script inside the sandbox, sourced before the agent runs."""
+        lines = self.harness.build_env_script_lines(otel_port, otel_rate_file)
         script = "\n".join(lines) + "\n"
         sandbox.exec_cmd(["bash", "-c", f"cat > {self._ENV_SCRIPT} << 'ENVEOF'\n{script}ENVEOF"])
 

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -1,28 +1,41 @@
 """Podman container backend for agentic-ci."""
 
+from __future__ import annotations
+
 import base64
 import json
 import os
 import subprocess
 import tempfile
+from typing import TYPE_CHECKING
 
 from agentic_ci import log
 from agentic_ci.backend import Backend
+
+if TYPE_CHECKING:
+    from agentic_ci.harness import Harness
 
 CONTAINER_NAME = "agentic-ci"
 
 
 class PodmanBackend(Backend):
-    """Runs Claude Code inside a persistent Podman container.
+    """Runs an AI agent inside a persistent Podman container.
 
     setup() creates a long-running detached container. run() execs
-    Claude inside it. stop() tears it down. The work directory is
+    the agent inside it. stop() tears it down. The work directory is
     mounted into the container and gcloud credentials are mounted
     read-only.
     """
 
-    def __init__(self, workdir=".", image=None, timeout=1200, extra_env=None):
-        super().__init__(workdir=workdir, image=image)
+    def __init__(
+        self,
+        workdir=".",
+        image=None,
+        timeout=1200,
+        extra_env=None,
+        harness: Harness | None = None,
+    ):
+        super().__init__(workdir=workdir, image=image, harness=harness)
         self.timeout = timeout
         self._config_dir = None
         self._extra_env = extra_env or {}
@@ -53,17 +66,20 @@ class PodmanBackend(Backend):
             ["--user", "1000:1000"] if os.getuid() == 0 else ["--userns=keep-id:uid=1000,gid=1000"]
         )
 
-        log.section("Pulling image")
-        proc = subprocess.Popen(
-            ["podman", "pull", self.image],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        )
-        for line in proc.stdout:
-            log.info(line.decode("utf-8", errors="replace").rstrip())
-        rc = proc.wait()
-        if rc != 0:
-            raise subprocess.CalledProcessError(rc, ["podman", "pull", self.image])
+        if self._is_local_image():
+            log.section("Local image, skipping pull")
+        else:
+            log.section("Pulling image")
+            proc = subprocess.Popen(
+                ["podman", "pull", self.image],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+            )
+            for line in proc.stdout:
+                log.info(line.decode("utf-8", errors="replace").rstrip())
+            rc = proc.wait()
+            if rc != 0:
+                raise subprocess.CalledProcessError(rc, ["podman", "pull", self.image])
 
         cmd = [
             "podman",
@@ -101,12 +117,12 @@ class PodmanBackend(Backend):
         if not self.is_running():
             self.setup()
 
-        log.section("Executing Claude in container")
-        otel_env = self._build_otel_exec_env(otel_port)
-        claude_args = self._build_claude_args(prompt, model, extra_args)
+        log.section(f"Executing {self.harness.name} in container")
+        otel_env = self.harness.build_otel_exec_env(otel_port)
+        agent_args = self.harness.build_args(prompt, model, extra_args)
 
         proc = subprocess.Popen(
-            ["podman", "exec", *otel_env, CONTAINER_NAME, *claude_args],
+            ["podman", "exec", *otel_env, CONTAINER_NAME, *agent_args],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -140,13 +156,21 @@ class PodmanBackend(Backend):
         )
         return result.returncode == 0 and result.stdout.strip() == "true"
 
+    def _is_local_image(self):
+        """Check if the image reference is local-only (not from a remote registry).
+
+        Images prefixed with 'localhost/' are local podman builds.
+        All other references (registry.example.com/..., ghcr.io/...,
+        or bare names) are treated as remote.
+        """
+        return self.image.startswith("localhost/")
+
     def _resolve_image(self):
         if not self.image:
-            self.image = os.environ.get("CLAUDE_CONTAINER_IMAGE")
+            env_var = self.harness.image_env_var()
+            self.image = os.environ.get(env_var)
             if not self.image:
-                raise RuntimeError(
-                    "No container image specified. Use --image or set CLAUDE_CONTAINER_IMAGE."
-                )
+                raise RuntimeError(f"No container image specified. Use --image or set {env_var}.")
         log.detail("Image", self.image)
 
     def _resolve_credentials(self):
@@ -211,41 +235,14 @@ class PodmanBackend(Backend):
         )
 
     def _build_env_args(self):
-        args = [
-            "--env",
-            "CLAUDE_CODE_USE_VERTEX=1",
-            "--env",
-            f"CLOUD_ML_REGION={os.environ.get('CLOUD_ML_REGION', 'global')}",
-            "--env",
-            f"ANTHROPIC_VERTEX_PROJECT_ID={os.environ.get('ANTHROPIC_VERTEX_PROJECT_ID', '')}",
-            "--env",
-            "DISABLE_AUTOUPDATER=1",
-        ]
+        args = list(self.harness.build_env_args())
         for key, val in self._extra_env.items():
             args.extend(["--env", f"{key}={val}"])
         return args
 
-    def _build_otel_exec_env(self, otel_port=None):
-        """Build --env flags for podman exec when OTEL is enabled."""
-        if not otel_port:
-            return []
-        return [
-            "--env",
-            "CLAUDE_CODE_ENABLE_TELEMETRY=1",
-            "--env",
-            "OTEL_METRICS_EXPORTER=otlp",
-            "--env",
-            "OTEL_LOGS_EXPORTER=otlp",
-            "--env",
-            "OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
-            "--env",
-            f"OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:{otel_port}",
-            "--env",
-            "OTEL_METRIC_EXPORT_INTERVAL=10000",
-        ]
-
     def _build_vol_args(self):
         assert self._config_dir is not None
+        mount_target = self.harness.credential_mount_target()
         adc = os.path.join(
             self._config_dir,
             ".config",
@@ -261,9 +258,9 @@ class PodmanBackend(Backend):
         )
         return [
             "-v",
-            f"{adc}:/home/claude/.config/gcloud/application_default_credentials.json:ro,z",
+            f"{adc}:{mount_target}/.config/gcloud/application_default_credentials.json:ro,z",
             "-v",
-            f"{config}:/home/claude/.config/gcloud/configurations/config_default:ro,z",
+            f"{config}:{mount_target}/.config/gcloud/configurations/config_default:ro,z",
             "-v",
             f"{self.workdir}:/workspace:z",
         ]

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -33,7 +33,8 @@ class PodmanBackend(Backend):
         image=None,
         timeout=1200,
         extra_env=None,
-        harness: Harness | None = None,
+        *,
+        harness: Harness,
     ):
         super().__init__(workdir=workdir, image=image, harness=harness)
         self.timeout = timeout

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -9,6 +9,7 @@ import tempfile
 from agentic_ci import log, otel
 from agentic_ci.backends import create_backend
 from agentic_ci.gates import resolve_gates, validate_gate_env
+from agentic_ci.harness import create_harness
 
 
 def _parse_gate_list(value: str | None) -> list[str]:
@@ -27,7 +28,7 @@ def cmd_stop(args, backend):
     backend.stop()
 
 
-def cmd_run(args, backend):
+def cmd_run(args, backend, harness):
     pre_gate_names = _parse_gate_list(getattr(args, "pre_gates", None))
     post_gate_names = _parse_gate_list(getattr(args, "post_gates", None))
 
@@ -52,16 +53,13 @@ def cmd_run(args, backend):
 
     backend.setup()
 
+    model_env = harness.model_env_var()
     if args.model:
         model = args.model
-        model_source = "--model flag"
-    elif os.environ.get("CLAUDE_MODEL"):
-        model = os.environ["CLAUDE_MODEL"]
-        model_source = "CLAUDE_MODEL env var"
+    elif os.environ.get(model_env):
+        model = os.environ[model_env]
     else:
-        model = "claude-opus-4-6"
-        model_source = "default"
-    log.detail("Model", f"{model} (from {model_source})")
+        model = harness.default_model()
 
     run_dir = tempfile.mkdtemp(prefix="agentic-ci-run.")
 
@@ -70,13 +68,13 @@ def cmd_run(args, backend):
     otel_rate = None
     otel_proc = None
 
-    if not args.no_otel:
+    if not args.no_otel and harness.supports_otel:
         log.section("Starting OTEL collector")
         otel_proc, otel_port, otel_log, otel_rate = otel.start_collector(run_dir)
         log.detail("pid", str(otel_proc.pid))
         log.detail("port", str(otel_port))
 
-    log.section(f"Running Claude ({model}) via {args.backend} backend")
+    log.section(f"Running {harness.name} ({model}) via {args.backend} backend")
     rc = backend.run(
         prompt=args.prompt,
         model=model,
@@ -89,12 +87,12 @@ def cmd_run(args, backend):
     if otel_proc:
         otel.stop_collector(otel_proc)
         print(flush=True)
-        log.section(f"Claude exit code: {rc}")
+        log.section(f"Agent exit code: {rc}")
         log.section("Token/Cost Summary (OpenTelemetry)")
         otel.print_summary(otel_log)
     else:
         print(flush=True)
-        log.section(f"Claude exit code: {rc}")
+        log.section(f"Agent exit code: {rc}")
 
     if rc == 0 and post_gate_names:
         log.section("Running post-gates")
@@ -127,7 +125,7 @@ def cmd_run(args, backend):
 def main():
     parser = argparse.ArgumentParser(
         prog="agentic-ci",
-        description="Run Claude Code in a sandboxed CI environment",
+        description="Run AI coding agents in a sandboxed CI environment",
     )
     parser.add_argument(
         "--backend",
@@ -135,13 +133,18 @@ def main():
         default="podman",
         help="Sandbox backend (default: podman)",
     )
-
     sub = parser.add_subparsers(dest="command")
 
     # Common arguments shared by both subcommands
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--workdir", default=".", metavar="PATH", help="Working directory")
     common.add_argument("--image", default=None, metavar="IMAGE", help="Container/sandbox image")
+    common.add_argument(
+        "--harness",
+        choices=["claude-code", "opencode"],
+        default="claude-code",
+        help="AI agent harness (default: claude-code)",
+    )
     common.add_argument(
         "--policy",
         default=None,
@@ -162,7 +165,7 @@ def main():
     p_run = sub.add_parser(
         "run", parents=[common], help="Execute a prompt in a sandbox environment"
     )
-    p_run.add_argument("prompt", help="Prompt to send to Claude")
+    p_run.add_argument("prompt", help="Prompt to send to the agent")
     p_run.add_argument(
         "--no-streaming", action="store_true", help="Disable pretty-printed stream output"
     )
@@ -176,19 +179,19 @@ def main():
         "--model",
         default=None,
         metavar="MODEL",
-        help="Claude model (default: $CLAUDE_MODEL or claude-opus-4-6)",
+        help="Agent model (default from harness env var or harness default)",
     )
     p_run.add_argument(
         "--pre-gates",
         default=None,
         metavar="GATES",
-        help="Comma-separated list of pre-agent gates to run before Claude",
+        help="Comma-separated list of pre-agent gates to run before the agent",
     )
     p_run.add_argument(
         "--post-gates",
         default=None,
         metavar="GATES",
-        help="Comma-separated list of post-agent gates to run after Claude",
+        help="Comma-separated list of post-agent gates to run after the agent",
     )
 
     args, extra = parser.parse_known_args()
@@ -201,10 +204,14 @@ def main():
         parser.print_help()
         sys.exit(1)
 
+    harness = create_harness(args.harness)
+
     log.section(f"Backend: {args.backend}")
+    log.detail("Harness", harness.name)
     log.detail("Workdir", os.path.abspath(args.workdir))
     backend = create_backend(
         args.backend,
+        harness=harness,
         workdir=args.workdir,
         image=args.image,
         policy=args.policy,
@@ -216,7 +223,7 @@ def main():
     elif args.command == "stop":
         cmd_stop(args, backend)
     elif args.command == "run":
-        cmd_run(args, backend)
+        cmd_run(args, backend, harness)
 
 
 if __name__ == "__main__":

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -67,57 +67,68 @@ def cmd_run(args, backend, harness):
     otel_log = None
     otel_rate = None
     otel_proc = None
+    rc = 1
 
-    if not args.no_otel and harness.supports_otel:
-        log.section("Starting OTEL collector")
-        otel_proc, otel_port, otel_log, otel_rate = otel.start_collector(run_dir)
-        log.detail("pid", str(otel_proc.pid))
-        log.detail("port", str(otel_port))
+    try:
+        if not args.no_otel and harness.supports_otel:
+            log.section("Starting OTEL collector")
+            otel_proc, otel_port, otel_log, otel_rate = otel.start_collector(run_dir)
+            log.detail("pid", str(otel_proc.pid))
+            log.detail("port", str(otel_port))
 
-    log.section(f"Running {harness.name} ({model}) via {args.backend} backend")
-    rc = backend.run(
-        prompt=args.prompt,
-        model=model,
-        otel_port=otel_port,
-        otel_rate_file=otel_rate,
-        extra_args=args.extra_args,
-        streaming=not args.no_streaming,
-    )
+        log.section(f"Running {harness.name} ({model}) via {args.backend} backend")
+        rc = backend.run(
+            prompt=args.prompt,
+            model=model,
+            otel_port=otel_port,
+            otel_rate_file=otel_rate,
+            extra_args=args.extra_args,
+            streaming=not args.no_streaming,
+        )
 
-    if otel_proc:
-        otel.stop_collector(otel_proc)
+        if otel_proc:
+            otel.stop_collector(otel_proc)
+            otel_proc = None
+            print(flush=True)
+            log.section(f"Agent exit code: {rc}")
+            log.section("Token/Cost Summary (OpenTelemetry)")
+            otel.print_summary(otel_log)
+        else:
+            print(flush=True)
+            log.section(f"Agent exit code: {rc}")
+
+        if rc == 0 and post_gate_names:
+            log.section("Running post-gates")
+            post_specs = resolve_gates(post_gate_names)
+            gate_errors: list[str] = []
+            for gate in post_specs:
+                errors = gate.fn(workdir=args.workdir)
+                if errors:
+                    gate_errors.extend(errors)
+                    for err in errors:
+                        print(f"  {gate.name}: FAILED - {err}", file=sys.stderr, flush=True)
+                else:
+                    log.info(f"{gate.name}: passed")
+            if gate_errors:
+                rc = 1
+
+        artifact_dir = os.environ.get("GITHUB_WORKSPACE") or os.environ.get("CI_PROJECT_DIR")
+        if artifact_dir and otel_log:
+            try:
+                shutil.copy2(otel_log, artifact_dir)
+            except (OSError, FileNotFoundError):
+                pass
+
+    except KeyboardInterrupt:
         print(flush=True)
-        log.section(f"Agent exit code: {rc}")
-        log.section("Token/Cost Summary (OpenTelemetry)")
-        otel.print_summary(otel_log)
-    else:
-        print(flush=True)
-        log.section(f"Agent exit code: {rc}")
+        log.section("Interrupted")
+        rc = 130
 
-    if rc == 0 and post_gate_names:
-        log.section("Running post-gates")
-        post_specs = resolve_gates(post_gate_names)
-        gate_errors: list[str] = []
-        for gate in post_specs:
-            errors = gate.fn(workdir=args.workdir)
-            if errors:
-                gate_errors.extend(errors)
-                for err in errors:
-                    print(f"  {gate.name}: FAILED - {err}", file=sys.stderr, flush=True)
-            else:
-                log.info(f"{gate.name}: passed")
-        if gate_errors:
-            rc = 1
-
-    artifact_dir = os.environ.get("GITHUB_WORKSPACE") or os.environ.get("CI_PROJECT_DIR")
-    if artifact_dir and otel_log:
-        try:
-            shutil.copy2(otel_log, artifact_dir)
-        except (OSError, FileNotFoundError):
-            pass
-
-    if not args.keep:
-        backend.stop()
+    finally:
+        if otel_proc:
+            otel.stop_collector(otel_proc)
+        if not args.keep:
+            backend.stop()
 
     sys.exit(rc)
 

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -125,7 +125,7 @@ class ClaudeCodeHarness(Harness):
                 ]
             )
             if otel_rate_file:
-                lines.append(f"export OTEL_RATE_FILE={otel_rate_file}")
+                lines.append(f"export OTEL_RATE_FILE={shlex.quote(otel_rate_file)}")
         return lines
 
     def build_otel_exec_env(self, otel_port=None):

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -247,7 +247,7 @@ class OpenCodeHarness(Harness):
         return "OPENCODE_MODEL"
 
     def default_model(self):
-        return "google-vertex/claude-sonnet-4-6@default"
+        return "google-vertex/claude-opus-4-6@default"
 
 
 def create_harness(name: str) -> Harness:

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -1,0 +1,260 @@
+"""Harness abstraction for AI agent CLI tools.
+
+A harness encapsulates everything specific to a particular agent CLI
+(Claude Code, OpenCode, etc.): how to build the command, what env vars
+it needs, where credentials are mounted, and how to parse its output.
+"""
+
+import os
+import shlex
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class Harness(ABC):
+    """Base class for agent CLI harnesses."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human-readable name for log messages."""
+
+    @abstractmethod
+    def build_args(self, prompt: str, model: str, extra_args: list[str] | None = None) -> list[str]:
+        """Build the CLI argument list to run inside the container."""
+
+    @abstractmethod
+    def build_env_args(self) -> list[str]:
+        """Return ['--env', 'K=V', ...] pairs for podman run."""
+
+    @abstractmethod
+    def build_env_script_lines(
+        self,
+        otel_port: int | None = None,
+        otel_rate_file: str | None = None,
+    ) -> list[str]:
+        """Return 'export K=V' lines for the OpenShell env script."""
+
+    @abstractmethod
+    def build_otel_exec_env(self, otel_port: int | None = None) -> list[str]:
+        """Return ['--env', 'K=V', ...] pairs for podman exec when OTEL is enabled."""
+
+    @abstractmethod
+    def credential_mount_target(self) -> str:
+        """Container-side home directory for credential mounts."""
+
+    @abstractmethod
+    def create_stream_processor(self, pid: int = 0) -> Any:
+        """Return a stream processor for this harness's output format."""
+
+    @abstractmethod
+    def image_env_var(self) -> str:
+        """Env var name for the fallback container image."""
+
+    @abstractmethod
+    def model_env_var(self) -> str:
+        """Env var name for the model override."""
+
+    @abstractmethod
+    def default_model(self) -> str:
+        """Default model when no --model flag or env var is set."""
+
+    @property
+    def supports_otel(self) -> bool:
+        """Whether the agent CLI supports OTEL telemetry export."""
+        return False
+
+
+class ClaudeCodeHarness(Harness):
+    """Claude Code CLI harness."""
+
+    @property
+    def name(self) -> str:
+        return "Claude Code"
+
+    def build_args(self, prompt, model, extra_args=None):
+        args = [
+            "claude",
+            "--permission-mode",
+            "bypassPermissions",
+            "--model",
+            model,
+            "--output-format",
+            "stream-json",
+            "--include-partial-messages",
+            "--verbose",
+            "-p",
+            prompt,
+        ]
+        if extra_args:
+            args.extend(extra_args)
+        return args
+
+    def build_env_args(self):
+        return [
+            "--env",
+            "CLAUDE_CODE_USE_VERTEX=1",
+            "--env",
+            f"CLOUD_ML_REGION={os.environ.get('CLOUD_ML_REGION', 'global')}",
+            "--env",
+            f"ANTHROPIC_VERTEX_PROJECT_ID={os.environ.get('ANTHROPIC_VERTEX_PROJECT_ID', '')}",
+            "--env",
+            "DISABLE_AUTOUPDATER=1",
+        ]
+
+    def build_env_script_lines(self, otel_port=None, otel_rate_file=None):
+        vertex_project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+        cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
+        lines = [
+            "export CLAUDE_CODE_USE_VERTEX=1",
+            f"export CLOUD_ML_REGION={shlex.quote(cloud_region)}",
+            f"export ANTHROPIC_VERTEX_PROJECT_ID={shlex.quote(vertex_project)}",
+            "export DISABLE_AUTOUPDATER=1",
+            "export GOOGLE_APPLICATION_CREDENTIALS="
+            '"$HOME/.config/gcloud/application_default_credentials.json"',
+        ]
+        if otel_port:
+            lines.extend(
+                [
+                    "export CLAUDE_CODE_ENABLE_TELEMETRY=1",
+                    "export OTEL_METRICS_EXPORTER=otlp",
+                    "export OTEL_LOGS_EXPORTER=otlp",
+                    "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+                    f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://10.200.0.1:{otel_port}",
+                    "export OTEL_METRIC_EXPORT_INTERVAL=10000",
+                ]
+            )
+            if otel_rate_file:
+                lines.append(f"export OTEL_RATE_FILE={otel_rate_file}")
+        return lines
+
+    def build_otel_exec_env(self, otel_port=None):
+        if not otel_port:
+            return []
+        return [
+            "--env",
+            "CLAUDE_CODE_ENABLE_TELEMETRY=1",
+            "--env",
+            "OTEL_METRICS_EXPORTER=otlp",
+            "--env",
+            "OTEL_LOGS_EXPORTER=otlp",
+            "--env",
+            "OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+            "--env",
+            f"OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:{otel_port}",
+            "--env",
+            "OTEL_METRIC_EXPORT_INTERVAL=10000",
+        ]
+
+    def credential_mount_target(self):
+        return "/home/claude"
+
+    def create_stream_processor(self, pid=0):
+        from agentic_ci.stream import ClaudeCodeStreamProcessor
+
+        return ClaudeCodeStreamProcessor(claude_pid=pid)
+
+    def image_env_var(self):
+        return "CLAUDE_CONTAINER_IMAGE"
+
+    def model_env_var(self):
+        return "CLAUDE_MODEL"
+
+    def default_model(self):
+        return "claude-opus-4-6"
+
+    @property
+    def supports_otel(self) -> bool:
+        return True
+
+
+class OpenCodeHarness(Harness):
+    """OpenCode CLI harness."""
+
+    @property
+    def name(self) -> str:
+        return "OpenCode"
+
+    def build_args(self, prompt, model, extra_args=None):
+        args = [
+            "opencode",
+            "run",
+            "--format",
+            "json",
+            "--dangerously-skip-permissions",
+            "-m",
+            model,
+            prompt,
+        ]
+        if extra_args:
+            args.extend(extra_args)
+        return args
+
+    def build_env_args(self):
+        project = os.environ.get(
+            "GOOGLE_CLOUD_PROJECT",
+            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
+        )
+        location = os.environ.get(
+            "VERTEX_LOCATION",
+            os.environ.get("CLOUD_ML_REGION", "global"),
+        )
+        mount_target = self.credential_mount_target()
+        return [
+            "--env",
+            f"GOOGLE_CLOUD_PROJECT={project}",
+            "--env",
+            f"VERTEX_LOCATION={location}",
+            "--env",
+            "OPENCODE_DISABLE_AUTOUPDATE=1",
+            "--env",
+            f"GOOGLE_APPLICATION_CREDENTIALS={mount_target}/.config/gcloud/application_default_credentials.json",
+        ]
+
+    def build_env_script_lines(self, otel_port=None, otel_rate_file=None):
+        project = os.environ.get(
+            "GOOGLE_CLOUD_PROJECT",
+            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
+        )
+        location = os.environ.get(
+            "VERTEX_LOCATION",
+            os.environ.get("CLOUD_ML_REGION", "global"),
+        )
+        lines = [
+            f"export GOOGLE_CLOUD_PROJECT={shlex.quote(project)}",
+            f"export VERTEX_LOCATION={shlex.quote(location)}",
+            "export OPENCODE_DISABLE_AUTOUPDATE=1",
+            "export GOOGLE_APPLICATION_CREDENTIALS="
+            '"$HOME/.config/gcloud/application_default_credentials.json"',
+        ]
+        return lines
+
+    def build_otel_exec_env(self, otel_port=None):
+        return []
+
+    def credential_mount_target(self):
+        return "/home/agent"
+
+    def create_stream_processor(self, pid=0):
+        from agentic_ci.stream import OpenCodeStreamProcessor
+
+        return OpenCodeStreamProcessor(agent_pid=pid)
+
+    def image_env_var(self):
+        return "OPENCODE_CONTAINER_IMAGE"
+
+    def model_env_var(self):
+        return "OPENCODE_MODEL"
+
+    def default_model(self):
+        return "google-vertex/claude-sonnet-4-6@default"
+
+
+def create_harness(name: str) -> Harness:
+    """Create a harness instance by name."""
+    if name == "claude-code":
+        return ClaudeCodeHarness()
+    elif name == "opencode":
+        return OpenCodeHarness()
+    else:
+        raise ValueError(f"Unknown harness: {name!r}. Choose 'claude-code' or 'opencode'.")

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -105,9 +105,11 @@ def _load_otel_cost(work_dir: Path) -> dict | None:
 def _default_run_container(work_dir, prompt, output_file, *, image=None):
     """Default container runner using PodmanBackend."""
     from agentic_ci.backends.podman import PodmanBackend
+    from agentic_ci.harness import ClaudeCodeHarness
 
-    model = os.environ.get("CLAUDE_MODEL", "claude-opus-4-6")
-    backend = PodmanBackend(workdir=str(work_dir), image=image)
+    harness = ClaudeCodeHarness()
+    model = os.environ.get(harness.model_env_var(), harness.default_model())
+    backend = PodmanBackend(workdir=str(work_dir), image=image, harness=harness)
     try:
         backend.setup()
         return backend.run(prompt, model=model)

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -108,7 +108,7 @@ def _default_run_container(work_dir, prompt, output_file, *, image=None):
     from agentic_ci.harness import ClaudeCodeHarness
 
     harness = ClaudeCodeHarness()
-    model = os.environ.get(harness.model_env_var(), harness.default_model())
+    model = os.environ.get(harness.model_env_var()) or harness.default_model()
     backend = PodmanBackend(workdir=str(work_dir), image=image, harness=harness)
     try:
         backend.setup()

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -1,6 +1,5 @@
-"""Parse Claude Code stream-json output into a human-readable CI log."""
+"""Stream processors for AI agent output formats."""
 
-import argparse
 import json
 import os
 import signal
@@ -12,6 +11,7 @@ from agentic_ci import log
 
 def _format_tool(name, params):
     """Return a compact one-line summary for known tools."""
+    name = name[0].upper() + name[1:] if name else name
     if name == "Bash":
         cmd = params.get("command", "")
         desc = params.get("description", "")
@@ -54,7 +54,7 @@ def _format_tool(name, params):
     return ", ".join(f"{k}={v}" for k, v in params.items())
 
 
-class StreamProcessor:
+class ClaudeCodeStreamProcessor:
     """Processes Claude Code stream-json and prints human-readable output."""
 
     def __init__(self, color=True, wrap=0, claude_pid=0):
@@ -331,31 +331,137 @@ class StreamProcessor:
         return False
 
 
-def main(args=None):
-    parser = argparse.ArgumentParser(description="Parse Claude Code stream-json output")
-    parser.add_argument(
-        "--wrap",
-        type=int,
-        default=0,
-        metavar="COLS",
-        help="Word-wrap output at COLS columns (0 = no wrapping)",
-    )
-    parser.add_argument(
-        "--no-color", action="store_true", help="Disable ANSI color codes in output"
-    )
-    parser.add_argument(
-        "--claude-pid", type=int, default=0, help="PID of Claude Code process to kill on completion"
-    )
-    parsed = parser.parse_args(args)
+class OpenCodeStreamProcessor:
+    """Processes OpenCode JSON output and prints human-readable CI logs."""
 
-    processor = StreamProcessor(
-        color=not parsed.no_color,
-        wrap=parsed.wrap,
-        claude_pid=parsed.claude_pid,
-    )
-    processor.process(sys.stdin)
-    print()
+    def __init__(self, color=True, wrap=0, agent_pid=0):
+        self.wrap = wrap
+        self.agent_pid = agent_pid
 
+        if color:
+            self.TOOL = "\033[1;90m"
+            self.AGENT = ""
+            self.RED = "\033[31m"
+            self.RESET = "\033[0m"
+        else:
+            self.TOOL = self.AGENT = self.RED = self.RESET = ""
 
-if __name__ == "__main__":
-    main()
+        self._in_text = False
+        self._emitted_first_line = False
+        self._line_buf = ""
+
+    _INDENT = "  "
+
+    def _print_line(self, line):
+        prefix = self._INDENT if self._in_text and self._emitted_first_line else ""
+        if self.wrap and len(line) > self.wrap:
+            wrapped = ""
+            col = 0
+            for word in line.split(" "):
+                if col + len(word) > self.wrap and col > 0:
+                    wrapped += f"\n{prefix}"
+                    col = 0
+                if col > 0:
+                    wrapped += " "
+                    col += 1
+                wrapped += word
+                col += len(word)
+            print(f"{prefix}{wrapped}", flush=True)
+        else:
+            print(f"{prefix}{line}", flush=True)
+        self._emitted_first_line = True
+
+    def _emit(self, text):
+        self._line_buf += text
+        while "\n" in self._line_buf:
+            line, self._line_buf = self._line_buf.split("\n", 1)
+            self._print_line(line)
+
+    def _flush_emit(self):
+        if self._line_buf:
+            self._print_line(self._line_buf)
+            self._line_buf = ""
+
+    def _end_text(self):
+        if self._in_text:
+            self._flush_emit()
+            sys.stdout.write(self.RESET + "\n")
+            self._in_text = False
+
+    def process_line(self, line):
+        """Process a single JSONL line from OpenCode. Returns True when run is complete."""
+        line = line.strip()
+        if not line:
+            return False
+
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return False
+
+        msg_type = msg.get("type")
+        part = msg.get("part", {})
+
+        if msg_type == "error":
+            self._end_text()
+            error = msg.get("error", {})
+            error_msg = error.get("data", {}).get("message", str(error))
+            print(f"{self._INDENT}{self.RED}❌ Error: {error_msg}{self.RESET}", flush=True)
+            return False
+
+        if msg_type == "text":
+            text = part.get("text", "")
+            if not self._in_text:
+                print(f"{self._INDENT}{self.AGENT}\U0001f4ac Agent ", end="", flush=True)
+                self._in_text = True
+                self._emitted_first_line = False
+            self._emit(text + "\n")
+
+        elif msg_type == "tool_use":
+            self._end_text()
+            tool_name = part.get("tool", "unknown")
+            display_name = tool_name[0].upper() + tool_name[1:] if tool_name else tool_name
+            state = part.get("state", {})
+            inp = state.get("input", {})
+            title = part.get("title", "")
+            summary = _format_tool(tool_name, inp) if inp else title
+            print(
+                f"{self._INDENT}{self.TOOL}\U0001f527 {display_name} {summary}{self.RESET}",
+                flush=True,
+            )
+
+        elif msg_type == "step_start":
+            self._end_text()
+
+        elif msg_type == "step_finish":
+            self._end_text()
+            reason = part.get("reason", "")
+            tokens = part.get("tokens", {})
+            cost = part.get("cost", 0)
+            total = tokens.get("total", 0)
+            inp = tokens.get("input", 0)
+            out = tokens.get("output", 0)
+            cache = tokens.get("cache", {})
+            cache_r = cache.get("read", 0)
+            cache_w = cache.get("write", 0)
+            print(
+                f"{self._INDENT}{self.TOOL}\U0001f4ca TOKENS in={inp} "
+                f"out={out} "
+                f"cache_r={cache_r} "
+                f"cache_w={cache_w} "
+                f"total={total} cost=${cost:.4f}{self.RESET}",
+                flush=True,
+            )
+            if reason == "stop":
+                return True
+
+        return False
+
+    def process(self, input_stream):
+        """Process a stream of lines. Returns True if run completed normally."""
+        for line in input_stream:
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="replace")
+            if self.process_line(line):
+                return True
+        return False

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -2,11 +2,21 @@
 
 import json
 import os
+import re
 import signal
 import sys
 import time
 
 from agentic_ci import log
+
+
+def _get(params, *keys):
+    """Get the first non-empty value for any of the given keys."""
+    for k in keys:
+        v = params.get(k, "")
+        if v:
+            return v
+    return ""
 
 
 def _format_tool(name, params):
@@ -17,7 +27,7 @@ def _format_tool(name, params):
         desc = params.get("description", "")
         return f"$ {cmd}" + (f"  # {desc}" if desc else "")
     if name == "Read":
-        path = params.get("file_path", "")
+        path = _get(params, "file_path", "filePath")
         parts = [path]
         if "offset" in params:
             parts.append(f"L{params['offset']}")
@@ -25,10 +35,10 @@ def _format_tool(name, params):
             parts.append(f"+{params['limit']}")
         return " ".join(parts)
     if name == "Write":
-        return params.get("file_path", "")
+        return _get(params, "file_path", "filePath")
     if name == "Edit":
-        path = params.get("file_path", "")
-        old = params.get("old_string", "")
+        path = _get(params, "file_path", "filePath")
+        old = _get(params, "old_string", "oldString")
         preview = old.split("\n")[0][:60]
         if len(old) > len(preview):
             preview += "…"
@@ -41,17 +51,26 @@ def _format_tool(name, params):
         pattern = params.get("pattern", "")
         path = params.get("path", ".")
         return f"/{pattern}/ in {path}"
-    if name == "Agent":
+    if name in ("Agent", "Task"):
         desc = params.get("description", "")
-        agent_type = params.get("subagent_type", "")
+        agent_type = _get(params, "subagent_type", "subagentType")
         return f"[{agent_type}] {desc}" if agent_type else desc
     if name == "Skill":
         skill = params.get("skill", "")
         skill_args = params.get("args", "")
         return f"/{skill} {skill_args}".strip()
-    if name == "TaskGet":
-        return params.get("task_id", "")
-    return ", ".join(f"{k}={v}" for k, v in params.items())
+    if name in ("TaskGet", "Taskget"):
+        return _get(params, "task_id", "taskId")
+    parts = []
+    for k, v in params.items():
+        val = str(v)
+        if len(val) > 60:
+            val = val[:60] + "…"
+        parts.append(f"{k}={val}")
+    result = ", ".join(parts)
+    if len(result) > 200:
+        result = result[:200] + "…"
+    return result
 
 
 class ClaudeCodeStreamProcessor:
@@ -339,14 +358,16 @@ class OpenCodeStreamProcessor:
         self.agent_pid = agent_pid
 
         if color:
+            self.THINK = "\033[3;31m"
             self.TOOL = "\033[1;90m"
             self.AGENT = ""
             self.RED = "\033[31m"
             self.RESET = "\033[0m"
         else:
-            self.TOOL = self.AGENT = self.RED = self.RESET = ""
+            self.THINK = self.TOOL = self.AGENT = self.RED = self.RESET = ""
 
         self._in_text = False
+        self._in_thinking = False
         self._emitted_first_line = False
         self._line_buf = ""
 
@@ -387,6 +408,32 @@ class OpenCodeStreamProcessor:
             self._flush_emit()
             sys.stdout.write(self.RESET + "\n")
             self._in_text = False
+        if self._in_thinking:
+            self._flush_emit()
+            sys.stdout.write(self.RESET + "\n")
+            self._in_thinking = False
+
+    _TASK_INDENT = "    "
+
+    def _print_task_detail(self, inp, output):
+        prompt = inp.get("prompt", "")
+        if prompt:
+            lines = prompt.split("\n")
+            for line in lines[:10]:
+                print(f"{self._TASK_INDENT}{self.TOOL}{line}{self.RESET}", flush=True)
+            if len(lines) > 10:
+                print(
+                    f"{self._TASK_INDENT}{self.TOOL}... ({len(lines) - 10} more lines){self.RESET}",
+                    flush=True,
+                )
+        if not output:
+            return
+        body = re.sub(r"^task_id:.*\n*", "", output)
+        body = re.sub(r"</?task_result>\n?", "", body).strip()
+        if not body:
+            return
+        for line in body.split("\n"):
+            print(f"{self._TASK_INDENT}{line}", flush=True)
 
     def process_line(self, line):
         """Process a single JSONL line from OpenCode. Returns True when run is complete."""
@@ -412,8 +459,18 @@ class OpenCodeStreamProcessor:
         if msg_type == "text":
             text = part.get("text", "")
             if not self._in_text:
+                self._end_text()
                 print(f"{self._INDENT}{self.AGENT}\U0001f4ac Agent ", end="", flush=True)
                 self._in_text = True
+                self._emitted_first_line = False
+            self._emit(text + "\n")
+
+        elif msg_type == "thinking":
+            text = part.get("text", "")
+            if not self._in_thinking:
+                self._end_text()
+                print(f"{self._INDENT}{self.THINK}\U0001f9e0 Thinking ", end="", flush=True)
+                self._in_thinking = True
                 self._emitted_first_line = False
             self._emit(text + "\n")
 
@@ -425,10 +482,13 @@ class OpenCodeStreamProcessor:
             inp = state.get("input", {})
             title = part.get("title", "")
             summary = _format_tool(tool_name, inp) if inp else title
+            icon = "\U0001f916" if tool_name in ("task", "agent") else "\U0001f527"
             print(
-                f"{self._INDENT}{self.TOOL}\U0001f527 {display_name} {summary}{self.RESET}",
+                f"{self._INDENT}{self.TOOL}{icon} {display_name} {summary}{self.RESET}",
                 flush=True,
             )
+            if tool_name in ("task", "agent"):
+                self._print_task_detail(inp, state.get("output", ""))
 
         elif msg_type == "step_start":
             self._end_text()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -5,42 +5,50 @@ import pytest
 from agentic_ci.backends import create_backend
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
+from agentic_ci.harness import create_harness
 
 
-def test_create_podman_backend():
-    backend = create_backend("podman", workdir="/tmp")
+@pytest.fixture()
+def harness():
+    return create_harness("claude-code")
+
+
+def test_create_podman_backend(harness):
+    backend = create_backend("podman", harness=harness, workdir="/tmp")
     assert isinstance(backend, PodmanBackend)
     assert backend.workdir == "/tmp"
+    assert backend.harness is harness
 
 
-def test_create_openshell_backend():
-    backend = create_backend("openshell", workdir="/tmp")
+def test_create_openshell_backend(harness):
+    backend = create_backend("openshell", harness=harness, workdir="/tmp")
     assert isinstance(backend, OpenShellBackend)
     assert backend.workdir == "/tmp"
+    assert backend.harness is harness
 
 
-def test_create_podman_with_image():
-    backend = create_backend("podman", image="my-image:latest")
+def test_create_podman_with_image(harness):
+    backend = create_backend("podman", harness=harness, image="my-image:latest")
     assert backend.image == "my-image:latest"
 
 
-def test_create_openshell_with_policy():
-    backend = create_backend("openshell", policy="/path/to/policy.yml")
+def test_create_openshell_with_policy(harness):
+    backend = create_backend("openshell", harness=harness, policy="/path/to/policy.yml")
     assert backend.policy_path == "/path/to/policy.yml"
 
 
-def test_create_podman_with_timeout():
-    backend = create_backend("podman", timeout=600)
+def test_create_podman_with_timeout(harness):
+    backend = create_backend("podman", harness=harness, timeout=600)
     assert backend.timeout == 600
 
 
-def test_unknown_backend_raises():
+def test_unknown_backend_raises(harness):
     with pytest.raises(ValueError, match="Unknown backend"):
-        create_backend("docker")
+        create_backend("docker", harness=harness)
 
 
-def test_backends_have_stop_method():
-    podman = create_backend("podman", workdir="/tmp")
-    openshell = create_backend("openshell", workdir="/tmp")
+def test_backends_have_stop_method(harness):
+    podman = create_backend("podman", harness=harness, workdir="/tmp")
+    openshell = create_backend("openshell", harness=harness, workdir="/tmp")
     assert callable(getattr(podman, "stop", None))
     assert callable(getattr(openshell, "stop", None))

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -168,4 +168,4 @@ class TestOpenCodeHarness:
         assert OpenCodeHarness().model_env_var() == "OPENCODE_MODEL"
 
     def test_default_model(self):
-        assert OpenCodeHarness().default_model() == "google-vertex/claude-sonnet-4-6@default"
+        assert OpenCodeHarness().default_model() == "google-vertex/claude-opus-4-6@default"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,0 +1,170 @@
+"""Tests for harness abstraction."""
+
+import pytest
+
+from agentic_ci.harness import (
+    ClaudeCodeHarness,
+    OpenCodeHarness,
+    create_harness,
+)
+
+
+def test_create_claude_code_harness():
+    harness = create_harness("claude-code")
+    assert isinstance(harness, ClaudeCodeHarness)
+
+
+def test_create_opencode_harness():
+    harness = create_harness("opencode")
+    assert isinstance(harness, OpenCodeHarness)
+
+
+def test_create_unknown_harness_raises():
+    with pytest.raises(ValueError, match="Unknown harness"):
+        create_harness("gemini")
+
+
+class TestClaudeCodeHarness:
+    def test_name(self):
+        assert ClaudeCodeHarness().name == "Claude Code"
+
+    def test_build_args(self):
+        harness = ClaudeCodeHarness()
+        args = harness.build_args("do something", "claude-opus-4-6")
+        assert args[0] == "claude"
+        assert "--permission-mode" in args
+        assert "bypassPermissions" in args
+        assert "--output-format" in args
+        assert "stream-json" in args
+        assert "--model" in args
+        assert "claude-opus-4-6" in args
+        assert "-p" in args
+        assert "do something" in args
+
+    def test_build_args_with_extra(self):
+        harness = ClaudeCodeHarness()
+        args = harness.build_args("prompt", "model", extra_args=["--foo", "bar"])
+        assert "--foo" in args
+        assert "bar" in args
+
+    def test_build_env_args(self, monkeypatch):
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-east1")
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj")
+        harness = ClaudeCodeHarness()
+        args = harness.build_env_args()
+        assert "CLAUDE_CODE_USE_VERTEX=1" in args
+        assert "CLOUD_ML_REGION=us-east1" in args
+        assert "ANTHROPIC_VERTEX_PROJECT_ID=my-proj" in args
+        assert "DISABLE_AUTOUPDATER=1" in args
+
+    def test_build_otel_exec_env(self):
+        harness = ClaudeCodeHarness()
+        args = harness.build_otel_exec_env(otel_port=4318)
+        assert "CLAUDE_CODE_ENABLE_TELEMETRY=1" in args
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318" in args
+
+    def test_build_otel_exec_env_empty_without_port(self):
+        assert ClaudeCodeHarness().build_otel_exec_env(otel_port=None) == []
+
+    def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-west1")
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert any("CLAUDE_CODE_USE_VERTEX=1" in line for line in lines)
+        assert any("DISABLE_AUTOUPDATER=1" in line for line in lines)
+
+    def test_build_env_script_lines_with_otel(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines(otel_port=4318, otel_rate_file="/tmp/rate.json")
+        assert any("CLAUDE_CODE_ENABLE_TELEMETRY=1" in line for line in lines)
+        assert any("OTEL_RATE_FILE=/tmp/rate.json" in line for line in lines)
+
+    def test_credential_mount_target(self):
+        assert ClaudeCodeHarness().credential_mount_target() == "/home/claude"
+
+    def test_create_stream_processor(self):
+        from agentic_ci.stream import ClaudeCodeStreamProcessor
+
+        proc = ClaudeCodeHarness().create_stream_processor(pid=123)
+        assert isinstance(proc, ClaudeCodeStreamProcessor)
+
+    def test_image_env_var(self):
+        assert ClaudeCodeHarness().image_env_var() == "CLAUDE_CONTAINER_IMAGE"
+
+    def test_model_env_var(self):
+        assert ClaudeCodeHarness().model_env_var() == "CLAUDE_MODEL"
+
+    def test_default_model(self):
+        assert ClaudeCodeHarness().default_model() == "claude-opus-4-6"
+
+
+class TestOpenCodeHarness:
+    def test_name(self):
+        assert OpenCodeHarness().name == "OpenCode"
+
+    def test_build_args(self):
+        harness = OpenCodeHarness()
+        args = harness.build_args("do something", "google-vertex/claude-haiku-4-5@20251001")
+        assert args[0] == "opencode"
+        assert "run" in args
+        assert "--format" in args
+        assert "json" in args
+        assert "--dangerously-skip-permissions" in args
+        assert "-m" in args
+        assert "google-vertex/claude-haiku-4-5@20251001" in args
+        assert "do something" in args
+
+    def test_build_args_with_extra(self):
+        harness = OpenCodeHarness()
+        args = harness.build_args("prompt", "model", extra_args=["--thinking"])
+        assert "--thinking" in args
+
+    def test_build_env_args(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-proj")
+        monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+        harness = OpenCodeHarness()
+        args = harness.build_env_args()
+        assert "GOOGLE_CLOUD_PROJECT=my-proj" in args
+        assert "VERTEX_LOCATION=us-central1" in args
+        assert "OPENCODE_DISABLE_AUTOUPDATE=1" in args
+
+    def test_build_env_args_fallback(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "fallback-proj")
+        monkeypatch.setenv("CLOUD_ML_REGION", "eu-west1")
+        harness = OpenCodeHarness()
+        args = harness.build_env_args()
+        assert "GOOGLE_CLOUD_PROJECT=fallback-proj" in args
+        assert "VERTEX_LOCATION=eu-west1" in args
+
+    def test_build_otel_exec_env_always_empty(self):
+        assert OpenCodeHarness().build_otel_exec_env(otel_port=4318) == []
+
+    def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj")
+        monkeypatch.setenv("VERTEX_LOCATION", "global")
+        harness = OpenCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert any("GOOGLE_CLOUD_PROJECT=" in line for line in lines)
+        assert any("OPENCODE_DISABLE_AUTOUPDATE=1" in line for line in lines)
+
+    def test_credential_mount_target(self):
+        assert OpenCodeHarness().credential_mount_target() == "/home/agent"
+
+    def test_create_stream_processor(self):
+        from agentic_ci.stream import OpenCodeStreamProcessor
+
+        proc = OpenCodeHarness().create_stream_processor(pid=456)
+        assert isinstance(proc, OpenCodeStreamProcessor)
+
+    def test_image_env_var(self):
+        assert OpenCodeHarness().image_env_var() == "OPENCODE_CONTAINER_IMAGE"
+
+    def test_model_env_var(self):
+        assert OpenCodeHarness().model_env_var() == "OPENCODE_MODEL"
+
+    def test_default_model(self):
+        assert OpenCodeHarness().default_model() == "google-vertex/claude-sonnet-4-6@default"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -74,12 +74,13 @@ class TestClaudeCodeHarness:
         assert any("CLAUDE_CODE_USE_VERTEX=1" in line for line in lines)
         assert any("DISABLE_AUTOUPDATER=1" in line for line in lines)
 
-    def test_build_env_script_lines_with_otel(self, monkeypatch):
+    def test_build_env_script_lines_with_otel(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
         harness = ClaudeCodeHarness()
-        lines = harness.build_env_script_lines(otel_port=4318, otel_rate_file="/tmp/rate.json")
+        rate_file = str(tmp_path / "rate.json")
+        lines = harness.build_env_script_lines(otel_port=4318, otel_rate_file=rate_file)
         assert any("CLAUDE_CODE_ENABLE_TELEMETRY=1" in line for line in lines)
-        assert any("OTEL_RATE_FILE=/tmp/rate.json" in line for line in lines)
+        assert any(f"OTEL_RATE_FILE={rate_file}" in line for line in lines)
 
     def test_credential_mount_target(self):
         assert ClaudeCodeHarness().credential_mount_target() == "/home/claude"

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -7,42 +7,53 @@ import os
 import pytest
 
 from agentic_ci.backends.podman import PodmanBackend
+from agentic_ci.harness import ClaudeCodeHarness, OpenCodeHarness
 
 
-def test_find_credentials_from_gcloud_credentials_json(monkeypatch, tmp_path):
+@pytest.fixture()
+def claude_harness():
+    return ClaudeCodeHarness()
+
+
+@pytest.fixture()
+def opencode_harness():
+    return OpenCodeHarness()
+
+
+def test_find_credentials_from_gcloud_credentials_json(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "authorized_user", "client_id": "test"})
     monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     result, source = backend._find_credentials()
     assert json.loads(result)["client_id"] == "test"
     assert source == "GCLOUD_CREDENTIALS env var"
 
 
-def test_find_credentials_from_base64(monkeypatch, tmp_path):
+def test_find_credentials_from_base64(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "service_account", "project_id": "test"})
     encoded = base64.b64encode(creds.encode()).decode()
     monkeypatch.setenv("GCLOUD_CREDENTIALS", encoded)
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     result, source = backend._find_credentials()
     assert json.loads(result)["project_id"] == "test"
     assert source == "GCLOUD_CREDENTIALS env var (base64)"
 
 
-def test_find_credentials_from_service_account_key(monkeypatch, tmp_path):
+def test_find_credentials_from_service_account_key(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "service_account", "project_id": "sa-test"})
     encoded = base64.b64encode(creds.encode()).decode()
     monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
     monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", encoded)
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     result, source = backend._find_credentials()
     assert json.loads(result)["project_id"] == "sa-test"
     assert source == "GCP_SERVICE_ACCOUNT_KEY env var"
 
 
-def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
+def test_find_credentials_from_adc_file(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "authorized_user", "client_id": "file-test"})
     adc_path = tmp_path / "adc.json"
     adc_path.write_text(creds)
@@ -51,49 +62,56 @@ def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
     monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(adc_path))
     monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     result, source = backend._find_credentials()
     assert json.loads(result)["client_id"] == "file-test"
     assert source == "GOOGLE_APPLICATION_CREDENTIALS file"
 
 
-def test_find_credentials_raises_when_missing(monkeypatch, tmp_path):
+def test_find_credentials_raises_when_missing(monkeypatch, tmp_path, claude_harness):
     monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
     monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
     monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
     monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     with pytest.raises(RuntimeError, match="No GCP credentials found"):
         backend._find_credentials()
 
 
-def test_find_credentials_invalid_json_raises(monkeypatch, tmp_path):
+def test_find_credentials_invalid_json_raises(monkeypatch, tmp_path, claude_harness):
     monkeypatch.setenv("GCLOUD_CREDENTIALS", "not-json-not-base64")
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     with pytest.raises(RuntimeError, match="not valid JSON"):
         backend._find_credentials()
 
 
-def test_build_env_args_basic(tmp_path):
-    backend = PodmanBackend(workdir=str(tmp_path))
+def test_build_env_args_claude_code(tmp_path, claude_harness):
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     args = backend._build_env_args()
     assert "--env" in args
     assert "CLAUDE_CODE_USE_VERTEX=1" in args
     assert "DISABLE_AUTOUPDATER=1" in args
 
 
-def test_build_otel_exec_env(tmp_path):
-    backend = PodmanBackend(workdir=str(tmp_path))
-    args = backend._build_otel_exec_env(otel_port=4318)
-    assert "CLAUDE_CODE_ENABLE_TELEMETRY=1" in args
-    assert "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318" in args
+def test_build_env_args_opencode(tmp_path, opencode_harness, monkeypatch):
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-proj")
+    monkeypatch.setenv("VERTEX_LOCATION", "us-east1")
+    backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
+    args = backend._build_env_args()
+    assert "GOOGLE_CLOUD_PROJECT=my-proj" in args
+    assert "VERTEX_LOCATION=us-east1" in args
+    assert "OPENCODE_DISABLE_AUTOUPDATE=1" in args
+    assert "CLAUDE_CODE_USE_VERTEX=1" not in args
 
 
-def test_build_otel_exec_env_empty_without_port(tmp_path):
-    backend = PodmanBackend(workdir=str(tmp_path))
-    assert backend._build_otel_exec_env(otel_port=None) == []
+def test_build_env_args_extra_env(tmp_path, claude_harness):
+    backend = PodmanBackend(
+        workdir=str(tmp_path), harness=claude_harness, extra_env={"MY_VAR": "value"}
+    )
+    args = backend._build_env_args()
+    assert "MY_VAR=value" in args
 
 
 def test_is_valid_json():
@@ -108,12 +126,12 @@ def test_try_base64_decode():
     assert PodmanBackend._try_base64_decode("!!!invalid!!!") is None
 
 
-def test_resolve_credentials_creates_config(monkeypatch, tmp_path):
+def test_resolve_credentials_creates_config(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "authorized_user", "client_id": "test"})
     monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
     monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-project")
 
-    backend = PodmanBackend(workdir=str(tmp_path))
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
     backend._resolve_credentials()
 
     assert backend._config_dir is not None
@@ -131,3 +149,44 @@ def test_resolve_credentials_creates_config(monkeypatch, tmp_path):
     with open(config_path) as f:
         content = f.read()
     assert "my-project" in content
+
+
+def test_resolve_image_claude_code(monkeypatch, tmp_path, claude_harness):
+    monkeypatch.setenv("CLAUDE_CONTAINER_IMAGE", "my-claude-image:latest")
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    backend._resolve_image()
+    assert backend.image == "my-claude-image:latest"
+
+
+def test_resolve_image_opencode(monkeypatch, tmp_path, opencode_harness):
+    monkeypatch.setenv("OPENCODE_CONTAINER_IMAGE", "my-opencode-image:latest")
+    backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
+    backend._resolve_image()
+    assert backend.image == "my-opencode-image:latest"
+
+
+def test_resolve_image_raises_with_correct_env_var(monkeypatch, tmp_path, opencode_harness):
+    monkeypatch.delenv("OPENCODE_CONTAINER_IMAGE", raising=False)
+    backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
+    with pytest.raises(RuntimeError, match="OPENCODE_CONTAINER_IMAGE"):
+        backend._resolve_image()
+
+
+def test_build_vol_args_claude_mount_target(monkeypatch, tmp_path, claude_harness):
+    creds = json.dumps({"type": "authorized_user"})
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    backend._resolve_credentials()
+    vol_args = backend._build_vol_args()
+    mount_str = " ".join(vol_args)
+    assert "/home/claude/.config/gcloud/" in mount_str
+
+
+def test_build_vol_args_opencode_mount_target(monkeypatch, tmp_path, opencode_harness):
+    creds = json.dumps({"type": "authorized_user"})
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
+    backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
+    backend._resolve_credentials()
+    vol_args = backend._build_vol_args()
+    mount_str = " ".join(vol_args)
+    assert "/home/agent/.config/gcloud/" in mount_str

--- a/tests/test_stream_opencode.py
+++ b/tests/test_stream_opencode.py
@@ -112,6 +112,63 @@ class TestProcessLine:
         assert "Model not found" in captured.out
 
 
+class TestThinking:
+    def test_thinking_event(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "thinking",
+            part={"type": "thinking", "text": "Let me analyze this code"},
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "\U0001f9e0" in captured.out
+        assert "Thinking" in captured.out
+        assert "Let me analyze this code" in captured.out
+
+    def test_thinking_ends_on_text(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        proc.process_line(_make_event("thinking", part={"type": "thinking", "text": "Hmm"}))
+        proc.process_line(_make_event("text", part={"type": "text", "text": "Hello"}))
+        captured = capsys.readouterr()
+        assert "Thinking" in captured.out
+        assert "Agent" in captured.out
+
+    def test_thinking_ends_on_tool(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        proc.process_line(_make_event("thinking", part={"type": "thinking", "text": "Planning"}))
+        proc.process_line(
+            _make_event(
+                "tool_use",
+                part={
+                    "type": "tool",
+                    "tool": "bash",
+                    "state": {"status": "completed", "input": {"command": "ls"}},
+                },
+            )
+        )
+        captured = capsys.readouterr()
+        assert "Thinking" in captured.out
+        assert "Bash" in captured.out
+
+
+class TestFallbackTruncation:
+    def test_long_value_truncated(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        long_val = "x" * 100
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "custom_tool",
+                "state": {"status": "completed", "input": {"data": long_val}},
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "x" * 60 + "…" in captured.out
+        assert "x" * 100 not in captured.out
+
+
 class TestProcess:
     def test_full_run(self, capsys):
         proc = OpenCodeStreamProcessor(color=False)
@@ -193,3 +250,98 @@ class TestToolFormatting:
         proc.process_line(line)
         captured = capsys.readouterr()
         assert "/tmp/test.py" in captured.out
+
+    def test_read_tool_camelcase(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "read",
+                "state": {
+                    "status": "completed",
+                    "input": {"filePath": "/workspace/README.md"},
+                },
+                "title": "README.md",
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "/workspace/README.md" in captured.out
+
+    def test_edit_tool_camelcase(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "edit",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "filePath": "/tmp/test.py",
+                        "oldString": "foo",
+                        "newString": "bar",
+                    },
+                },
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "/tmp/test.py" in captured.out
+
+    def test_task_tool(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "task",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "description": "Explore codebase structure",
+                        "subagent_type": "explore",
+                        "prompt": "Thoroughly explore the codebase\nLine 2\nLine 3",
+                    },
+                    "output": (
+                        "task_id: ses_abc123\n\n<task_result>\n"
+                        "Found 5 files.\nAll tests pass.\n</task_result>"
+                    ),
+                },
+                "title": "Explore codebase structure",
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "\U0001f916" in captured.out
+        assert "[explore]" in captured.out
+        assert "Explore codebase structure" in captured.out
+        assert "Thoroughly explore the codebase" in captured.out
+        assert "Line 2" in captured.out
+        assert "Found 5 files." in captured.out
+        assert "All tests pass." in captured.out
+        assert "task_id" not in captured.out
+        assert "task_result" not in captured.out
+
+    def test_task_tool_camelcase(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "task",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "description": "Verify README",
+                        "subagentType": "explore",
+                        "prompt": "Check the README",
+                    },
+                },
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "[explore]" in captured.out
+        assert "Verify README" in captured.out

--- a/tests/test_stream_opencode.py
+++ b/tests/test_stream_opencode.py
@@ -1,0 +1,195 @@
+"""Tests for OpenCodeStreamProcessor."""
+
+import json
+
+from agentic_ci.stream import OpenCodeStreamProcessor
+
+
+def _make_event(event_type, **kwargs):
+    """Build an OpenCode JSONL event."""
+    event = {"type": event_type, "timestamp": 1234567890, "sessionID": "test-session"}
+    event.update(kwargs)
+    return json.dumps(event)
+
+
+class TestProcessLine:
+    def test_empty_line(self):
+        proc = OpenCodeStreamProcessor(color=False)
+        assert proc.process_line("") is False
+
+    def test_invalid_json(self):
+        proc = OpenCodeStreamProcessor(color=False)
+        assert proc.process_line("not json") is False
+
+    def test_step_start(self):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event("step_start", part={"type": "step-start"})
+        assert proc.process_line(line) is False
+
+    def test_text_event(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "text",
+            part={"type": "text", "text": "Hello world"},
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Agent" in captured.out
+        assert "Hello world" in captured.out
+
+    def test_tool_use_event(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "bash",
+                "callID": "call-1",
+                "state": {
+                    "status": "completed",
+                    "input": {"command": "ls -la", "description": "list files"},
+                    "output": "file1\nfile2\n",
+                },
+                "title": "list files",
+            },
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Bash" in captured.out
+        assert "ls -la" in captured.out
+
+    def test_step_finish_stop(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "step_finish",
+            part={
+                "type": "step-finish",
+                "reason": "stop",
+                "tokens": {
+                    "total": 1000,
+                    "input": 500,
+                    "output": 100,
+                    "reasoning": 0,
+                    "cache": {"write": 400, "read": 0},
+                },
+                "cost": 0.0123,
+            },
+        )
+        assert proc.process_line(line) is True
+        captured = capsys.readouterr()
+        assert "TOKENS" in captured.out
+        assert "in=500" in captured.out
+        assert "out=100" in captured.out
+        assert "cost=$0.0123" in captured.out
+
+    def test_step_finish_tool_calls(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "step_finish",
+            part={
+                "type": "step-finish",
+                "reason": "tool-calls",
+                "tokens": {
+                    "total": 500,
+                    "input": 300,
+                    "output": 50,
+                    "reasoning": 0,
+                    "cache": {"write": 0, "read": 150},
+                },
+                "cost": 0.005,
+            },
+        )
+        assert proc.process_line(line) is False
+
+    def test_error_event(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "error",
+            error={"name": "UnknownError", "data": {"message": "Model not found"}},
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Model not found" in captured.out
+
+
+class TestProcess:
+    def test_full_run(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        events = [
+            _make_event("step_start", part={"type": "step-start"}),
+            _make_event("text", part={"type": "text", "text": "Hello"}),
+            _make_event(
+                "step_finish",
+                part={
+                    "type": "step-finish",
+                    "reason": "stop",
+                    "tokens": {
+                        "total": 100,
+                        "input": 50,
+                        "output": 10,
+                        "reasoning": 0,
+                        "cache": {"write": 40, "read": 0},
+                    },
+                    "cost": 0.001,
+                },
+            ),
+        ]
+        result = proc.process(events)
+        assert result is True
+
+    def test_incomplete_stream(self):
+        proc = OpenCodeStreamProcessor(color=False)
+        events = [
+            _make_event("step_start", part={"type": "step-start"}),
+            _make_event("text", part={"type": "text", "text": "Hello"}),
+        ]
+        result = proc.process(events)
+        assert result is False
+
+    def test_bytes_input(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event("text", part={"type": "text", "text": "Hello"})
+        result = proc.process([line.encode("utf-8")])
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Hello" in captured.out
+
+
+class TestToolFormatting:
+    def test_read_tool(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "read",
+                "state": {
+                    "status": "completed",
+                    "input": {"file_path": "/tmp/test.py"},
+                },
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "/tmp/test.py" in captured.out
+
+    def test_edit_tool(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        line = _make_event(
+            "tool_use",
+            part={
+                "type": "tool",
+                "tool": "edit",
+                "state": {
+                    "status": "completed",
+                    "input": {
+                        "file_path": "/tmp/test.py",
+                        "old_string": "foo",
+                        "new_string": "bar",
+                    },
+                },
+            },
+        )
+        proc.process_line(line)
+        captured = capsys.readouterr()
+        assert "/tmp/test.py" in captured.out


### PR DESCRIPTION
## Description
Introduce a Harness layer that decouples agent-specific logic (CLI args, env vars, credential paths, stream parsing) from backend execution (Podman, OpenShell). This enables running OpenCode alongside Claude Code via the new --harness flag.

- Add Harness ABC with ClaudeCodeHarness and OpenCodeHarness
- Add OpenCodeStreamProcessor for OpenCode's JSON event format
- Refactor backends to delegate agent-specific details to harness
- Skip podman pull for localhost/ images (local builds)
- Skip OTEL collector for harnesses that don't support it

## How Has This Been Tested?
Tested with:

```bash
> uv run --with . agentic-ci run --harness opencode --model google-vertex/claude-haiku-4-5@20251001 --image localhost/opencode-test "say hello"
▶ Backend: podman
  Harness: OpenCode
  Workdir: /home/mprpic/repos/github.com/mprpic/agentic-ci
  Image: localhost/opencode-test
▶ Credentials staged (default ADC file)
  Container user: rootless (userns keep-id)
▶ Local image, skipping pull
▶ Podman container started
▶ Running OpenCode (google-vertex/claude-haiku-4-5@20251001) via podman backend
▶ Executing OpenCode in container
  💬 Agent Hello! 👋

  I'm OpenCode, your AI coding assistant. I'm here to help you with software engineering tasks like:

  - Writing and refactoring code
  - Debugging issues
  - Exploring codebases
  - Running tests and builds
  - Creating features and fixing bugs
  - And much more

  What would you like help with today? You can also press `ctrl+p` to see available actions, or visit https://github.com/anomalyco/opencode to report feedback.

  📊 TOKENS in=3 out=111 cache_r=9573 cache_w=0 total=9687 cost=$0.0015
  stream processor detected run complete (rc=-9), treating as success

▶ Agent exit code: 0
▶ Podman container stopped
```

using a minimal OpenCode Containerfile:

```Dockerfile
FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1

ARG OPENCODE_VERSION=1.15.6
ARG OPENCODE_SHA256=9874d0857f7b01a09189ebb8af42ef20d556be3f0d054563e5eef1234528c71f

RUN microdnf install -y --nodocs \
        git \
        curl \
        jq \
        tar \
        shadow-utils \
    && microdnf clean all

RUN useradd -u 1000 -m agent

RUN curl -fsSL -o /tmp/opencode.tar.gz \
        "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
    && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
    && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin \
    && chmod +x /usr/local/bin/opencode \
    && rm -f /tmp/opencode.tar.gz

RUN mkdir -p /home/agent/.config/opencode \
    && printf '{"$schema":"https://opencode.ai/config.json","permission":{"*":"allow"}}\n' \
       > /home/agent/.config/opencode/opencode.json \
    && chown -R agent:agent /home/agent/.config

USER agent
WORKDIR /home/agent

ENV OPENCODE_DISABLE_AUTOUPDATE=1
CMD ["opencode"]
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added support for multiple AI agent implementations via pluggable harnesses; CLI now includes `--harness` argument to select between different agent backends
  * Introduced flexible execution backends (Podman and OpenShell) enabling customizable container environments

* **Documentation**
  * Updated architecture documentation to describe pluggable backend and harness system with supported options and configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->