### PR TITLE
Remove commit-message-key post-agent gate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.7"
+version = "0.2.8"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/gates.py
+++ b/src/agentic_ci/gates.py
@@ -125,16 +125,6 @@ def check_commit_author(commit_info: dict, expected_email: str) -> bool:
     return actual.lower() == expected_email.lower()
 
 
-def check_commit_message_key(commit_info: dict, ticket_key: str) -> bool:
-    """Verify the ticket key appears as a whole token in the commit subject.
-
-    Uses word-boundary matching so "ABC-1" does not match "ABC-10".
-    """
-    subject = commit_info.get("subject", "")
-    escaped = re.escape(ticket_key)
-    return bool(re.search(rf"(?<![A-Za-z0-9]){escaped}(?![A-Za-z0-9])", subject, re.IGNORECASE))
-
-
 def log_changed_files(changed_files: list[str], ticket_key: str) -> None:
     """Log changed files for observability."""
     if changed_files:
@@ -289,21 +279,6 @@ def _run_commit_author(workdir: str, **_kw: object) -> list[str]:
     return []
 
 
-def _run_commit_message_key(workdir: str, **_kw: object) -> list[str]:
-    """CLI runner for the commit-message-key gate."""
-    from agentic_ci.git import get_commit_info
-
-    ticket_key = os.environ.get("TICKET_KEY", "")
-    try:
-        info = get_commit_info(Path(workdir))
-    except subprocess.CalledProcessError as exc:
-        return [f"Could not read commit info: {exc}"]
-
-    if not check_commit_message_key(info, ticket_key):
-        return [f"Ticket key '{ticket_key}' not found in commit message: '{info.get('subject')}'"]
-    return []
-
-
 def _run_gitleaks(workdir: str, **_kw: object) -> list[str]:
     """CLI runner for the gitleaks gate."""
     return gitleaks_scan(Path(workdir))
@@ -313,10 +288,4 @@ def _run_gitleaks(workdir: str, **_kw: object) -> list[str]:
 
 _register("sensitive-files", _run_sensitive_files, phase="post")
 _register("commit-author", _run_commit_author, phase="post", required_env=["BOT_EMAIL"])
-_register(
-    "commit-message-key",
-    _run_commit_message_key,
-    phase="post",
-    required_env=["TICKET_KEY"],
-)
 _register("gitleaks", _run_gitleaks, phase="post")

--- a/tests/test_gate_registry.py
+++ b/tests/test_gate_registry.py
@@ -18,7 +18,6 @@ class TestGateRegistry:
     def test_built_in_gates_registered(self):
         assert "sensitive-files" in GATE_REGISTRY
         assert "commit-author" in GATE_REGISTRY
-        assert "commit-message-key" in GATE_REGISTRY
         assert "gitleaks" in GATE_REGISTRY
 
     def test_sensitive_files_is_post(self):
@@ -26,9 +25,6 @@ class TestGateRegistry:
 
     def test_commit_author_requires_bot_email(self):
         assert "BOT_EMAIL" in GATE_REGISTRY["commit-author"].required_env
-
-    def test_commit_message_key_requires_ticket_key(self):
-        assert "TICKET_KEY" in GATE_REGISTRY["commit-message-key"].required_env
 
     def test_gitleaks_has_no_required_env(self):
         assert GATE_REGISTRY["gitleaks"].required_env == []
@@ -48,8 +44,8 @@ class TestResolveGates:
 
 class TestValidateGateEnv:
     def test_all_vars_present(self):
-        gates = [GATE_REGISTRY["commit-author"], GATE_REGISTRY["commit-message-key"]]
-        with patch.dict(os.environ, {"BOT_EMAIL": "bot@ci.com", "TICKET_KEY": "PROJ-1"}):
+        gates = [GATE_REGISTRY["commit-author"]]
+        with patch.dict(os.environ, {"BOT_EMAIL": "bot@ci.com"}):
             validate_gate_env(gates)
 
     def test_missing_var_exits(self):
