### PR TITLE
Add Anthropic API key auth as alternative to Vertex AI

### DIFF
--- a/.claude/skills/test-e2e-podman/SKILL.md
+++ b/.claude/skills/test-e2e-podman/SKILL.md
@@ -1,88 +1,220 @@
 ---
 name: test-e2e-podman
-description: Run end-to-end tests for the podman backend using a real container and Claude API call
+description: Run end-to-end tests for the podman backend using real container and API calls
 ---
 
 # End-to-End Podman Backend Test
 
-Run a full lifecycle test of the podman backend: setup, run (multiple modes), and stop.
+Run full lifecycle tests of the podman backend across harnesses and auth modes.
+
+Each section below is independent. Run whichever sections match your environment and skip the rest.
 
 ## Prerequisites
 
+All sections require:
 - `podman` installed and working (rootless)
-- GCP ADC credentials available (`~/.config/gcloud/application_default_credentials.json`)
-- Network access to Vertex AI and `ghcr.io`
+- Network access to `ghcr.io` (image pull)
 
-## Steps
+Per-section requirements:
+- **Vertex AI auth**: GCP ADC credentials (`~/.config/gcloud/application_default_credentials.json`)
+- **API key auth**: `ANTHROPIC_API_KEY` set in the environment
+- **OpenCode harness**: An OpenCode container image (set `OPENCODE_CONTAINER_IMAGE` or pass `--image`)
 
-Clean up any leftover container first:
+## Auth isolation
+
+`ANTHROPIC_API_KEY` controls auth mode globally. To ensure Vertex sections use Vertex and API key sections use API key auth, prefix commands with the appropriate environment:
+
+- Vertex sections: `env -u ANTHROPIC_API_KEY uv run --with . agentic-ci ...`
+- API key sections: run normally (key inherited from environment)
+
+The commands below already include these prefixes.
+
+## Cleanup
+
+Before starting any section, clean up leftover containers:
 
 ```bash
 podman rm -f agentic-ci 2>/dev/null || true
 ```
 
-### 1. Setup
+---
+
+## Section A: Claude Code + Vertex AI
+
+### A1. Setup
 
 ```bash
-uv run agentic-ci setup --image ghcr.io/opendatahub-io/ai-helpers:latest
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci setup \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest
 ```
 
 Verify:
+- Output shows `Auth: Vertex AI`
 - Output says `--- Podman container started ---`
 - `podman ps --filter name=agentic-ci` shows the container running
 
-### 2. First run (streaming, no OTEL)
+### A2. Run (streaming, no OTEL)
 
 ```bash
-uv run agentic-ci run "Respond with exactly: RUN1_OK" \
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A2_OK" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-sonnet-4-6 --no-otel
+    --model claude-haiku-4-5-20251001 --no-otel
 ```
 
 Verify:
 - Output says `--- Podman container already running ---` (reuses container from setup)
 - Streaming output shows colored text blocks (thinking, tool calls, Claude response)
-- Claude's response contains `RUN1_OK`
+- Claude's response contains `A2_OK`
 - Exit code is 0
 
-### 3. Second run (streaming, with OTEL)
+### A3. Run (streaming, with OTEL)
 
 ```bash
-uv run agentic-ci run "Respond with exactly: RUN2_OK" \
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A3_OK" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-sonnet-4-6
+    --model claude-haiku-4-5-20251001
 ```
 
 Verify:
 - Container is still reused (`already running`)
 - OTEL collector starts on a dynamic port
 - Streaming output works
-- Claude's response contains `RUN2_OK`
+- Claude's response contains `A3_OK`
 - OTEL Token/Cost Summary prints at the end with token counts and USD costs
 - Exit code is 0
 
-### 4. Run without streaming
+### A4. Run (no streaming)
 
 ```bash
-uv run agentic-ci run "Respond with exactly: RUN3_OK" \
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A4_OK" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-sonnet-4-6 --no-streaming --no-otel
+    --model claude-haiku-4-5-20251001 --no-streaming --no-otel
 ```
 
 Verify:
 - No formatted streaming output (no colored blocks, no tool summaries)
 - Exit code is 0
 
-### 5. Stop
+### A5. Stop
 
 ```bash
-uv run agentic-ci stop --image ghcr.io/opendatahub-io/ai-helpers:latest
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci stop \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest
 ```
 
 Verify:
 - Output says `--- Podman container stopped ---`
