### PR TITLE
Add set_security_level() to JiraClient

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -837,6 +837,56 @@ class JiraClient:
         assert self._field_schema_cache is not None
         return self._field_schema_cache.get(field_name, "")
 
+    def set_security_level(self, key: str, level_name: str) -> None:
+        """Set the security level on an issue by level name.
+
+        Fetches available security levels for the issue, matches
+        *level_name* (case-insensitive), and sets it via the REST API.
+
+        Raises ``JiraError`` if the level name is not found.
+        """
+        resp = self._request(
+            "get",
+            self._api_url(f"issue/{key}"),
+            headers=self._headers(),
+            params={"fields": "project"},
+        )
+        self._check(resp)
+        project_id = resp.json().get("fields", {}).get("project", {}).get("id")
+        if not project_id:
+            raise JiraError(f"Could not determine project ID for issue {key}")
+
+        resp = self._request(
+            "get",
+            self._api_url(f"project/{project_id}/securitylevel"),
+            headers=self._headers(),
+        )
+        self._check(resp)
+
+        level_id = None
+        available = []
+        for level in resp.json().get("levels", []):
+            name = level.get("name", "")
+            available.append(name)
+            if name.lower() == level_name.lower():
+                level_id = level.get("id")
+                break
+
+        if level_id is None:
+            raise JiraError(
+                f"Security level '{level_name}' not found for {key}. "
+                f"Available: {', '.join(available)}"
+            )
+
+        resp = self._request(
+            "put",
+            self._api_url(f"issue/{key}"),
+            headers=self._headers(),
+            json={"fields": {"security": {"id": level_id}}},
+        )
+        self._check(resp, expected=(200, 204))
+        log.info("Set security level '%s' on %s", level_name, key)
+
     def set_custom_field(self, key: str, field_name: str, value: str) -> None:
         """Set a custom field by name.
 

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -536,6 +536,72 @@ class TestGetDescriptionEditors:
         mock_sleep.assert_called_once_with(1.0)
 
 
+class TestSetSecurityLevel:
+    @patch("agentic_ci.jira.client.requests")
+    def test_set_security_level_success(self, mock_requests, client):
+        issue_resp = MagicMock()
+        issue_resp.status_code = 200
+        issue_resp.json.return_value = {"fields": {"project": {"id": "10001"}}}
+
+        levels_resp = MagicMock()
+        levels_resp.status_code = 200
+        levels_resp.json.return_value = {
+            "levels": [
+                {"id": "100", "name": "Internal"},
+                {"id": "200", "name": "Confidential"},
+            ]
+        }
+
+        put_resp = MagicMock()
+        put_resp.status_code = 204
+
+        mock_requests.get.side_effect = [issue_resp, levels_resp]
+        mock_requests.put.return_value = put_resp
+
+        client.set_security_level("TEST-1", "Confidential")
+
+        mock_requests.put.assert_called_once()
+        call_json = mock_requests.put.call_args.kwargs["json"]
+        assert call_json == {"fields": {"security": {"id": "200"}}}
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_set_security_level_case_insensitive(self, mock_requests, client):
+        issue_resp = MagicMock()
+        issue_resp.status_code = 200
+        issue_resp.json.return_value = {"fields": {"project": {"id": "10001"}}}
+
+        levels_resp = MagicMock()
+        levels_resp.status_code = 200
+        levels_resp.json.return_value = {"levels": [{"id": "100", "name": "Internal"}]}
+
+        put_resp = MagicMock()
+        put_resp.status_code = 204
+
+        mock_requests.get.side_effect = [issue_resp, levels_resp]
+        mock_requests.put.return_value = put_resp
+
+        client.set_security_level("TEST-1", "internal")
+
+        mock_requests.put.assert_called_once()
+        call_json = mock_requests.put.call_args.kwargs["json"]
+        assert call_json == {"fields": {"security": {"id": "100"}}}
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_set_security_level_not_found(self, mock_requests, client):
+        issue_resp = MagicMock()
+        issue_resp.status_code = 200
+        issue_resp.json.return_value = {"fields": {"project": {"id": "10001"}}}
+
+        levels_resp = MagicMock()
+        levels_resp.status_code = 200
+        levels_resp.json.return_value = {"levels": [{"id": "100", "name": "Internal"}]}
+
+        mock_requests.get.side_effect = [issue_resp, levels_resp]
+
+        with pytest.raises(JiraError, match="Security level 'TopSecret' not found"):
+            client.set_security_level("TEST-1", "TopSecret")
+
+
 class TestResolveAccountId:
     @patch("agentic_ci.jira.client.requests")
     def test_resolve_account_id_email(self, mock_requests, client):


### PR DESCRIPTION
## Summary
- Add `set_security_level(key, level_name)` method to `JiraClient`
- Uses the proper project security level API (`/project/{id}/securitylevel`) instead of `set_custom_field("Security Level", ...)` which returns HTTP 400 on some Jira projects
- Case-insensitive level name matching with clear error message listing available levels

## Motivation
`set_custom_field()` doesn't work reliably for security levels because it's a special field type in Jira. Consumers (e.g. package-onboarding) currently use `set_custom_field(ticket, "Security Level", level)` as a workaround, which fails on some projects.

## Test plan
- [x] Test successful security level set
- [x] Test case-insensitive name matching
- [x] Test error when level name not found
- [x] All 348 existing tests pass
- [x] Lint, format, typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)