@@ -59,13 +55,12 @@ class TestValidateGateEnv:
                 validate_gate_env(gates)
 
     def test_reports_all_missing_at_once(self):
-        gates = [GATE_REGISTRY["commit-author"], GATE_REGISTRY["commit-message-key"]]
+        gates = [GATE_REGISTRY["commit-author"], GATE_REGISTRY["sensitive-files"]]
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(SystemExit) as exc_info:
                 validate_gate_env(gates)
             msg = str(exc_info.value)
             assert "BOT_EMAIL" in msg
-            assert "TICKET_KEY" in msg
 
     def test_no_required_env_passes(self):
         gates = [GATE_REGISTRY["sensitive-files"]]
@@ -113,33 +108,6 @@ class TestRunCommitAuthor:
             errors = gate.fn(workdir="/tmp/test")
         assert len(errors) == 1
         assert "human@ci.com" in errors[0]
-
-
-class TestRunCommitMessageKey:
-    def test_key_present_passes(self):
-        gate = GATE_REGISTRY["commit-message-key"]
-        with (
-            patch.dict(os.environ, {"TICKET_KEY": "PROJ-123"}),
-            patch(
-                "agentic_ci.git.get_commit_info",
-                return_value={"email": "bot@ci.com", "subject": "PROJ-123: fix bug"},
-            ),
-        ):
-            errors = gate.fn(workdir="/tmp/test")
-        assert errors == []
-
-    def test_key_missing_fails(self):
-        gate = GATE_REGISTRY["commit-message-key"]
-        with (
-            patch.dict(os.environ, {"TICKET_KEY": "PROJ-123"}),
-            patch(
-                "agentic_ci.git.get_commit_info",
-                return_value={"email": "bot@ci.com", "subject": "random fix"},
-            ),
-        ):
-            errors = gate.fn(workdir="/tmp/test")
-        assert len(errors) == 1
-        assert "PROJ-123" in errors[0]
 
 
 class TestGitleaksScan:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -4,7 +4,6 @@ import re
 
 from agentic_ci.gates import (
     check_commit_author,
-    check_commit_message_key,
     check_external_reporter,
     check_sensitive_files,
     filter_bot_comments,
@@ -45,23 +44,6 @@ class TestCheckCommitAuthor:
 
     def test_mismatch(self):
         assert check_commit_author({"email": "human@ci.com"}, "bot@ci.com") is False
-
-
-class TestCheckCommitMessageKey:
-    def test_key_present(self):
-        assert check_commit_message_key({"subject": "PROJ-123: fix bug"}, "PROJ-123") is True
-
-    def test_key_absent(self):
-        assert check_commit_message_key({"subject": "fix something"}, "PROJ-123") is False
-
-    def test_case_insensitive(self):
-        assert check_commit_message_key({"subject": "proj-123: fix"}, "PROJ-123") is True
-
-    def test_no_prefix_match(self):
-        assert check_commit_message_key({"subject": "ABC-10: fix"}, "ABC-1") is False
-
-    def test_exact_boundary_match(self):
-        assert check_commit_message_key({"subject": "ABC-1: fix"}, "ABC-1") is True
 
 
 class TestFilterCommentsByDomain:


### PR DESCRIPTION
## Summary

- Removes the `commit-message-key` post-agent gate that required the Jira ticket key in the commit subject
- The gate conflicted with target repos using their own commit format (e.g. conventional commits like `fix(scope): message`), causing the autofix bot to be blocked even when the fix was correct
- Traceability is already provided by the MR/PR title and branch name, which are constructed independently from the commit message

Observed on [RHOAIENG-61517](https://redhat.atlassian.net/browse/RHOAIENG-61517): the agent followed the target repo's conventional commit format and the gate rejected it.

## Test plan

- [x] `tox -e py314` passes (186 tests)
- [x] `tox -e lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removals**
  * The `commit-message-key` gate has been removed. This gate previously validated that commit messages contained the required ticket key prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->