-- `podman ps -a --filter name=agentic-ci` shows no container (removed)
+- `podman ps -a --filter name=agentic-ci` shows no container
+
+---
+
+## Section B: Claude Code + API Key
+
+Requires `ANTHROPIC_API_KEY` set in the environment.
+
+### B1. Setup and run
+
+```bash
+podman rm -f agentic-ci 2>/dev/null || true
+uv run --with . agentic-ci run "Respond with exactly: B1_OK" \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest \
+    --model claude-haiku-4-5-20251001 --no-otel
+```
+
+Verify:
+- Output shows `Auth: API key` (not `Vertex AI`)
+- Streaming output works
+- Claude's response contains `B1_OK`
+- Exit code is 0
+
+### B2. Run (streaming, with OTEL)
+
+```bash
+uv run --with . agentic-ci run "Respond with exactly: B2_OK" \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest \
+    --model claude-haiku-4-5-20251001
+```
+
+Verify:
+- OTEL collector starts and Token/Cost Summary prints at the end
+- Claude's response contains `B2_OK`
+- Exit code is 0
+
+### B3. Stop
+
+```bash
+uv run --with . agentic-ci stop --image ghcr.io/opendatahub-io/ai-helpers:latest
+```
+
+Verify:
+- Output says `--- Podman container stopped ---`
+
+---
+
+## Section C: OpenCode + Vertex AI
+
+Requires GCP ADC credentials and an OpenCode container image.
+
+### C1. Run
+
+```bash
+podman rm -f agentic-ci 2>/dev/null || true
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: C1_OK" \
+    --harness opencode \
+    --image "$OPENCODE_CONTAINER_IMAGE" \
+    --model google-vertex/claude-haiku-4-5@20251001 \
+    --no-otel
+```
+
+Verify:
+- Output shows `Harness: OpenCode` and `Auth: Vertex AI`
+- Streaming output shows agent activity
+- Exit code is 0
+
+### C2. Stop
+
+```bash
+env -u ANTHROPIC_API_KEY uv run --with . agentic-ci stop --harness opencode \
+    --image "$OPENCODE_CONTAINER_IMAGE"
+```
+
+Verify:
+- Output says `--- Podman container stopped ---`
+
+---
+
+## Section D: OpenCode + API Key
+
+Requires `ANTHROPIC_API_KEY` set in the environment and an OpenCode container image.
+
+### D1. Run
+
+```bash
+podman rm -f agentic-ci 2>/dev/null || true
+uv run --with . agentic-ci run "Respond with exactly: D1_OK" \
+    --harness opencode \
+    --image "$OPENCODE_CONTAINER_IMAGE" \
+    --model anthropic/claude-haiku-4-5-20251001 \
+    --no-otel
+```
+
+Verify:
+- Output shows `Harness: OpenCode` and `Auth: API key`
+- Streaming output shows agent activity
+- Exit code is 0
+
+### D2. Stop
+
+```bash
+uv run --with . agentic-ci stop --harness opencode \
+    --image "$OPENCODE_CONTAINER_IMAGE"
+```
+
+Verify:
+- Output says `--- Podman container stopped ---`
+
+---
 
 ## Running the full suite
 
-Execute all steps sequentially. If any step fails, stop and investigate. Clean up with `podman rm -f agentic-ci` before retrying.
+Execute sections in order (A through D), skipping any whose prerequisites are not met. If any step fails, stop and investigate. Clean up with `podman rm -f agentic-ci` before retrying.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,7 +45,7 @@ src/agentic_ci/
 
 ### Key
 
-- **Vertex AI** for Claude API access. Credentials are staged via gcloud ADC files.
+- **Authentication** is auto-detected: if `ANTHROPIC_API_KEY` is set, direct API auth is used (no gcloud credentials needed); otherwise Vertex AI with gcloud ADC files.
 - **OTEL collector runs on the host**, not inside the sandbox/container. Currently only Claude Code emits OTEL metrics; OpenCode provides token/cost data via its JSON output.
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -167,8 +167,25 @@ every missing variable and which gate needs it.
 
 ## Credentials
 
