### PR TITLE
feat: add get_description_editors() to JiraClient

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -389,6 +389,47 @@ class JiraClient:
             return {"found": False}
         return {"found": True, "email": author_email, "displayName": author_name}
 
+    def get_description_editors(self, key: str) -> list[str]:
+        """Return email addresses of all users who edited the issue description.
+
+        Walks the full changelog looking for description field changes.
+        Returns a list of unique email addresses (may be empty if the
+        description was never edited after creation).
+        """
+        editors: list[str] = []
+        seen: set[str] = set()
+        start_at = 0
+
+        while True:
+            resp = self._request(
+                "get",
+                self._api_url(f"issue/{key}/changelog"),
+                headers=self._headers(),
+                params={"startAt": start_at, "maxResults": 100},
+            )
+            self._check(resp)
+
+            data = resp.json()
+            for entry in data.get("values", []):
+                if not any(item.get("field") == "description" for item in entry.get("items", [])):
+                    continue
+                author = entry.get("author", {})
+                email = author.get("emailAddress", "")
+                if not email:
+                    account_id = author.get("accountId", "unknown")
+                    email = f"missing-email:{account_id}"
+                if email not in seen:
+                    editors.append(email)
+                    seen.add(email)
+
+            total = data.get("total", 0)
+            values = data.get("values", [])
+            start_at += len(values)
+            if start_at >= total or not values:
+                break
+
+        return editors
+
     def get_custom_field(self, key: str, *field_names: str) -> dict[str, object]:
         """Read custom fields by name. Returns ``{name: value}``."""
         field_ids = {name: self._resolve_field_id(name) for name in field_names}

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -342,6 +342,178 @@ class TestRetryOn429:
         assert resp.status_code == 200
         mock_sleep.assert_called_once_with(1.0)
 
+
+class TestGetDescriptionEditors:
+    @patch("agentic_ci.jira.client.requests")
+    def test_no_edits_returns_empty(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {"values": [], "total": 0}
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == []
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_redhat_editor_returned(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {
+                        "emailAddress": "dev@redhat.com",
+                        "accountId": "abc123",
+                    },
+                    "items": [{"field": "description", "fromString": "old", "toString": "new"}],
+                }
+            ],
+            "total": 1,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["dev@redhat.com"]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_external_editor_returned(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {
+                        "emailAddress": "attacker@evil.com",
+                        "accountId": "xyz789",
+                    },
+                    "items": [{"field": "description", "fromString": "old", "toString": "new"}],
+                }
+            ],
+            "total": 1,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["attacker@evil.com"]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_missing_email_produces_sentinel(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {"accountId": "hidden-user-42"},
+                    "items": [{"field": "description", "fromString": "old", "toString": "new"}],
+                }
+            ],
+            "total": 1,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["missing-email:hidden-user-42"]
+
+    @pytest.mark.parametrize("email_value", [None, ""])
+    @patch("agentic_ci.jira.client.requests")
+    def test_null_or_empty_email_produces_sentinel(self, mock_requests, client, email_value):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {
+                        "emailAddress": email_value,
+                        "accountId": "hidden-user-42",
+                    },
+                    "items": [{"field": "description"}],
+                }
+            ],
+            "total": 1,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["missing-email:hidden-user-42"]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_non_description_changes_ignored(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {"emailAddress": "dev@redhat.com"},
+                    "items": [{"field": "summary", "fromString": "old", "toString": "new"}],
+                },
+                {
+                    "author": {"emailAddress": "dev@redhat.com"},
+                    "items": [{"field": "labels", "fromString": "", "toString": "bug"}],
+                },
+            ],
+            "total": 2,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == []
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_deduplicates_editors(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "values": [
+                {
+                    "author": {"emailAddress": "dev@redhat.com"},
+                    "items": [{"field": "description"}],
+                },
+                {
+                    "author": {"emailAddress": "dev@redhat.com"},
+                    "items": [{"field": "description"}],
+                },
+                {
+                    "author": {"emailAddress": "other@redhat.com"},
+                    "items": [{"field": "description"}],
+                },
+            ],
+            "total": 3,
+        }
+        mock_requests.get.return_value = resp
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["dev@redhat.com", "other@redhat.com"]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_paginates_changelog(self, mock_requests, client):
+        page1 = MagicMock()
+        page1.status_code = 200
+        page1.json.return_value = {
+            "values": [
+                {
+                    "author": {"emailAddress": "dev@redhat.com"},
+                    "items": [{"field": "description"}],
+                }
+            ],
+            "total": 2,
+        }
+        page2 = MagicMock()
+        page2.status_code = 200
+        page2.json.return_value = {
+            "values": [
+                {
+                    "author": {"emailAddress": "attacker@evil.com"},
+                    "items": [{"field": "description"}],
+                }
+            ],
+            "total": 2,
+        }
+        mock_requests.get.side_effect = [page1, page2]
+
+        result = client.get_description_editors("TEST-1")
+        assert result == ["dev@redhat.com", "attacker@evil.com"]
+        assert mock_requests.get.call_count == 2
+
     @pytest.mark.parametrize("bad_value", ["nan", "NaN", "inf", "-inf", "Infinity"])
     @patch("time.sleep")
     @patch("agentic_ci.jira.client.random.uniform", return_value=0.0)


### PR DESCRIPTION
## Summary

Adds `get_description_editors(key)` public method to `JiraClient` for walking the Jira changelog to find all users who edited an issue's description field.

## Changes

- New method `JiraClient.get_description_editors(key)` that paginates through the changelog, filters for description field changes, and returns a deduplicated list of editor email addresses
- Follows the same pagination pattern as the existing `get_label_author()` method
- Fails closed on missing emails: produces a `missing-email:<accountId>` sentinel so downstream checks treat unknown editors as untrusted

## Context

Used by the autofix description editor verification gate ([RHOAIENG-62667](https://redhat.atlassian.net/browse/RHOAIENG-62667)) to detect prompt injection via untrusted description edits.

Companion MR: https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability to retrieve the unique list of users who edited an issue's description, including a fallback sentinel for editors without email addresses.

* **Tests**
  * Added tests covering empty results, extraction of editor emails (internal and external), sentinel behavior for missing/null emails, ignoring non-description changes, deduplication, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->