### PR TITLE
Support GCP_SERVICE_ACCOUNT_KEY as a file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Claude API access via gcloud Application Default Credentials.
 The **podman** backend checks credentials in this order:
 
 1. `GCLOUD_CREDENTIALS` env var (raw JSON or base64-encoded)
-2. `GCP_SERVICE_ACCOUNT_KEY` env var (base64-encoded)
+2. `GCP_SERVICE_ACCOUNT_KEY` env var (file path, raw JSON, or base64-encoded)
 3. `~/.config/gcloud/application_default_credentials.json`
 4. Path in `GOOGLE_APPLICATION_CREDENTIALS` env var
 
@@ -213,7 +213,7 @@ The **openshell** backend uploads the local ADC file
 | `CLOUD_ML_REGION` | `global` | Vertex AI region |
 | `VERTEX_LOCATION` | — | Vertex AI region (OpenCode uses this before falling back to `CLOUD_ML_REGION`) |
 | `GCLOUD_CREDENTIALS` | — | Raw JSON or base64 gcloud credentials |
-| `GCP_SERVICE_ACCOUNT_KEY` | — | Base64-encoded service account key |
+| `GCP_SERVICE_ACCOUNT_KEY` | — | Service account key: file path, raw JSON, or base64-encoded JSON |
 | `GOOGLE_APPLICATION_CREDENTIALS` | — | Path to ADC credentials file |
 | `OPENSHELL_SUPERVISOR_IMAGE` | `openshell/supervisor:dev` | OpenShell supervisor image (`openshell` backend only) |
 

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -220,10 +220,24 @@ class PodmanBackend(Backend):
 
         sa_key = os.environ.get("GCP_SERVICE_ACCOUNT_KEY", "")
         if sa_key:
+            if os.path.isfile(sa_key):
+                try:
+                    with open(sa_key) as f:
+                        content = f.read().strip()
+                except OSError as exc:
+                    raise RuntimeError(
+                        f"Failed to read GCP_SERVICE_ACCOUNT_KEY file {sa_key}: {exc}"
+                    ) from exc
+                sa_key = content
+                source_label = "GCP_SERVICE_ACCOUNT_KEY file"
+            else:
+                source_label = "GCP_SERVICE_ACCOUNT_KEY env var"
+            if self._is_valid_json(sa_key):
+                return sa_key, source_label
             decoded = self._try_base64_decode(sa_key)
             if decoded and self._is_valid_json(decoded):
-                return decoded, "GCP_SERVICE_ACCOUNT_KEY env var"
-            raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid base64-encoded JSON")
+                return decoded, source_label
+            raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid JSON or base64-encoded JSON")
 
         adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
         ga_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -53,6 +53,48 @@ def test_find_credentials_from_service_account_key(monkeypatch, tmp_path, claude
     assert source == "GCP_SERVICE_ACCOUNT_KEY env var"
 
 
+def test_find_credentials_from_service_account_key_json_file(monkeypatch, tmp_path, claude_harness):
+    creds = json.dumps({"type": "service_account", "project_id": "sa-file-test"})
+    key_file = tmp_path / "sa-key.json"
+    key_file.write_text(creds)
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    result, source = backend._find_credentials()
+    assert json.loads(result)["project_id"] == "sa-file-test"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
+
+
+def test_find_credentials_from_service_account_key_base64_file(
+    monkeypatch, tmp_path, claude_harness
+):
+    creds = json.dumps({"type": "service_account", "project_id": "sa-b64-file"})
+    encoded = base64.b64encode(creds.encode()).decode()
+    key_file = tmp_path / "sa-key.b64"
+    key_file.write_text(encoded)
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    result, source = backend._find_credentials()
+    assert json.loads(result)["project_id"] == "sa-b64-file"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
+
+
+def test_find_credentials_from_service_account_key_file_invalid(
+    monkeypatch, tmp_path, claude_harness
+):
+    key_file = tmp_path / "bad-key.json"
+    key_file.write_text("not valid json or base64")
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
+    with pytest.raises(RuntimeError, match="not valid JSON or base64"):
+        backend._find_credentials()
+
+
 def test_find_credentials_from_adc_file(monkeypatch, tmp_path, claude_harness):
     creds = json.dumps({"type": "authorized_user", "client_id": "file-test"})
     adc_path = tmp_path / "adc.json"


### PR DESCRIPTION
## Summary

- When `GCP_SERVICE_ACCOUNT_KEY` points to an existing file, read its contents instead of treating the value as an inline credential
- File content goes through the same JSON/base64 validation as before
- Uses a temporary variable for the file read so that error messages can never leak key material
- Makes it easier to use in CI environments where secrets are mounted as files

## Test plan

- [x] New test: JSON file path works (`test_find_credentials_from_service_account_key_json_file`)
- [x] New test: base64 file path works (`test_find_credentials_from_service_account_key_base64_file`)
- [x] New test: invalid file content raises (`test_find_credentials_from_service_account_key_file_invalid`)
- [x] Existing base64 env var test still passes
- [x] All 348 tests pass, lint/format/typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Podman backend accepts GCP service account credentials as a JSON file path, raw JSON, or base64-encoded JSON via the GCP_SERVICE_ACCOUNT_KEY environment variable.

* **Documentation**
  * Updated credential docs to reflect the new precedence and accepted formats for GCP_SERVICE_ACCOUNT_KEY.

* **Tests**
  * Added tests covering credential loading from JSON files, base64 files, and invalid file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->