-Both backends use Vertex AI for Claude API access via gcloud
-Application Default Credentials.
+Two authentication modes are supported. The mode is auto-detected
+and logged at startup.
+
+### Anthropic API key (direct)
+
+Set `ANTHROPIC_API_KEY` in the environment. No gcloud credentials
+are needed; the key is passed directly to the agent inside the
+container or sandbox. Vertex-specific env vars and credential mounts
+are skipped.
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+agentic-ci run "Fix the bug" --image ghcr.io/opendatahub-io/ai-helpers:latest
+```
+
+### Vertex AI (default)
+
+When `ANTHROPIC_API_KEY` is not set, both backends use Vertex AI for
+Claude API access via gcloud Application Default Credentials.
 
 The **podman** backend checks credentials in this order:
 
@@ -185,6 +202,7 @@ The **openshell** backend uploads the local ADC file
 
 | Variable | Default | Description |
 |---|---|---|
+| `ANTHROPIC_API_KEY` | -- | Anthropic API key. When set, uses direct API auth instead of Vertex AI |
 | `CLAUDE_MODEL` | `claude-opus-4-6` | Default model for Claude Code harness (overridden by `--model`) |
 | `CLAUDE_CONTAINER_IMAGE` | — | Default container image for Claude Code harness |
 | `OPENCODE_MODEL` | `google-vertex/claude-opus-4-6@default` | Default model for OpenCode harness (overridden by `--model`) |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ agentic-ci run "Fix the flaky test in test_auth.py" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest
 
 # OpenShell
-agentic-ci --backend openshell run "Fix the flaky test in test_auth.py"
+agentic-ci run --backend openshell "Fix the flaky test in test_auth.py"
 ```
 
 ### Setup and stop
@@ -89,7 +89,7 @@ agentic-ci stop
 ### Options
 
 ```
-agentic-ci [--backend {podman,openshell}] {setup,run,stop} [options]
+agentic-ci {setup,run,stop} [options]
 ```
 
 | Flag | Default | Description |
@@ -135,12 +135,12 @@ agentic-ci run "Fix the bug" \
     --post-gates sensitive-files,commit-author,commit-message-key,gitleaks
 
 # OpenShell with custom policy
-agentic-ci --backend openshell run "Deploy staging" \
+agentic-ci run --backend openshell "Deploy staging" \
     --policy custom-policy.yml
 
 # OpenShell with repo-level policy (auto-discovered from
 # .agentic-ci/openshell-policy.yml in the workdir)
