### PR TITLE
Use --force-with-lease for git push

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.8"
+version = "0.2.9"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -244,7 +244,7 @@ def push_branch(repo_dir: Path, remote: str = "origin", branch: str | None = Non
         if not _validate_ref(branch):
             log.error("push_branch: detected invalid branch name: %s", branch)
             return False
-    cmd = ["git", "push", "--set-upstream", remote, branch]
+    cmd = ["git", "push", "--force-with-lease", "--set-upstream", remote, branch]
     try:
         subprocess.run(
             cmd,


### PR DESCRIPTION
## Summary

- Changes `push_branch()` to use `--force-with-lease` instead of plain `git push`
- Fixes push failures when the agent rebases an existing branch (e.g. to address reviewer feedback), which causes non-fast-forward rejections
- `--force-with-lease` is safe for bot-owned branches: it still rejects if the remote ref moved unexpectedly (concurrent push protection)
- Bumps version to 0.2.9

Observed on [RHOAIENG-61517](https://redhat.atlassian.net/browse/RHOAIENG-61517): the agent rebased onto latest main per reviewer request, then push was rejected ([job log](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14531105838)).

## Test plan

- [x] `tox -e py314` passes (186 tests)
- [x] `tox -e lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.9

* **Improvements**
  * Enhanced branch push mechanism for improved safety and reliability during remote updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->