### PR TITLE
fix: resolve email to account ID in JiraClient.assign() REST fallback

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -185,6 +185,33 @@ class JiraClient:
             self._field_schema_cache[name] = f.get("schema", {}).get("type", "")
             self._field_schema_cache[fid] = f.get("schema", {}).get("type", "")
 
+    def _resolve_account_id(self, assignee: str) -> str:
+        """Resolve an email address to a Jira account ID.
+
+        If the input is already an account ID (no '@'), returns it as-is.
+        """
+        assignee = assignee.strip()
+        if not assignee:
+            raise JiraError("Assignee cannot be empty")
+
+        if "@" not in assignee:
+            return assignee
+
+        resp = self._request(
+            "get",
+            self._api_url("user/search"),
+            headers=self._headers(),
+            params={"query": assignee},
+        )
+        self._check(resp)
+        users = resp.json()
+        if not users:
+            raise JiraError(f"No Jira user found for '{assignee}'")
+        account_id = users[0].get("accountId")
+        if not account_id:
+            raise JiraError(f"Jira user search returned invalid response for '{assignee}'")
+        return account_id
+
     def _resolve_field_id(self, field_name: str) -> str:
         """Resolve a human-readable field name to its ``customfield_XXXXX`` ID."""
         self._load_field_metadata()
@@ -646,11 +673,12 @@ class JiraClient:
             except acli_mod.AcliError as exc:
                 log.warning("acli assign failed, falling back to REST: %s", exc)
 
+        account_id = self._resolve_account_id(assignee)
         resp = self._request(
             "put",
             self._api_url(f"issue/{key}/assignee"),
             headers=self._headers(),
-            json={"accountId": assignee},
+            json={"accountId": account_id},
         )
         self._check(resp, expected=(200, 204))
         log.info("Assigned %s to %s", key, assignee)

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -534,3 +534,82 @@ class TestGetDescriptionEditors:
         resp = client._request("get", "https://test.atlassian.net/rest/api/3/test")
         assert resp.status_code == 200
         mock_sleep.assert_called_once_with(1.0)
+
+
+class TestResolveAccountId:
+    @patch("agentic_ci.jira.client.requests")
+    def test_resolve_account_id_email(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{"accountId": "abc123", "displayName": "Test User"}]
+        mock_requests.get.return_value = resp
+
+        result = client._resolve_account_id("user@example.com")
+        assert result == "abc123"
+        mock_requests.get.assert_called_once()
+        assert mock_requests.get.call_args.kwargs["params"] == {"query": "user@example.com"}
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_resolve_account_id_passthrough(self, mock_requests, client):
+        result = client._resolve_account_id("abc123")
+        assert result == "abc123"
+        mock_requests.get.assert_not_called()
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_resolve_account_id_not_found(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = []
+        mock_requests.get.return_value = resp
+
+        with pytest.raises(JiraError, match="No Jira user found"):
+            client._resolve_account_id("nobody@example.com")
+
+    def test_resolve_account_id_empty_raises(self, client):
+        with pytest.raises(JiraError, match="cannot be empty"):
+            client._resolve_account_id("")
+
+    def test_resolve_account_id_whitespace_raises(self, client):
+        with pytest.raises(JiraError, match="cannot be empty"):
+            client._resolve_account_id("   ")
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_resolve_account_id_missing_key_raises(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = [{"displayName": "Test User"}]
+        mock_requests.get.return_value = resp
+
+        with pytest.raises(JiraError, match="invalid response"):
+            client._resolve_account_id("user@example.com")
+
+
+class TestAssignRest:
+    @patch("agentic_ci.jira.client.requests")
+    def test_assign_rest_resolves_email(self, mock_requests, client):
+        search_resp = MagicMock()
+        search_resp.status_code = 200
+        search_resp.json.return_value = [{"accountId": "acct-456"}]
+
+        assign_resp = MagicMock()
+        assign_resp.status_code = 204
+
+        mock_requests.get.return_value = search_resp
+        mock_requests.put.return_value = assign_resp
+
+        client.assign("TEST-1", "dev@example.com")
+
+        mock_requests.put.assert_called_once()
+        assert mock_requests.put.call_args.kwargs["json"] == {"accountId": "acct-456"}
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_assign_rest_account_id_passthrough(self, mock_requests, client):
+        assign_resp = MagicMock()
+        assign_resp.status_code = 204
+        mock_requests.put.return_value = assign_resp
+
+        client.assign("TEST-1", "acct-456")
+
+        mock_requests.get.assert_not_called()
+        mock_requests.put.assert_called_once()
+        assert mock_requests.put.call_args.kwargs["json"] == {"accountId": "acct-456"}


### PR DESCRIPTION
## Summary
- `assign()` REST fallback was sending the email address directly as `accountId`, causing HTTP 404 on Jira Cloud
- Add `_resolve_account_id()` helper that looks up the account ID via `/user/search` when given an email
- Non-email strings (already account IDs) pass through unchanged

## Context
Discovered in [AIPCC-17345](https://redhat.atlassian.net/browse/AIPCC-17345) — when `acli` is unavailable (e.g. in CI containers), callers pass an email address but Jira Cloud requires an account ID.

Pipeline: https://gitlab.com/redhat/rhel-ai/core/package-onboarding/-/pipelines/2561225937

## Test plan
- [x] All 326 tests pass (`tox -e py313`)
- [x] Lint passes (`tox -e lint`)
- [x] Format check passes (`tox -e check-format`)
- [x] Type check passes (`tox -e typecheck`)
- [ ] Verify fix on a ticket where assign previously returned 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jira assignment now properly handles email addresses by automatically resolving them to the correct account IDs.
  * Improved error handling when no matching Jira user is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->