-agentic-ci --backend openshell run "Add input validation"
+agentic-ci run --backend openshell "Add input validation"
 ```
 
 ### Gates

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -77,6 +77,13 @@ class Backend(ABC):
             log.info(f"stream processor detected run complete (rc={rc}), treating as success")
             rc = 0
 
+        if rc != 0 and proc.stderr:
+            stderr = proc.stderr.read()
+            if stderr:
+                log.section("Agent stderr")
+                sys.stderr.buffer.write(stderr)
+                sys.stderr.buffer.flush()
+
         return rc
 
     def _wait_for_otel_flush(self, otel_port):

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
@@ -52,8 +53,23 @@ class Backend(ABC):
         Returns the exit code, treating stream-complete as success even
         if the process exit code is non-zero.
         """
+        stderr_buf = bytearray()
+
+        def _drain_stderr():
+            if proc.stderr is None:
+                return
+            while True:
+                chunk = proc.stderr.read(4096)
+                if not chunk:
+                    break
+                stderr_buf.extend(chunk)
+
+        stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+        stderr_thread.start()
+
         stream_complete = False
 
+        processor = None
         if streaming:
             processor = self.harness.create_stream_processor(pid=proc.pid)
             for line in proc.stdout:
@@ -71,20 +87,36 @@ class Backend(ABC):
         except OSError:
             pass
         proc.wait()
+        stderr_thread.join(timeout=5)
         rc = proc.returncode
+
+        if processor:
+            processor.flush_errors()
 
         if stream_complete and rc != 0:
             log.info(f"stream processor detected run complete (rc={rc}), treating as success")
             rc = 0
 
-        if rc != 0 and proc.stderr:
-            stderr = proc.stderr.read()
-            if stderr:
+        if rc != 0 and stderr_buf:
+            filtered = self._filter_stderr_noise(stderr_buf)
+            if filtered:
                 log.section("Agent stderr")
-                sys.stderr.buffer.write(stderr)
+                sys.stderr.buffer.write(filtered)
                 sys.stderr.buffer.flush()
 
         return rc
+
+    _STDERR_NOISE = (
+        "Performing one time database migration",
+        "sqlite-migration:",
+        "Database migration complete",
+    )
+
+    @classmethod
+    def _filter_stderr_noise(cls, buf):
+        lines = buf.decode("utf-8", errors="replace").splitlines(keepends=True)
+        filtered = [line for line in lines if not any(p in line for p in cls._STDERR_NOISE)]
+        return "".join(filtered).encode("utf-8") if filtered else b""
 
     def _wait_for_otel_flush(self, otel_port):
         """Wait for OTEL metrics to flush after Claude exits."""

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -83,6 +83,10 @@ class OpenShellBackend(Backend):
         sandbox.exec_cmd(["bash", "-c", f"cat > {self._ENV_SCRIPT} << 'ENVEOF'\n{script}ENVEOF"])
 
     def _upload_credentials(self):
+        if self.harness.auth_mode == "api-key":
+            log.section("Using API key auth (skipping credential upload)")
+            return
+
         adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
         if os.path.isfile(adc):
             source = "default ADC file"

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -44,6 +44,18 @@ network_policies:
       - path: /usr/local/bin/claude
       - path: /usr/local/bin/node
 
+  anthropic_api:
+    name: anthropic-api
+    endpoints:
+      - host: api.anthropic.com
+        port: 443
+        protocol: rest
+        enforcement: enforce
+        access: full
+    binaries:
+      - path: /usr/local/bin/claude
+      - path: /usr/local/bin/node
+
   github_api:
     name: github-api
     endpoints:

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -43,7 +43,8 @@ class PodmanBackend(Backend):
 
     def setup(self):
         self._resolve_image()
-        self._resolve_credentials()
+        if self.harness.auth_mode == "vertex":
+            self._resolve_credentials()
 
         if self.is_running():
             log.section("Podman container already running")
@@ -248,29 +249,31 @@ class PodmanBackend(Backend):
         return args
 
     def _build_vol_args(self):
-        assert self._config_dir is not None
-        mount_target = self.harness.credential_mount_target()
-        adc = os.path.join(
-            self._config_dir,
-            ".config",
-            "gcloud",
-            "application_default_credentials.json",
-        )
-        config = os.path.join(
-            self._config_dir,
-            ".config",
-            "gcloud",
-            "configurations",
-            "config_default",
-        )
-        return [
-            "-v",
-            f"{adc}:{mount_target}/.config/gcloud/application_default_credentials.json:ro,z",
-            "-v",
-            f"{config}:{mount_target}/.config/gcloud/configurations/config_default:ro,z",
-            "-v",
-            f"{self.workdir}:/workspace:z",
-        ]
+        vols = ["-v", f"{self.workdir}:/workspace:z"]
+        if self._config_dir is not None:
+            mount_target = self.harness.credential_mount_target()
+            adc = os.path.join(
+                self._config_dir,
+                ".config",
+                "gcloud",
+                "application_default_credentials.json",
+            )
+            config = os.path.join(
+                self._config_dir,
+                ".config",
+                "gcloud",
+                "configurations",
+                "config_default",
+            )
+            vols.extend(
+                [
+                    "-v",
+                    f"{adc}:{mount_target}/.config/gcloud/application_default_credentials.json:ro,z",
+                    "-v",
+                    f"{config}:{mount_target}/.config/gcloud/configurations/config_default:ro,z",
+                ]
+            )
+        return vols
 
     @staticmethod
     def _is_valid_json(text):

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -219,6 +219,7 @@ def main():
 
     log.section(f"Backend: {args.backend}")
     log.detail("Harness", harness.name)
+    log.detail("Auth", "API key" if harness.auth_mode == "api-key" else "Vertex AI")
     log.detail("Workdir", os.path.abspath(args.workdir))
     backend = create_backend(
         args.backend,

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -138,16 +138,16 @@ def main():
         prog="agentic-ci",
         description="Run AI coding agents in a sandboxed CI environment",
     )
-    parser.add_argument(
+    sub = parser.add_subparsers(dest="command")
+
+    # Common arguments shared by all subcommands
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
         "--backend",
         choices=["podman", "openshell"],
         default="podman",
         help="Sandbox backend (default: podman)",
     )
-    sub = parser.add_subparsers(dest="command")
-
-    # Common arguments shared by both subcommands
-    common = argparse.ArgumentParser(add_help=False)
     common.add_argument("--workdir", default=".", metavar="PATH", help="Working directory")
     common.add_argument("--image", default=None, metavar="IMAGE", help="Container/sandbox image")
     common.add_argument(

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -15,6 +15,13 @@ class Harness(ABC):
     """Base class for agent CLI harnesses."""
 
     @property
+    def auth_mode(self) -> str:
+        """Return 'api-key' if ANTHROPIC_API_KEY is set, else 'vertex'."""
+        if os.environ.get("ANTHROPIC_API_KEY"):
+            return "api-key"
+        return "vertex"
+
+    @property
     @abstractmethod
     def name(self) -> str:
         """Human-readable name for log messages."""
@@ -91,6 +98,13 @@ class ClaudeCodeHarness(Harness):
         return args
 
     def build_env_args(self):
+        if self.auth_mode == "api-key":
+            return [
+                "--env",
+                "ANTHROPIC_API_KEY",
+                "--env",
+                "DISABLE_AUTOUPDATER=1",
+            ]
         return [
             "--env",
             "CLAUDE_CODE_USE_VERTEX=1",
@@ -103,16 +117,22 @@ class ClaudeCodeHarness(Harness):
         ]
 
     def build_env_script_lines(self, otel_port=None, otel_rate_file=None):
-        vertex_project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
-        cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
-        lines = [
-            "export CLAUDE_CODE_USE_VERTEX=1",
-            f"export CLOUD_ML_REGION={shlex.quote(cloud_region)}",
-            f"export ANTHROPIC_VERTEX_PROJECT_ID={shlex.quote(vertex_project)}",
-            "export DISABLE_AUTOUPDATER=1",
-            "export GOOGLE_APPLICATION_CREDENTIALS="
-            '"$HOME/.config/gcloud/application_default_credentials.json"',
-        ]
+        if self.auth_mode == "api-key":
+            lines = [
+                f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",
+                "export DISABLE_AUTOUPDATER=1",
+            ]
+        else:
+            vertex_project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+            cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
+            lines = [
+                "export CLAUDE_CODE_USE_VERTEX=1",
+                f"export CLOUD_ML_REGION={shlex.quote(cloud_region)}",
+                f"export ANTHROPIC_VERTEX_PROJECT_ID={shlex.quote(vertex_project)}",
+                "export DISABLE_AUTOUPDATER=1",
+                "export GOOGLE_APPLICATION_CREDENTIALS="
+                '"$HOME/.config/gcloud/application_default_credentials.json"',
+            ]
         if otel_port:
             lines.extend(
                 [
@@ -191,6 +211,13 @@ class OpenCodeHarness(Harness):
         return args
 
     def build_env_args(self):
+        if self.auth_mode == "api-key":
+            return [
+                "--env",
+                "ANTHROPIC_API_KEY",
+                "--env",
+                "OPENCODE_DISABLE_AUTOUPDATE=1",
+            ]
         project = os.environ.get(
             "GOOGLE_CLOUD_PROJECT",
             os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
@@ -212,6 +239,11 @@ class OpenCodeHarness(Harness):
         ]
 
     def build_env_script_lines(self, otel_port=None, otel_rate_file=None):
+        if self.auth_mode == "api-key":
+            return [
+                f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",
+                "export OPENCODE_DISABLE_AUTOUPDATE=1",
+            ]
         project = os.environ.get(
             "GOOGLE_CLOUD_PROJECT",
             os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
@@ -220,14 +252,13 @@ class OpenCodeHarness(Harness):
             "VERTEX_LOCATION",
             os.environ.get("CLOUD_ML_REGION", "global"),
         )
-        lines = [
+        return [
             f"export GOOGLE_CLOUD_PROJECT={shlex.quote(project)}",
             f"export VERTEX_LOCATION={shlex.quote(location)}",
             "export OPENCODE_DISABLE_AUTOUPDATE=1",
             "export GOOGLE_APPLICATION_CREDENTIALS="
             '"$HOME/.config/gcloud/application_default_credentials.json"',
         ]
-        return lines
 
     def build_otel_exec_env(self, otel_port=None):
         return []

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -202,6 +202,10 @@ class ClaudeCodeStreamProcessor:
         log.detail("Turns", str(turns))
         log.detail("Cost", f"${cost:.4f}")
 
+    def flush_errors(self):
+        # Claude Code reports errors inline; nothing to flush.
+        pass
+
     def process_line(self, line):
         """Process a single line of stream-json. Returns True if run is complete."""
         line = line.strip()
@@ -373,6 +377,7 @@ class OpenCodeStreamProcessor:
         self._in_thinking = False
         self._emitted_first_line = False
         self._line_buf = ""
+        self._errors: list[str] = []
 
     _INDENT = "  "
 
@@ -438,6 +443,27 @@ class OpenCodeStreamProcessor:
         for line in body.split("\n"):
             print(f"{self._TASK_INDENT}{line}", flush=True)
 
+    _GENERIC_ERROR = "Unexpected server error. Check server logs for details."
+
+    def flush_errors(self):
+        """Print collected errors, deduplicating generic messages."""
+        if not self._errors:
+            return
+        specific = [e for e in self._errors if e != self._GENERIC_ERROR]
+        if specific:
+            for error_msg in dict.fromkeys(specific):
+                print(
+                    f"{self._INDENT}{self.RED}❌ Error: {error_msg}{self.RESET}",
+                    flush=True,
+                )
+        else:
+            print(
+                f"{self._INDENT}{self.RED}❌ Error: OpenCode returned a server error. "
+                f"Common causes: invalid model name, missing or expired credentials, "
+                f"or insufficient API permissions.{self.RESET}",
+                flush=True,
+            )
+
     def process_line(self, line):
         """Process a single JSONL line from OpenCode. Returns True when run is complete."""
         line = line.strip()
@@ -456,7 +482,7 @@ class OpenCodeStreamProcessor:
             self._end_text()
             error = msg.get("error", {})
             error_msg = error.get("data", {}).get("message", str(error))
-            print(f"{self._INDENT}{self.RED}❌ Error: {error_msg}{self.RESET}", flush=True)
+            self._errors.append(error_msg)
             return False
 
         if msg_type == "text":

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -24,6 +24,23 @@ def test_create_unknown_harness_raises():
         create_harness("gemini")
 
 
+class TestAuthMode:
+    def test_vertex_when_no_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert ClaudeCodeHarness().auth_mode == "vertex"
+        assert OpenCodeHarness().auth_mode == "vertex"
+
+    def test_api_key_when_set(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        assert ClaudeCodeHarness().auth_mode == "api-key"
+        assert OpenCodeHarness().auth_mode == "api-key"
+
+    def test_vertex_when_api_key_empty(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+        assert ClaudeCodeHarness().auth_mode == "vertex"
+        assert OpenCodeHarness().auth_mode == "vertex"
+
+
 class TestClaudeCodeHarness:
     def test_name(self):
         assert ClaudeCodeHarness().name == "Claude Code"
@@ -48,6 +65,7 @@ class TestClaudeCodeHarness:
         assert "bar" in args
 
     def test_build_env_args(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("CLOUD_ML_REGION", "us-east1")
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj")
         harness = ClaudeCodeHarness()
@@ -56,6 +74,15 @@ class TestClaudeCodeHarness:
         assert "CLOUD_ML_REGION=us-east1" in args
         assert "ANTHROPIC_VERTEX_PROJECT_ID=my-proj" in args
         assert "DISABLE_AUTOUPDATER=1" in args
+
+    def test_build_env_args_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        harness = ClaudeCodeHarness()
+        args = harness.build_env_args()
+        assert "ANTHROPIC_API_KEY" in args
+        assert "ANTHROPIC_API_KEY=sk-test-key" not in args
+        assert "DISABLE_AUTOUPDATER=1" in args
+        assert "CLAUDE_CODE_USE_VERTEX=1" not in args
 
     def test_build_otel_exec_env(self):
         harness = ClaudeCodeHarness()
@@ -67,12 +94,22 @@ class TestClaudeCodeHarness:
         assert ClaudeCodeHarness().build_otel_exec_env(otel_port=None) == []
 
     def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
         monkeypatch.setenv("CLOUD_ML_REGION", "us-west1")
         harness = ClaudeCodeHarness()
         lines = harness.build_env_script_lines()
         assert any("CLAUDE_CODE_USE_VERTEX=1" in line for line in lines)
         assert any("DISABLE_AUTOUPDATER=1" in line for line in lines)
+
+    def test_build_env_script_lines_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert "export ANTHROPIC_API_KEY=sk-test-key" in lines
+        assert any("DISABLE_AUTOUPDATER=1" in line for line in lines)
+        assert not any("CLAUDE_CODE_USE_VERTEX" in line for line in lines)
+        assert not any("GOOGLE_APPLICATION_CREDENTIALS" in line for line in lines)
 
     def test_build_env_script_lines_with_otel(self, monkeypatch, tmp_path):
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
@@ -123,6 +160,7 @@ class TestOpenCodeHarness:
         assert "--thinking" in args
 
     def test_build_env_args(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-proj")
         monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
         harness = OpenCodeHarness()
@@ -130,6 +168,15 @@ class TestOpenCodeHarness:
         assert "GOOGLE_CLOUD_PROJECT=my-proj" in args
         assert "VERTEX_LOCATION=us-central1" in args
         assert "OPENCODE_DISABLE_AUTOUPDATE=1" in args
+
+    def test_build_env_args_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        harness = OpenCodeHarness()
+        args = harness.build_env_args()
+        assert "ANTHROPIC_API_KEY" in args
+        assert "ANTHROPIC_API_KEY=sk-test-key" not in args
+        assert "OPENCODE_DISABLE_AUTOUPDATE=1" in args
+        assert not any("GOOGLE_CLOUD_PROJECT" in a for a in args)
 
     def test_build_env_args_fallback(self, monkeypatch):
         monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
@@ -145,12 +192,22 @@ class TestOpenCodeHarness:
         assert OpenCodeHarness().build_otel_exec_env(otel_port=4318) == []
 
     def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "proj")
         monkeypatch.setenv("VERTEX_LOCATION", "global")
         harness = OpenCodeHarness()
         lines = harness.build_env_script_lines()
         assert any("GOOGLE_CLOUD_PROJECT=" in line for line in lines)
         assert any("OPENCODE_DISABLE_AUTOUPDATE=1" in line for line in lines)
+
+    def test_build_env_script_lines_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        harness = OpenCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert "export ANTHROPIC_API_KEY=sk-test-key" in lines
+        assert any("OPENCODE_DISABLE_AUTOUPDATE=1" in line for line in lines)
+        assert not any("GOOGLE_CLOUD_PROJECT" in line for line in lines)
+        assert not any("GOOGLE_APPLICATION_CREDENTIALS" in line for line in lines)
 
     def test_credential_mount_target(self):
         assert OpenCodeHarness().credential_mount_target() == "/home/agent"

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -173,6 +173,7 @@ def test_resolve_image_raises_with_correct_env_var(monkeypatch, tmp_path, openco
 
 
 def test_build_vol_args_claude_mount_target(monkeypatch, tmp_path, claude_harness):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     creds = json.dumps({"type": "authorized_user"})
     monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
     backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
@@ -183,6 +184,7 @@ def test_build_vol_args_claude_mount_target(monkeypatch, tmp_path, claude_harnes
 
 
 def test_build_vol_args_opencode_mount_target(monkeypatch, tmp_path, opencode_harness):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     creds = json.dumps({"type": "authorized_user"})
     monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
     backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
@@ -190,3 +192,21 @@ def test_build_vol_args_opencode_mount_target(monkeypatch, tmp_path, opencode_ha
     vol_args = backend._build_vol_args()
     mount_str = " ".join(vol_args)
     assert "/home/agent/.config/gcloud/" in mount_str
+
+
+def test_build_vol_args_api_key_no_gcloud_mounts(monkeypatch, tmp_path, claude_harness):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    vol_args = backend._build_vol_args()
+    mount_str = " ".join(vol_args)
+    assert "/workspace" in mount_str
+    assert ".config/gcloud" not in mount_str
+
+
+def test_build_env_args_api_key(monkeypatch, tmp_path, claude_harness):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    args = backend._build_env_args()
+    assert "ANTHROPIC_API_KEY" in args
+    assert "ANTHROPIC_API_KEY=sk-test-key" not in args
+    assert "CLAUDE_CODE_USE_VERTEX=1" not in args

--- a/tests/test_stream_opencode.py
+++ b/tests/test_stream_opencode.py
@@ -108,8 +108,44 @@ class TestProcessLine:
             error={"name": "UnknownError", "data": {"message": "Model not found"}},
         )
         assert proc.process_line(line) is False
+        proc.flush_errors()
         captured = capsys.readouterr()
         assert "Model not found" in captured.out
+
+    def test_error_dedup_generic(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        specific = _make_event(
+            "error",
+            error={"name": "UnknownError", "data": {"message": "Model not found: foo"}},
+        )
+        generic = _make_event(
+            "error",
+            error={
+                "name": "UnknownError",
+                "data": {"message": "Unexpected server error. Check server logs for details."},
+            },
+        )
+        proc.process_line(specific)
+        proc.process_line(generic)
+        proc.flush_errors()
+        captured = capsys.readouterr()
+        assert "Model not found: foo" in captured.out
+        assert "Unexpected server error" not in captured.out
+
+    def test_error_generic_only(self, capsys):
+        proc = OpenCodeStreamProcessor(color=False)
+        generic = _make_event(
+            "error",
+            error={
+                "name": "UnknownError",
+                "data": {"message": "Unexpected server error. Check server logs for details."},
+            },
+        )
+        proc.process_line(generic)
+        proc.flush_errors()
+        captured = capsys.readouterr()
+        assert "Common causes:" in captured.out
+        assert "invalid model name" in captured.out
 
 
 class TestThinking:


### PR DESCRIPTION
## Description

Add Anthropic API key auth as alternative to Vertex AI

Auto-detect auth mode from the environment: if ANTHROPIC_API_KEY is
set, use direct API auth and skip Vertex env vars, gcloud credential
staging, and gcloud volume mounts. Otherwise fall back to the
existing Vertex AI flow.

- Add auth_mode property to Harness ABC
- Branch build_env_args/build_env_script_lines for both harnesses
- Skip credential staging in PodmanBackend for api-key mode
- Skip credential upload in OpenShellBackend for api-key mode
- Add api.anthropic.com to OpenShell default network policy
- Log selected auth mode at startup
- Show agent stderr on non-zero exit for easier debugging

## How Has This Been Tested?

```
> uv run --with . agentic-ci run --backend podman --harness opencode --image localhost/agentic-ci-opencode --model anthropic/claude-haiku-4-5-20251001 "say hello and nothing else"
▶ Backend: podman
  Harness: OpenCode
  Auth: API key
  Workdir: ...
  Image: localhost/agentic-ci-opencode
  Container user: rootless (userns keep-id)
