### PR TITLE
Authenticate acli when JiraClient detects it on PATH

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -98,7 +98,11 @@ class JiraClient:
         self._field_schema_cache: dict[str, str] | None = None
         self._acli_available = acli_mod.is_available()
         if self._acli_available:
-            log.debug("acli detected on PATH, will delegate supported operations")
+            try:
+                acli_mod.setup_auth()
+            except acli_mod.AcliError as exc:
+                log.debug("acli on PATH but auth failed, using REST only: %s", exc)
+                self._acli_available = False
 
     @classmethod
     def from_env(cls, url: str | None = None) -> JiraClient:

--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -100,6 +100,7 @@ class JiraClient:
         if self._acli_available:
             try:
                 acli_mod.setup_auth()
+                log.debug("acli authenticated, will use acli for supported operations")
             except acli_mod.AcliError as exc:
                 log.debug("acli on PATH but auth failed, using REST only: %s", exc)
                 self._acli_available = False

--- a/tests/test_acli_client.py
+++ b/tests/test_acli_client.py
@@ -11,7 +11,10 @@ from agentic_ci.jira.client import JiraClient
 @pytest.fixture()
 def acli_client():
     """JiraClient with acli detected as available."""
-    with patch("agentic_ci.jira.client.acli_mod.is_available", return_value=True):
+    with (
+        patch("agentic_ci.jira.client.acli_mod.is_available", return_value=True),
+        patch("agentic_ci.jira.client.acli_mod.setup_auth"),
+    ):
         return JiraClient("https://test.atlassian.net", "user@test.com", "tok123")
 
 


### PR DESCRIPTION
## Summary

- Call `setup_auth()` in `JiraClient.__init__` when acli is detected on PATH
- If auth fails (no `JIRA_EMAIL`/`JIRA_API_TOKEN`, or acli rejects), set `_acli_available = False` so all operations use REST API

## Problem

When acli is installed but not authenticated, `JiraClient` delegates operations to it. acli silently "succeeds" (exit code 0) for some operations like `edit --labels` without actually applying changes. This caused:

1. `edit_labels("jira-autofix")` — acli returns success, method returns early, label never set
2. `get_label_author("jira-autofix")` — changelog has no entry, returns `found=False`
3. Label-author gate blocks the ticket

This was not an issue before because acli was not installed in the CI image. With the switch to `quay.io/aipcc/agentic-ci/podman:latest` (which includes acli), the bug surfaced.

## Fix

Authenticate acli during `JiraClient.__init__` using the same credentials already available for REST calls. If authentication fails, disable acli entirely and fall back to REST-only mode. `setup_auth()` was already implemented but never called.

## Test plan

- [ ] E2e tests pass with acli installed in the image (autofix MR !506)
- [ ] Verify acli is authenticated when `JIRA_EMAIL`/`JIRA_API_TOKEN` are set
- [ ] Verify graceful fallback to REST when acli auth fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved resilience for optional authentication mechanisms. When authentication setup fails, the system now gracefully logs the issue and falls back to standard functionality instead of stopping, ensuring continuous service availability even if advanced authentication cannot be initialized.

**Tests**
* Enhanced test fixtures to properly simulate authentication scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->