### PR TITLE
Add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # agentic-ci
 
+[![PyPI version](https://img.shields.io/pypi/v/agentic-ci)](https://pypi.org/project/agentic-ci/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/agentic-ci)](https://pypi.org/project/agentic-ci/)
+[![CI](https://github.com/opendatahub-io/agentic-ci/actions/workflows/ci.yml/badge.svg)](https://github.com/opendatahub-io/agentic-ci/actions/workflows/ci.yml)
+[![License](https://img.shields.io/github/license/opendatahub-io/agentic-ci)](https://github.com/opendatahub-io/agentic-ci/blob/main/LICENSE)
+[![PyPI - Downloads](https://img.shields.io/pypi/dm/agentic-ci)](https://pypi.org/project/agentic-ci/)
+
 Run AI coding agents in sandboxed CI environments with streaming output
 and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
 and isolation backends so you can choose the right tradeoff between


### PR DESCRIPTION
## Summary
- Add PyPI version, Python versions, CI build status, license, and download count badges to the top of the README

## Test plan
- [ ] Verify badges render correctly on GitHub
- [ ] Verify badge links point to the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)