### PR TITLE
Add from_env_optional() to JiraClient

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -124,6 +124,14 @@ class JiraClient:
         timeout = int(os.environ.get("JIRA_API_TIMEOUT", "30"))
         return cls(jira_url, email, token, timeout=timeout)
 
+    @classmethod
+    def from_env_optional(cls, url: str | None = None) -> JiraClient | None:
+        """Create a client from env vars, or return ``None`` if credentials are missing."""
+        try:
+            return cls.from_env(url)
+        except RuntimeError:
+            return None
+
     def _api_url(self, path: str) -> str:
         return f"{self.url}/rest/api/{API_VERSION}/{path}"
 

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -47,6 +47,43 @@ class TestFromEnv:
             assert c.url == "https://right.atlassian.net"
 
 
+class TestFromEnvOptional:
+    def test_returns_none_when_url_missing(self):
+        with patch.dict(os.environ, {}, clear=True):
+            assert JiraClient.from_env_optional() is None
+
+    def test_returns_none_when_email_missing(self):
+        with patch.dict(os.environ, {"JIRA_URL": "https://x.atlassian.net"}, clear=True):
+            assert JiraClient.from_env_optional() is None
+
+    def test_returns_none_when_token_missing(self):
+        env = {"JIRA_URL": "https://x.atlassian.net", "JIRA_EMAIL": "a@b.com"}
+        with patch.dict(os.environ, env, clear=True):
+            assert JiraClient.from_env_optional() is None
+
+    def test_returns_client_when_all_set(self):
+        env = {
+            "JIRA_URL": "https://x.atlassian.net",
+            "JIRA_EMAIL": "a@b.com",
+            "JIRA_API_TOKEN": "tok",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            c = JiraClient.from_env_optional()
+            assert c is not None
+            assert c.url == "https://x.atlassian.net"
+
+    def test_url_param_override(self):
+        env = {
+            "JIRA_URL": "https://wrong.atlassian.net",
+            "JIRA_EMAIL": "a@b.com",
+            "JIRA_API_TOKEN": "tok",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            c = JiraClient.from_env_optional(url="https://right.atlassian.net")
+            assert c is not None
+            assert c.url == "https://right.atlassian.net"
+
+
 class TestGetIssue:
     @patch("agentic_ci.jira.client.requests")
     def test_get_issue_basic(self, mock_requests, client):


### PR DESCRIPTION
## Summary
- Add `from_env_optional()` classmethod to `JiraClient` — returns `None` instead of raising `RuntimeError` when required env vars are missing
- Enables graceful degradation without try/except boilerplate

## Motivation
`JiraClient.from_env()` raises `RuntimeError` when required env vars are missing. Consumers that want optional Jira integration (e.g. print a warning and continue without Jira) must wrap the call in try/except. This is common boilerplate that should live in the library.

Usage:
```python
jira = JiraClient.from_env_optional()
if jira:
    jira.add_comment(ticket, "Done")
```

## Test plan
- [x] Test returns None when JIRA_URL missing
- [x] Test returns None when JIRA_EMAIL missing
- [x] Test returns None when JIRA_API_TOKEN missing
- [x] Test returns JiraClient when all vars set
- [x] Test url param override
- [x] All 347 existing tests pass
- [x] Lint, format, typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)