### PR TITLE
Add save_job_artifacts utility for CI artifact collection

### DIFF
--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -305,3 +305,48 @@ def run_skill(
         verdict.get("verdict", "unknown"),
     )
     return 0
+
+
+def save_job_artifacts(
+    work_dir: Path,
+    repo_dir: Path | None = None,
+    prompt: str = "",
+) -> None:
+    """Collect debugging artifacts into work_dir for CI artifact upload."""
+    try:
+        work_dir.mkdir(parents=True, exist_ok=True)
+        if prompt:
+            (work_dir / "prompt.txt").write_text(prompt, encoding="utf-8")
+        for candidate in [repo_dir, work_dir]:
+            if candidate is None:
+                continue
+            output_file = candidate / "claude-output.txt"
+            if output_file.exists():
+                dest = work_dir / "claude_output.txt"
+                if output_file.resolve() != dest.resolve():
+                    shutil.copy2(str(output_file), str(dest))
+                content = output_file.read_text(encoding="utf-8", errors="replace")
+                lines = content.splitlines()
+                if len(lines) > 500:
+                    (work_dir / "claude_output_tail.txt").write_text(
+                        "\n".join(lines[-500:]), encoding="utf-8"
+                    )
+                break
+        if repo_dir and (repo_dir / ".git").is_dir():
+            _collect_git_artifacts(work_dir, repo_dir)
+    except Exception as exc:
+        log.debug("Artifact collection failed (non-fatal): %s", exc)
+
+
+def _collect_git_artifacts(work_dir: Path, repo_dir: Path) -> None:
+    """Capture git diff and log from repo_dir into work_dir."""
+    from agentic_ci.git import get_default_branch, git_output
+
+    default_branch = get_default_branch(repo_dir)
+    base_ref = f"origin/{default_branch}"
+    diff = git_output(repo_dir, "diff", f"{base_ref}...HEAD")
+    if diff:
+        (work_dir / "diff.patch").write_text(diff, encoding="utf-8")
+    log_text = git_output(repo_dir, "log", "--oneline", f"{base_ref}..HEAD")
+    if log_text:
+        (work_dir / "git-log.txt").write_text(log_text, encoding="utf-8")

--- a/tests/test_skill.py
+++ b/tests/test_skill.py
@@ -1,0 +1,71 @@
+"""Tests for save_job_artifacts in agentic_ci.skill."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from agentic_ci.skill import save_job_artifacts
+
+
+def test_prompt_saved(tmp_path: Path) -> None:
+    """save_job_artifacts writes prompt.txt when prompt is provided."""
+    save_job_artifacts(tmp_path, prompt="hello world")
+    assert (tmp_path / "prompt.txt").read_text() == "hello world"
+
+
+def test_output_copied(tmp_path: Path) -> None:
+    """Claude output is copied from repo_dir to work_dir."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    work = tmp_path / "work"
+    (repo / "claude-output.txt").write_text("some output", encoding="utf-8")
+
+    save_job_artifacts(work, repo_dir=repo)
+
+    assert (work / "claude_output.txt").read_text() == "some output"
+    assert not (work / "claude_output_tail.txt").exists()
+
+
+def test_tail_created_for_long_output(tmp_path: Path) -> None:
+    """A tail file is created when output exceeds 500 lines."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    work = tmp_path / "work"
+    lines = [f"line {i}" for i in range(600)]
+    (repo / "claude-output.txt").write_text("\n".join(lines), encoding="utf-8")
+
+    save_job_artifacts(work, repo_dir=repo)
+
+    assert (work / "claude_output.txt").exists()
+    tail = (work / "claude_output_tail.txt").read_text()
+    tail_lines = tail.splitlines()
+    assert len(tail_lines) == 500
+    assert tail_lines[-1] == "line 599"
+    assert tail_lines[0] == "line 100"
+
+
+def test_graceful_on_exception(tmp_path: Path) -> None:
+    """save_job_artifacts does not raise even on internal errors."""
+    with patch("agentic_ci.skill.Path.mkdir", side_effect=OSError("disk full")):
+        # Should not raise
+        save_job_artifacts(tmp_path / "nonexistent", prompt="test")
+
+
+def test_no_prompt_no_file(tmp_path: Path) -> None:
+    """No prompt.txt is created when prompt is empty."""
+    save_job_artifacts(tmp_path)
+    assert not (tmp_path / "prompt.txt").exists()
+
+
+def test_output_in_work_dir(tmp_path: Path) -> None:
+    """Claude output in work_dir is handled when repo_dir has none."""
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "claude-output.txt").write_text("work output", encoding="utf-8")
+
+    save_job_artifacts(work)
+
+    # Output file already in work_dir, resolve() should match, so no copy
+    # but no error either
+    assert (work / "claude-output.txt").read_text() == "work output"


### PR DESCRIPTION
## Summary
- Add `save_job_artifacts()` and `_collect_git_artifacts()` to `agentic_ci.skill`
- Collects prompt, Claude output (with tail for large outputs), git diff, and git log into a work directory for CI artifact upload
- Consolidates duplicated artifact collection code from downstream consumers (jira-autofix)

## Test plan
- [x] Unit tests in `tests/test_skill.py` covering prompt save, output copy, tail creation, and graceful error handling
- [ ] Verify downstream autofix MR can import and use `save_job_artifacts`
