### PR TITLE
Make OpenCode credential mount target configurable + 0.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.2.12"
+version = "0.2.13"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -264,7 +264,7 @@ class OpenCodeHarness(Harness):
         return []
 
     def credential_mount_target(self):
-        return "/home/agent"
+        return os.environ.get("OPENCODE_CONTAINER_HOME", "/home/agent-ci")
 
     def create_stream_processor(self, pid=0):
         from agentic_ci.stream import OpenCodeStreamProcessor

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -214,7 +214,11 @@ class TestOpenCodeHarness:
         assert not any("GOOGLE_APPLICATION_CREDENTIALS" in line for line in lines)
 
     def test_credential_mount_target(self):
-        assert OpenCodeHarness().credential_mount_target() == "/home/agent"
+        assert OpenCodeHarness().credential_mount_target() == "/home/agent-ci"
+
+    def test_credential_mount_target_env_override(self, monkeypatch):
+        monkeypatch.setenv("OPENCODE_CONTAINER_HOME", "/home/opencode")
+        assert OpenCodeHarness().credential_mount_target() == "/home/opencode"
 
     def test_create_stream_processor(self):
         from agentic_ci.stream import OpenCodeStreamProcessor

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -191,7 +191,7 @@ def test_build_vol_args_opencode_mount_target(monkeypatch, tmp_path, opencode_ha
     backend._resolve_credentials()
     vol_args = backend._build_vol_args()
     mount_str = " ".join(vol_args)
-    assert "/home/agent/.config/gcloud/" in mount_str
+    assert "/home/agent-ci/.config/gcloud/" in mount_str
 
 
 def test_build_vol_args_api_key_no_gcloud_mounts(monkeypatch, tmp_path, claude_harness):


### PR DESCRIPTION
## Summary

- Fix `OpenCodeHarness.credential_mount_target()` which was hardcoded to `/home/agent` but the actual container image uses `/home/agent-ci`
- Make it configurable via `OPENCODE_CONTAINER_HOME` env var, matching the pattern from #36 for `ClaudeCodeHarness`
- Bump version to 0.2.13

## Test plan

- [x] All 342 tests pass
- [x] Lint, format, and type checks pass
- [x] New env override test added for OpenCode harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.2.13
  * Updated container credential mount configuration path

<!-- end of auto-generated comment: release notes by coderabbit.ai -->