▶ Local image, skipping pull
▶ Podman container started
▶ Running OpenCode (anthropic/claude-haiku-4-5-20251001) via podman backend
▶ Executing OpenCode in container
  💬 Agent Hello

  📊 TOKENS in=3 out=4 cache_r=0 cache_w=9599 total=9606 cost=$0.0120
  stream processor detected run complete (rc=-9), treating as success

▶ Agent exit code: 0
▶ Podman container stopped
> uv run --with . agentic-ci run --backend podman --model claude-haiku-4-5-20251001 "say hello and nothing else" --image ghcr.io/opendatahub-io/ai-helpers:latest
▶ Backend: podman
  Harness: Claude Code
  Auth: API key
  Workdir: ...
  Image: ghcr.io/opendatahub-io/ai-helpers:latest
  Container user: rootless (userns keep-id)
▶ Pulling image
  Trying to pull ghcr.io/opendatahub-io/ai-helpers:latest...
  Getting image source signatures
  [truncated]
  Writing manifest to image destination
  7948a87be28a8bc2004775ca03bfee2ecb63b2d9ea7b8303aff0ed8c33b34032
▶ Podman container started
▶ Starting OTEL collector
  pid: 147890
  port: 44571
▶ Running Claude Code (claude-haiku-4-5-20251001) via podman backend
▶ Executing Claude Code in container
▶ Claude Code v2.1.150
  Model: claude-haiku-4-5-20251001
  Permissions: bypassPermissions
  Tools: 29 available
  MCP servers: none
  Agents: 7 available
  Plugins: odh-ai-helpers
  🧠 Thinking The user is asking me to say hello and nothing else. This is a simple request for a greeting. I should respond with just "hello" or similar, without any additional text or tool calls.

  💬 Claude Hello!

  📊 TOKENS in=10 out=53 cache_r=0 cache_w=32900 total=32963
▶ Result: success (end_turn)
  Duration: 1.5s (API: 1.4s, TTFT: 1.5s)
  Turns: 1
  Cost: $0.0414
  stream processor detected run complete (rc=-9), treating as success

▶ Agent exit code: 0
▶ Token/Cost Summary (OpenTelemetry)

  Model: claude-haiku-4-5-20251001
  Token Type                  Count
  -------------------- ------------
  input                          10
  cacheRead                       0
  cacheCreation              32,900
  output                         53
  TOTAL                      32,963

  Model                            Cost (USD)
  ------------------------------ ------------
  claude-haiku-4-5-20251001      $     0.0414

  Active Time:
    cli: 0m 1s
▶ Podman container stopped
```

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic authentication mode detection (API-key vs Vertex) with startup log of selected mode.
  * Improved deferred error collection and flushing for streamed backend output.

* **Behavior Changes**
  * Container volume/credential mounts and env wiring now follow detected auth mode; workspace is always mounted.
  * Filtered stderr from failed backend runs is captured and presented to aid troubleshooting.

* **Documentation**
  * CLI usage updated (moved --backend to subcommands) and expanded authentication and end-to-end podman guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->