### PR TITLE
RHAIFIRST-46: Add update_description to Forge interface

### DIFF
--- a/src/agentic_ci/forge/__init__.py
+++ b/src/agentic_ci/forge/__init__.py
@@ -109,6 +109,22 @@ class Forge(ABC):
         """Resolve a review comment thread."""
 
     @abstractmethod
+    def update_description(
+        self,
+        mr_url: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        """Update an existing MR/PR title and/or description.
+
+        Only the provided keyword arguments are updated; omitted fields
+        are left unchanged.
+
+        Raises ``ForgeError`` on API failure.
+        """
+
+    @abstractmethod
     def pipeline_failures(self, mr_url: str) -> dict:
         """Get failed CI job names and log tails.
 

--- a/src/agentic_ci/forge/cli.py
+++ b/src/agentic_ci/forge/cli.py
@@ -70,6 +70,13 @@ def cmd_pipeline_failures(args: argparse.Namespace) -> None:
     print()
 
 
+def cmd_mr_update(args: argparse.Namespace) -> None:
+    """Update MR/PR title and/or description."""
+    forge = Forge.detect(args.url, github_token=args.token)
+    forge.update_description(args.url, title=args.title, description=args.description)
+    print(f"Updated {args.url}")
+
+
 def cmd_mr_diff_position(args: argparse.Namespace) -> None:
     """Get the first changed line position and diff refs (GitLab only)."""
     from agentic_ci.forge.gitlab import GitLabForge
@@ -147,6 +154,12 @@ def register_subcommands(forge_parser: argparse.ArgumentParser) -> None:
     )
     p_pipeline.add_argument("url", help="MR/PR URL")
     p_pipeline.set_defaults(func=cmd_pipeline_failures)
+
+    p_update = subparsers.add_parser("mr-update", help="Update MR/PR title and/or description")
+    p_update.add_argument("url", help="MR/PR URL")
+    p_update.add_argument("--title", help="New title")
+    p_update.add_argument("--description", help="New description")
+    p_update.set_defaults(func=cmd_mr_update)
 
     p_diffpos = subparsers.add_parser(
         "mr-diff-position",

--- a/src/agentic_ci/forge/github.py
+++ b/src/agentic_ci/forge/github.py
@@ -79,6 +79,29 @@ class GitHubForge(Forge):
             "pipeline_status": pipeline_status,
         }
 
+    def update_description(
+        self,
+        mr_url: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        repo_path, pr_number = parse_github_pr_url(mr_url)
+        payload: dict[str, str] = {}
+        if title is not None:
+            payload["title"] = title
+        if description is not None:
+            payload["body"] = description
+        if not payload:
+            return
+        resp = self._session.patch(
+            f"https://api.github.com/repos/{repo_path}/pulls/{pr_number}",
+            json=payload,
+        )
+        if resp.status_code != 200:
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} updating PR: {error}")
+
     def review_comments(self, mr_url: str) -> list[dict]:
         repo_path, pr_number = parse_github_pr_url(mr_url)
         owner, repo = repo_path.split("/", 1)

--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -95,6 +95,30 @@ class GitLabForge(Forge):
             "pipeline_status": pipeline_status,
         }
 
+    def update_description(
+        self,
+        mr_url: str,
+        *,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        payload: dict[str, str] = {}
+        if title is not None:
+            payload["title"] = title
+        if description is not None:
+            payload["description"] = description
+        if not payload:
+            return
+        project_path, mr_iid = parse_gitlab_mr_url(mr_url)
+        pid = self.project_id(project_path)
+        resp = self._session.put(
+            f"https://gitlab.com/api/v4/projects/{pid}/merge_requests/{mr_iid}",
+            json=payload,
+        )
+        if resp.status_code != 200:
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} updating MR: {error}")
+
     def review_comments(self, mr_url: str) -> list[dict]:
         project_path, mr_iid = parse_gitlab_mr_url(mr_url)
         pid = self.project_id(project_path)

--- a/tests/test_forge_cli.py
+++ b/tests/test_forge_cli.py
@@ -178,6 +178,44 @@ class TestGithubTokenCommand:
         assert output == "inst-tok"
 
 
+class TestMrUpdateCommand:
+    def test_dispatches_with_description(self, capsys):
+        mock_forge = MagicMock()
+        with patch("agentic_ci.forge.cli.Forge.detect", return_value=mock_forge):
+            _run_forge_cli(
+                [
+                    "mr-update",
+                    "https://gitlab.com/o/r/-/merge_requests/1",
+                    "--description",
+                    "New desc",
+                ]
+            )
+
+        mock_forge.update_description.assert_called_once_with(
+            "https://gitlab.com/o/r/-/merge_requests/1",
+            title=None,
+            description="New desc",
+        )
+
+    def test_dispatches_with_title(self, capsys):
+        mock_forge = MagicMock()
+        with patch("agentic_ci.forge.cli.Forge.detect", return_value=mock_forge):
+            _run_forge_cli(
+                [
+                    "mr-update",
+                    "https://gitlab.com/o/r/-/merge_requests/1",
+                    "--title",
+                    "New title",
+                ]
+            )
+
+        mock_forge.update_description.assert_called_once_with(
+            "https://gitlab.com/o/r/-/merge_requests/1",
+            title="New title",
+            description=None,
+        )
+
+
 class TestMrDiffPositionCommand:
     def test_non_gitlab_exits(self, capsys):
         mock_forge = MagicMock(spec=[])

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -59,6 +59,39 @@ class TestCreateMergeRequest:
         assert error == "Validation Failed"
 
 
+class TestUpdateMergeRequest:
+    def test_updates_body(self, forge, mock_session):
+        mock_session.patch.return_value = _make_response(200)
+        forge.update_description(
+            "https://github.com/owner/repo/pull/42",
+            description="Updated desc",
+        )
+        mock_session.patch.assert_called_once()
+        call_kwargs = mock_session.patch.call_args
+        assert call_kwargs[1]["json"] == {"body": "Updated desc"}
+
+    def test_updates_title(self, forge, mock_session):
+        mock_session.patch.return_value = _make_response(200)
+        forge.update_description(
+            "https://github.com/owner/repo/pull/42",
+            title="New title",
+        )
+        call_kwargs = mock_session.patch.call_args
+        assert call_kwargs[1]["json"] == {"title": "New title"}
+
+    def test_noop_when_nothing_provided(self, forge, mock_session):
+        forge.update_description("https://github.com/owner/repo/pull/42")
+        mock_session.patch.assert_not_called()
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.patch.return_value = _make_response(403, {"message": "Forbidden"}, "Forbidden")
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.update_description(
+                "https://github.com/owner/repo/pull/42",
+                description="x",
+            )
+
+
 class TestMrStatus:
     def test_open_pr(self, forge, mock_session):
         pr_resp = _make_response(

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -71,6 +71,53 @@ class TestCreateMergeRequest:
         assert error == "Branch already exists"
 
 
+class TestUpdateMergeRequest:
+    def test_updates_description(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(200)
+        forge.update_description(
+            "https://gitlab.com/org/repo/-/merge_requests/10",
+            description="Updated desc",
+        )
+        mock_session.put.assert_called_once()
+        call_kwargs = mock_session.put.call_args
+        assert call_kwargs[1]["json"] == {"description": "Updated desc"}
+
+    def test_updates_title(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(200)
+        forge.update_description(
+            "https://gitlab.com/org/repo/-/merge_requests/10",
+            title="New title",
+        )
+        call_kwargs = mock_session.put.call_args
+        assert call_kwargs[1]["json"] == {"title": "New title"}
+
+    def test_updates_both(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(200)
+        forge.update_description(
+            "https://gitlab.com/org/repo/-/merge_requests/10",
+            title="New title",
+            description="New desc",
+        )
+        call_kwargs = mock_session.put.call_args
+        assert call_kwargs[1]["json"] == {"title": "New title", "description": "New desc"}
+
+    def test_noop_when_nothing_provided(self, forge, mock_session):
+        forge.update_description("https://gitlab.com/org/repo/-/merge_requests/10")
+        mock_session.put.assert_not_called()
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(403, {"message": "Forbidden"}, "Forbidden")
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.update_description(
+                "https://gitlab.com/org/repo/-/merge_requests/10",
+                description="x",
+            )
+
+
 class TestMrStatus:
     def test_normalizes_opened_to_open(self, forge, mock_session):
         mr_resp = _make_response(200, {"state": "opened", "source_branch": "fix/bug"})


### PR DESCRIPTION
## Summary

- Add `update_merge_request` abstract method to the `Forge` base class with `title` and `description` keyword-only args
- Implement in `GitLabForge` (PUT to MR endpoint) and `GitHubForge` (PATCH to PR endpoint)
- Add `mr-update` CLI subcommand to `agentic-ci forge`

## Why

Companion to [autofix MR !455](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/455) which refreshes MR/PR descriptions during iteration. The `Forge` interface had `create_merge_request` but no way to update an existing one, so autofix had to catch `AttributeError` as a fallback.

## Files changed

- `src/agentic_ci/forge/__init__.py` — New `update_merge_request` abstract method on `Forge`
- `src/agentic_ci/forge/gitlab.py` — GitLab implementation (PUT)
- `src/agentic_ci/forge/github.py` — GitHub implementation (PATCH)
- `src/agentic_ci/forge/cli.py` — `mr-update` subcommand + `cmd_mr_update` handler
- `tests/test_forge_gitlab.py` — 5 new tests (update desc, title, both, noop, error)
- `tests/test_forge_github.py` — 4 new tests (update body, title, noop, error)
- `tests/test_forge_cli.py` — 2 new tests (CLI dispatch with description, title)

## Test plan

- [x] All 77 forge tests pass
- [ ] E2E: verify `agentic-ci forge mr-update <URL> --description "..."` updates a real MR

🤖 Generated with [Claude Code](https://claude.com/claude-code)