### PR TITLE
Bump debug logging to info

### DIFF
--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -380,7 +380,7 @@ def setup_git_credentials(
             return False
         return _setup_github_credentials(repo_url, github_token_resolver)
 
-    log.debug("No credential setup needed for URL: %s", repo_url)
+    log.info("No credential setup needed for URL: %s", repo_url)
     return True
 
 
@@ -431,7 +431,7 @@ def _set_insteadof(authenticated_prefix: str, original_prefix: str) -> bool:
             capture_output=True,
             text=True,
         )
-        log.debug("Configured git insteadOf for %s", original_prefix)
+        log.info("Configured git insteadOf for %s", original_prefix)
         return True
     except subprocess.CalledProcessError as exc:
         log.error("git config --global failed: %s", exc.stderr)

--- a/src/agentic_ci/jira/acli.py
+++ b/src/agentic_ci/jira/acli.py
@@ -145,7 +145,7 @@ def run_acli(
     if json_output:
         cmd.append("--json")
 
-    log.debug("Running: %s", " ".join(_redact_cmd(cmd)))
+    log.info("Running: %s", " ".join(_redact_cmd(cmd)))
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT)
     except subprocess.TimeoutExpired as exc:

--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -100,9 +100,9 @@ class JiraClient:
         if self._acli_available:
             try:
                 acli_mod.setup_auth()
-                log.debug("acli authenticated, will use acli for supported operations")
+                log.info("acli authenticated, will use acli for supported operations")
             except acli_mod.AcliError as exc:
-                log.debug("acli on PATH but auth failed, using REST only: %s", exc)
+                log.info("acli on PATH but auth failed, using REST only: %s", exc)
                 self._acli_available = False
 
     @classmethod
@@ -593,7 +593,7 @@ class JiraClient:
                     "--labels",
                     ",".join(add),
                 )
-                log.debug("Labels updated on %s (via acli)", key)
+                log.info("Labels updated on %s (via acli)", key)
                 return
             except acli_mod.AcliError as exc:
                 log.warning("acli edit_labels failed, falling back to REST: %s", exc)
@@ -611,7 +611,7 @@ class JiraClient:
             json={"update": update},
         )
         self._check(resp, expected=(200, 204))
-        log.debug("Labels updated on %s", key)
+        log.info("Labels updated on %s", key)
 
     def transition(self, key: str, status: str) -> None:
         """Transition an issue to a new status by name."""


### PR DESCRIPTION
## Summary
- Bumps all `log.debug()` calls to `log.info()` across `git.py`, `jira/acli.py`, and `jira/client.py`
- These log statements provide useful operational visibility (acli commands, credential setup, label updates) and should be visible at the default INFO level

## Test plan
- [x] All 345 tests pass
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy type check clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased visibility of operational logs by elevating several messages from DEBUG to INFO.
  - Git credential setup now reports no-op and successful configuration at INFO.
  - Jira: redacted “Running” command for ACLI now logs at INFO.
  - Jira: auth setup outcomes (when ACLI is available) and successful label updates (via ACLI or REST) now log at INFO.
  - No functional behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->