### PR TITLE
Add iterate module for MR/PR lifecycle helpers

### DIFF
--- a/src/agentic_ci/iterate.py
+++ b/src/agentic_ci/iterate.py
@@ -1,0 +1,230 @@
+"""MR/PR iteration lifecycle helpers.
+
+Provides reusable functions for managing the iterate phase of MR/PR workflows:
+extracting MR URLs from bot comments, counting iterations, checking readiness,
+resolving review threads, and collecting feedback from forges.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import requests
+
+from agentic_ci.forge import ForgeError, detect_forge
+
+log = logging.getLogger(__name__)
+
+DEFAULT_BOT_IDENTIFIER = "agentic-ci bot"
+
+
+def extract_mr_url(
+    comments: list[dict],
+    bot_pattern: re.Pattern[str] | None = None,
+) -> str | None:
+    """Extract MR/PR URL from bot comments.
+
+    Scans comments for those matching the bot header pattern, then extracts
+    the first GitLab MR or GitHub PR URL found.
+
+    Args:
+        comments: List of comment dicts with ``"body"`` keys.
+        bot_pattern: Compiled regex to identify bot comments.
+            Defaults to matching ``jira-autofix bot`` headers.
+
+    Returns:
+        The MR/PR URL string, or ``None`` if not found.
+    """
+    if bot_pattern is None:
+        bot_pattern = re.compile(
+            rf"^(h3\.\s+|#{{1,6}}\s+)?{re.escape(DEFAULT_BOT_IDENTIFIER)}",
+            re.MULTILINE,
+        )
+    for c in comments:
+        body = c.get("body", "")
+        if not bot_pattern.search(body):
+            continue
+        m = re.search(r"https?://gitlab\.com/\S+/-/merge_requests/\d+", body)
+        if m:
+            return m.group(0)
+        m = re.search(r"https?://github\.com/\S+/pull/\d+", body)
+        if m:
+            return m.group(0)
+    return None
+
+
+def count_iterations(
+    comments: list[dict],
+    bot_identifier: str = DEFAULT_BOT_IDENTIFIER,
+) -> int:
+    """Count iteration comments posted by the bot.
+
+    Looks for comments containing the bot identifier and an
+    ``Iteration N/M:`` pattern.
+
+    Args:
+        comments: List of comment dicts with ``"body"`` keys.
+        bot_identifier: String that identifies bot comments.
+
+    Returns:
+        Number of iteration comments found.
+    """
+    pattern = re.compile(r"Iteration \d+/\d+:")
+    return sum(
+        1
+        for c in comments
+        if bot_identifier in c.get("body", "") and pattern.search(c.get("body", ""))
+    )
+
+
+def already_notified_ready(
+    comments: list[dict],
+    bot_pattern: re.Pattern[str] | None = None,
+) -> bool:
+    """Check if last bot comment is a 'ready for merge' notification.
+
+    Args:
+        comments: List of comment dicts with ``"body"`` keys.
+        bot_pattern: Compiled regex to identify bot comments.
+            Defaults to matching ``jira-autofix bot`` headers.
+
+    Returns:
+        ``True`` if the last bot comment indicates the MR/PR is ready.
+    """
+    if bot_pattern is None:
+        bot_pattern = re.compile(
+            rf"^(h3\.\s+|#{{1,6}}\s+)?{re.escape(DEFAULT_BOT_IDENTIFIER)}",
+            re.MULTILINE,
+        )
+    last_bot_body = ""
+    for c in comments:
+        if bot_pattern.search(c.get("body", "")):
+            last_bot_body = c.get("body", "")
+    return (
+        "ready for a maintainer to review and merge" in last_bot_body
+        or "ready for a maintainer to merge" in last_bot_body
+    )
+
+
+def resolve_threads(
+    mr_url: str,
+    review_comments: list[dict],
+    reply_message: str = "Addressed in the latest revision.",
+    github_token: str | None = None,
+) -> int:
+    """Reply to and resolve review threads on an MR/PR.
+
+    For each comment with a ``thread_id``, posts a reply and resolves
+    the thread via the detected forge API.
+
+    Args:
+        mr_url: Full URL of the MR/PR.
+        review_comments: List of review comment dicts with ``"thread_id"`` keys.
+        reply_message: Message to post as a reply before resolving.
+        github_token: Token for GitHub API authentication.
+
+    Returns:
+        Number of threads successfully resolved.
+    """
+    if not review_comments:
+        return 0
+    try:
+        forge = detect_forge(mr_url, github_token=github_token)
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("forge detection error for %s: %s", mr_url, exc)
+        return 0
+
+    resolved = 0
+    for comment in review_comments:
+        thread_id = comment.get("thread_id")
+        if not thread_id:
+            continue
+        try:
+            forge.reply(mr_url, str(thread_id), reply_message)
+            forge.resolve(mr_url, str(thread_id))
+            resolved += 1
+        except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+            log.warning("forge thread resolve error: %s", exc)
+    return resolved
+
+
+def check_mr_state(
+    mr_url: str,
+    github_token: str | None = None,
+) -> dict | None:
+    """Check MR/PR state via the forge API.
+
+    Args:
+        mr_url: Full URL of the MR/PR.
+        github_token: Token for GitHub API authentication.
+
+    Returns:
+        Dict with ``state``, ``source_branch``, ``pipeline_status`` keys,
+        or ``None`` on error.
+    """
+    try:
+        forge = detect_forge(mr_url, github_token=github_token)
+        return forge.mr_status(mr_url)
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("mr_status error for %s: %s", mr_url, exc)
+        return None
+
+
+def collect_feedback(
+    mr_url: str,
+    github_token: str | None = None,
+) -> dict:
+    """Collect review comments, general comments, and CI failures from an MR/PR.
+
+    Makes three independent forge API calls, catching errors individually
+    so partial results are still returned.
+
+    Args:
+        mr_url: Full URL of the MR/PR.
+        github_token: Token for GitHub API authentication.
+
+    Returns:
+        Dict with keys: ``review_comments``, ``general_comments``,
+        ``ci_failures``, ``review_count``, ``general_count``, ``ci_fail_count``.
+    """
+    empty: dict = {
+        "review_comments": [],
+        "general_comments": [],
+        "ci_failures": {},
+        "review_count": 0,
+        "general_count": 0,
+        "ci_fail_count": 0,
+    }
+    try:
+        forge = detect_forge(mr_url, github_token=github_token)
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("forge error for %s: %s", mr_url, exc)
+        return empty
+
+    review_comments: list[dict] = []
+    general_comments: list[dict] = []
+    ci_failures: dict = {}
+
+    try:
+        review_comments = forge.review_comments(mr_url) or []
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("review_comments error for %s: %s", mr_url, exc)
+    try:
+        general_comments = forge.general_comments(mr_url) or []
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("general_comments error for %s: %s", mr_url, exc)
+    try:
+        ci_failures = forge.pipeline_failures(mr_url) or {}
+    except (ForgeError, requests.RequestException, ValueError, OSError) as exc:
+        log.warning("pipeline_failures error for %s: %s", mr_url, exc)
+
+    ci_fail_count = len(ci_failures.get("failed_jobs", [])) if isinstance(ci_failures, dict) else 0
+    return {
+        "review_comments": review_comments,
+        "general_comments": general_comments,
+        "ci_failures": ci_failures,
+        "review_count": len(review_comments),
+        "general_count": len(general_comments),
+        "ci_fail_count": ci_fail_count,
+    }

--- a/tests/test_iterate.py
+++ b/tests/test_iterate.py
@@ -1,0 +1,348 @@
+"""Tests for agentic_ci.iterate module."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock, patch
+
+from agentic_ci.iterate import (
+    already_notified_ready,
+    check_mr_state,
+    collect_feedback,
+    count_iterations,
+    extract_mr_url,
+    resolve_threads,
+)
+
+
+class TestExtractMrUrl:
+    def test_gitlab_url(self):
+        comments = [
+            {
+                "body": (
+                    "### agentic-ci bot\n\n"
+                    "MR created: https://gitlab.com/org/repo/-/merge_requests/42"
+                ),
+            },
+        ]
+        assert extract_mr_url(comments) == ("https://gitlab.com/org/repo/-/merge_requests/42")
+
+    def test_github_url(self):
+        comments = [
+            {
+                "body": ("### agentic-ci bot\n\nPR created: https://github.com/owner/repo/pull/99"),
+            },
+        ]
+        assert extract_mr_url(comments) == "https://github.com/owner/repo/pull/99"
+
+    def test_no_match(self):
+        comments = [{"body": "just a regular comment"}]
+        assert extract_mr_url(comments) is None
+
+    def test_empty_comments(self):
+        assert extract_mr_url([]) is None
+
+    def test_custom_pattern(self):
+        custom = re.compile(r"my-bot", re.MULTILINE)
+        comments = [
+            {
+                "body": ("my-bot: https://gitlab.com/a/b/-/merge_requests/1"),
+            },
+        ]
+        assert extract_mr_url(comments, bot_pattern=custom) == (
+            "https://gitlab.com/a/b/-/merge_requests/1"
+        )
+
+    def test_jira_wiki_header(self):
+        comments = [
+            {
+                "body": ("h3. agentic-ci bot\n\nhttps://gitlab.com/x/y/-/merge_requests/7"),
+            },
+        ]
+        assert extract_mr_url(comments) == ("https://gitlab.com/x/y/-/merge_requests/7")
+
+    def test_gitlab_preferred_over_github(self):
+        """When both URLs appear in the same comment, GitLab is matched first."""
+        comments = [
+            {
+                "body": (
+                    "### agentic-ci bot\n\n"
+                    "https://gitlab.com/org/repo/-/merge_requests/1 "
+                    "https://github.com/owner/repo/pull/2"
+                ),
+            },
+        ]
+        assert extract_mr_url(comments) == ("https://gitlab.com/org/repo/-/merge_requests/1")
+
+
+class TestCountIterations:
+    def test_zero_iterations(self):
+        comments = [{"body": "### agentic-ci bot\n\nMR created."}]
+        assert count_iterations(comments) == 0
+
+    def test_one_iteration(self):
+        comments = [
+            {
+                "body": ("### agentic-ci bot\n\nIteration 1/36: addressed 2 review comment(s)."),
+            },
+        ]
+        assert count_iterations(comments) == 1
+
+    def test_multiple_iterations(self):
+        comments = [
+            {"body": "### agentic-ci bot\n\nIteration 1/36: changes."},
+            {"body": "### agentic-ci bot\n\nIteration 2/36: more changes."},
+            {"body": "### agentic-ci bot\n\nIteration 3/36: final changes."},
+        ]
+        assert count_iterations(comments) == 3
+
+    def test_non_bot_comments_ignored(self):
+        comments = [
+            {"body": "Iteration 1/36: this is from a human"},
+            {"body": "### agentic-ci bot\n\nIteration 1/36: real one."},
+        ]
+        assert count_iterations(comments) == 1
+
+
+class TestAlreadyNotifiedReady:
+    def test_ready_for_review_and_merge(self):
+        comments = [
+            {
+                "body": (
+                    "### agentic-ci bot\n\n"
+                    "CI is green -- the merge/pull request is "
+                    "ready for a maintainer to review and merge."
+                ),
+            },
+        ]
+        assert already_notified_ready(comments) is True
+
+    def test_ready_for_merge(self):
+        comments = [
+            {
+                "body": ("### agentic-ci bot\n\nThe MR is ready for a maintainer to merge."),
+            },
+        ]
+        assert already_notified_ready(comments) is True
+
+    def test_not_ready(self):
+        comments = [
+            {"body": "### agentic-ci bot\n\nIteration 1/36: pushed changes."},
+        ]
+        assert already_notified_ready(comments) is False
+
+    def test_empty_comments(self):
+        assert already_notified_ready([]) is False
+
+    def test_last_comment_wins(self):
+        """Only the last bot comment matters."""
+        comments = [
+            {
+                "body": ("### agentic-ci bot\n\nready for a maintainer to review and merge."),
+            },
+            {
+                "body": "### agentic-ci bot\n\nIteration 2/36: pushed changes.",
+            },
+        ]
+        assert already_notified_ready(comments) is False
+
+
+class TestResolveThreads:
+    def test_empty_comments_returns_zero(self):
+        assert resolve_threads("https://gitlab.com/o/r/-/merge_requests/1", []) == 0
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_resolves_threads(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_detect.return_value = mock_forge
+
+        comments = [
+            {"thread_id": "t1", "body": "fix this"},
+            {"thread_id": "t2", "body": "and this"},
+        ]
+        result = resolve_threads(
+            "https://gitlab.com/org/repo/-/merge_requests/5",
+            comments,
+        )
+        assert result == 2
+        assert mock_forge.reply.call_count == 2
+        assert mock_forge.resolve.call_count == 2
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_skips_comments_without_thread_id(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_detect.return_value = mock_forge
+
+        comments = [
+            {"body": "no thread id"},
+            {"thread_id": "t1", "body": "has thread id"},
+        ]
+        result = resolve_threads(
+            "https://gitlab.com/org/repo/-/merge_requests/5",
+            comments,
+        )
+        assert result == 1
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_forge_detection_failure_returns_zero(self, mock_detect):
+        from agentic_ci.forge import ForgeError
+
+        mock_detect.side_effect = ForgeError("bad url")
+
+        comments = [{"thread_id": "t1", "body": "fix"}]
+        result = resolve_threads("https://bad.example.com/mr/1", comments)
+        assert result == 0
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_partial_failure(self, mock_detect):
+        """When one thread fails to resolve, the others still count."""
+        from agentic_ci.forge import ForgeError
+
+        mock_forge = MagicMock()
+        mock_forge.reply.side_effect = [None, ForgeError("fail")]
+        mock_forge.resolve.return_value = None
+        mock_detect.return_value = mock_forge
+
+        comments = [
+            {"thread_id": "t1", "body": "first"},
+            {"thread_id": "t2", "body": "second"},
+        ]
+        result = resolve_threads(
+            "https://gitlab.com/org/repo/-/merge_requests/5",
+            comments,
+        )
+        assert result == 1
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_custom_reply_message(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_detect.return_value = mock_forge
+
+        comments = [{"thread_id": "t1", "body": "fix this"}]
+        resolve_threads(
+            "https://gitlab.com/o/r/-/merge_requests/1",
+            comments,
+            reply_message="Done.",
+        )
+        mock_forge.reply.assert_called_once_with(
+            "https://gitlab.com/o/r/-/merge_requests/1",
+            "t1",
+            "Done.",
+        )
+
+
+class TestCheckMrState:
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_returns_status(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_forge.mr_status.return_value = {
+            "state": "open",
+            "source_branch": "fix/bug",
+            "pipeline_status": "success",
+        }
+        mock_detect.return_value = mock_forge
+
+        result = check_mr_state("https://gitlab.com/o/r/-/merge_requests/1")
+        assert result == {
+            "state": "open",
+            "source_branch": "fix/bug",
+            "pipeline_status": "success",
+        }
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_returns_none_on_error(self, mock_detect):
+        from agentic_ci.forge import ForgeError
+
+        mock_detect.side_effect = ForgeError("connection failed")
+
+        result = check_mr_state("https://gitlab.com/o/r/-/merge_requests/1")
+        assert result is None
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_passes_github_token(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_forge.mr_status.return_value = {"state": "open"}
+        mock_detect.return_value = mock_forge
+
+        check_mr_state(
+            "https://github.com/owner/repo/pull/1",
+            github_token="ghp_test",
+        )
+        mock_detect.assert_called_once_with(
+            "https://github.com/owner/repo/pull/1",
+            github_token="ghp_test",
+        )
+
+
+class TestCollectFeedback:
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_collects_all_feedback(self, mock_detect):
+        mock_forge = MagicMock()
+        mock_forge.review_comments.return_value = [
+            {"thread_id": "t1", "body": "fix"},
+        ]
+        mock_forge.general_comments.return_value = [
+            {"body": "looks good"},
+        ]
+        mock_forge.pipeline_failures.return_value = {
+            "pipeline_status": "failed",
+            "failed_jobs": [{"name": "lint", "id": "1", "log": "error"}],
+        }
+        mock_detect.return_value = mock_forge
+
+        result = collect_feedback("https://gitlab.com/o/r/-/merge_requests/1")
+
+        assert result["review_count"] == 1
+        assert result["general_count"] == 1
+        assert result["ci_fail_count"] == 1
+        assert len(result["review_comments"]) == 1
+        assert len(result["general_comments"]) == 1
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_forge_detection_failure_returns_empty(self, mock_detect):
+        from agentic_ci.forge import ForgeError
+
+        mock_detect.side_effect = ForgeError("bad url")
+
+        result = collect_feedback("https://bad.example.com/mr/1")
+        assert result["review_comments"] == []
+        assert result["general_comments"] == []
+        assert result["ci_failures"] == {}
+        assert result["review_count"] == 0
+        assert result["general_count"] == 0
+        assert result["ci_fail_count"] == 0
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_partial_api_failure(self, mock_detect):
+        """Individual API call failures produce empty results for that call."""
+        from agentic_ci.forge import ForgeError
+
+        mock_forge = MagicMock()
+        mock_forge.review_comments.side_effect = ForgeError("api error")
+        mock_forge.general_comments.return_value = [{"body": "ok"}]
+        mock_forge.pipeline_failures.return_value = {
+            "pipeline_status": "success",
+            "failed_jobs": [],
+        }
+        mock_detect.return_value = mock_forge
+
+        result = collect_feedback("https://gitlab.com/o/r/-/merge_requests/1")
+        assert result["review_comments"] == []
+        assert result["general_count"] == 1
+        assert result["ci_fail_count"] == 0
+
+    @patch("agentic_ci.iterate.detect_forge")
+    def test_none_returns_from_forge(self, mock_detect):
+        """Forge methods returning None are handled gracefully."""
+        mock_forge = MagicMock()
+        mock_forge.review_comments.return_value = None
+        mock_forge.general_comments.return_value = None
+        mock_forge.pipeline_failures.return_value = None
+        mock_detect.return_value = mock_forge
+
+        result = collect_feedback("https://gitlab.com/o/r/-/merge_requests/1")
+        assert result["review_comments"] == []
+        assert result["general_comments"] == []
+        assert result["ci_failures"] == {}
+        assert result["review_count"] == 0
+        assert result["ci_fail_count"] == 0


### PR DESCRIPTION
## Summary

- Create `agentic_ci.iterate` module with reusable MR/PR iteration lifecycle helpers
- Functions: `extract_mr_url`, `count_iterations`, `already_notified_ready`, `resolve_threads`, `check_mr_state`, `collect_feedback`
- 29 unit tests covering all functions

## Test plan
- [x] `pytest tests/test_iterate.py` — 29 tests pass
- [x] `ruff check` passes
- [x] `ruff format --check` passes

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added merge request and pull request iteration management capabilities, enabling automated tracking of review cycles, readiness detection for merge approvals, and aggregation of feedback from code reviews and CI pipeline results.

* **Tests**
  * Added comprehensive test suite for iteration management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->