### PR TITLE
fix: check committer email instead of author in commit gate

### DIFF
--- a/src/agentic_ci/gates.py
+++ b/src/agentic_ci/gates.py
@@ -119,10 +119,13 @@ def check_sensitive_files(
     return blocked
 
 
-def check_commit_author(commit_info: dict, expected_email: str) -> bool:
-    """Verify the commit author matches the expected bot email."""
+def check_commit_identity(commit_info: dict, expected_email: str) -> bool:
+    """Verify the commit committer matches the expected bot email."""
     actual = commit_info.get("email", "")
     return actual.lower() == expected_email.lower()
+
+
+check_commit_author = check_commit_identity
 
 
 def log_changed_files(changed_files: list[str], ticket_key: str) -> None:
@@ -291,8 +294,8 @@ def _run_commit_author(workdir: str, **_kw: object) -> list[str]:
     except subprocess.CalledProcessError as exc:
         return [f"Could not read commit info: {exc}"]
 
-    if not check_commit_author(info, expected):
-        return [f"Commit author '{info.get('email')}' does not match expected '{expected}'"]
+    if not check_commit_identity(info, expected):
+        return [f"Commit committer '{info.get('email')}' does not match expected '{expected}'"]
     return []
 
 

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -299,8 +299,12 @@ def harden_git_config(repo_dir: Path) -> None:
 
 
 def get_commit_info(repo_dir: Path) -> dict:
-    """Get the latest commit info (author, email, message, sha)."""
-    fmt = "%H%n%ae%n%an%n%s"
+    """Get the latest commit info (committer, email, message, sha).
+
+    Uses committer identity (not author) so that rebased or
+    cherry-picked commits always reflect the current git config.
+    """
+    fmt = "%H%n%ce%n%cn%n%s"
     result = subprocess.run(
         ["git", "log", "-1", f"--format={fmt}"],
         cwd=str(repo_dir),

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -3,7 +3,7 @@
 import re
 
 from agentic_ci.gates import (
-    check_commit_author,
+    check_commit_identity,
     check_external_reporter,
     check_label_author_email,
     check_sensitive_files,
@@ -38,13 +38,13 @@ class TestCheckSensitiveFiles:
 
 class TestCheckCommitAuthor:
     def test_match(self):
-        assert check_commit_author({"email": "bot@ci.com"}, "bot@ci.com") is True
+        assert check_commit_identity({"email": "bot@ci.com"}, "bot@ci.com") is True
 
     def test_case_insensitive(self):
-        assert check_commit_author({"email": "Bot@CI.com"}, "bot@ci.com") is True
+        assert check_commit_identity({"email": "Bot@CI.com"}, "bot@ci.com") is True
 
     def test_mismatch(self):
-        assert check_commit_author({"email": "human@ci.com"}, "bot@ci.com") is False
+        assert check_commit_identity({"email": "human@ci.com"}, "bot@ci.com") is False
 
 
 class TestFilterCommentsByDomain:


### PR DESCRIPTION
## Summary
- Changed `get_commit_info` to use committer email (`%ce`) instead of author email (`%ae`)
- After `git rebase`, the author email is preserved from the original commit while the committer reflects the current git config
- This caused the commit-author gate to fail when iterating on branches with commits from the old bot email (`jira-autofix-bot@redhat.com`)
- Updated error messages to say "committer" instead of "author"

## Test plan
- [x] All 36 agentic-ci tests pass (`tox -e py3`)
- [x] Lint passes (`tox -e lint`)
- [ ] Verify fix on a ticket with rebased commits from old bot email

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Commit validation now uses committer information instead of author information for identity verification.
  * Updated error messages to reference "commit committer" in validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->