### PR TITLE
Fix harness gcp fallback

### DIFF
--- a/.claude/skills/test-e2e-podman/SKILL.md
+++ b/.claude/skills/test-e2e-podman/SKILL.md
@@ -13,12 +13,27 @@ Each section below is independent. Run whichever sections match your environment
 
 All sections require:
 - `podman` installed and working (rootless)
-- Network access to `ghcr.io` (image pull)
+- Network access to container registries (image pull)
 
 Per-section requirements:
 - **Vertex AI auth**: GCP ADC credentials (`~/.config/gcloud/application_default_credentials.json`)
 - **API key auth**: `ANTHROPIC_API_KEY` set in the environment
-- **OpenCode harness**: An OpenCode container image (set `OPENCODE_CONTAINER_IMAGE` or pass `--image`)
+
+## Container images
+
+Default images are used unless overridden by environment variables:
+
+| Harness    | Default image                                        | Override env var           |
+|------------|------------------------------------------------------|----------------------------|
+| Claude Code | `quay.io/aipcc/agentic-ci/claude-runner:latest`     | `CLAUDE_CONTAINER_IMAGE`   |
+| OpenCode   | `quay.io/aipcc/agentic-ci/opencode-runner:latest`   | `OPENCODE_CONTAINER_IMAGE` |
+
+The commands below use `$CLAUDE_IMAGE` and `$OPENCODE_IMAGE` variables. Set them at the start of the session:
+
+```bash
+CLAUDE_IMAGE="${CLAUDE_CONTAINER_IMAGE:-quay.io/aipcc/agentic-ci/claude-runner:latest}"
+OPENCODE_IMAGE="${OPENCODE_CONTAINER_IMAGE:-quay.io/aipcc/agentic-ci/opencode-runner:latest}"
+```
 
 ## Auth isolation
 
@@ -45,7 +60,7 @@ podman rm -f agentic-ci 2>/dev/null || true
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci setup \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest
+    --image $CLAUDE_IMAGE
 ```
 
 Verify:
@@ -57,8 +72,8 @@ Verify:
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A2_OK" \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-haiku-4-5-20251001 --no-otel
+    --image $CLAUDE_IMAGE \
+    --model claude-haiku-4-5 --no-otel
 ```
 
 Verify:
@@ -71,8 +86,8 @@ Verify:
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A3_OK" \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-haiku-4-5-20251001
+    --image $CLAUDE_IMAGE \
+    --model claude-haiku-4-5
 ```
 
 Verify:
@@ -87,8 +102,8 @@ Verify:
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: A4_OK" \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-haiku-4-5-20251001 --no-streaming --no-otel
+    --image $CLAUDE_IMAGE \
+    --model claude-haiku-4-5 --no-streaming --no-otel
 ```
 
 Verify:
@@ -99,7 +114,7 @@ Verify:
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci stop \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest
+    --image $CLAUDE_IMAGE
 ```
 
 Verify:
@@ -117,8 +132,8 @@ Requires `ANTHROPIC_API_KEY` set in the environment.
 ```bash
 podman rm -f agentic-ci 2>/dev/null || true
 uv run --with . agentic-ci run "Respond with exactly: B1_OK" \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-haiku-4-5-20251001 --no-otel
+    --image $CLAUDE_IMAGE \
+    --model claude-haiku-4-5 --no-otel
 ```
 
 Verify:
@@ -131,8 +146,8 @@ Verify:
 
 ```bash
 uv run --with . agentic-ci run "Respond with exactly: B2_OK" \
-    --image ghcr.io/opendatahub-io/ai-helpers:latest \
-    --model claude-haiku-4-5-20251001
+    --image $CLAUDE_IMAGE \
+    --model claude-haiku-4-5
 ```
 
 Verify:
@@ -143,7 +158,7 @@ Verify:
 ### B3. Stop
 
 ```bash
-uv run --with . agentic-ci stop --image ghcr.io/opendatahub-io/ai-helpers:latest
+uv run --with . agentic-ci stop --image $CLAUDE_IMAGE
 ```
 
 Verify:
@@ -153,7 +168,7 @@ Verify:
 
 ## Section C: OpenCode + Vertex AI
 
-Requires GCP ADC credentials and an OpenCode container image.
+Requires GCP ADC credentials.
 
 ### C1. Run
 
@@ -161,7 +176,7 @@ Requires GCP ADC credentials and an OpenCode container image.
 podman rm -f agentic-ci 2>/dev/null || true
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci run "Respond with exactly: C1_OK" \
     --harness opencode \
-    --image "$OPENCODE_CONTAINER_IMAGE" \
+    --image "$OPENCODE_IMAGE" \
     --model google-vertex/claude-haiku-4-5@20251001 \
     --no-otel
 ```
@@ -175,7 +190,7 @@ Verify:
 
 ```bash
 env -u ANTHROPIC_API_KEY uv run --with . agentic-ci stop --harness opencode \
-    --image "$OPENCODE_CONTAINER_IMAGE"
+    --image "$OPENCODE_IMAGE"
 ```
 
 Verify:
@@ -185,7 +200,7 @@ Verify:
 
 ## Section D: OpenCode + API Key
 
-Requires `ANTHROPIC_API_KEY` set in the environment and an OpenCode container image.
+Requires `ANTHROPIC_API_KEY` set in the environment.
 
 ### D1. Run
 
@@ -193,7 +208,7 @@ Requires `ANTHROPIC_API_KEY` set in the environment and an OpenCode container im
 podman rm -f agentic-ci 2>/dev/null || true
 uv run --with . agentic-ci run "Respond with exactly: D1_OK" \
     --harness opencode \
-    --image "$OPENCODE_CONTAINER_IMAGE" \
+    --image "$OPENCODE_IMAGE" \
     --model anthropic/claude-haiku-4-5-20251001 \
     --no-otel
 ```
@@ -207,7 +222,7 @@ Verify:
 
 ```bash
 uv run --with . agentic-ci stop --harness opencode \
-    --image "$OPENCODE_CONTAINER_IMAGE"
+    --image "$OPENCODE_IMAGE"
 ```
 
 Verify:

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -105,13 +105,16 @@ class ClaudeCodeHarness(Harness):
                 "--env",
                 "DISABLE_AUTOUPDATER=1",
             ]
+        vertex_project = os.environ.get(
+            "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+        )
         return [
             "--env",
             "CLAUDE_CODE_USE_VERTEX=1",
             "--env",
             f"CLOUD_ML_REGION={os.environ.get('CLOUD_ML_REGION', 'global')}",
             "--env",
-            f"ANTHROPIC_VERTEX_PROJECT_ID={os.environ.get('ANTHROPIC_VERTEX_PROJECT_ID', '')}",
+            f"ANTHROPIC_VERTEX_PROJECT_ID={vertex_project}",
             "--env",
             "DISABLE_AUTOUPDATER=1",
         ]
@@ -123,7 +126,9 @@ class ClaudeCodeHarness(Harness):
                 "export DISABLE_AUTOUPDATER=1",
             ]
         else:
-            vertex_project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+            vertex_project = os.environ.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+            )
             cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
             lines = [
                 "export CLAUDE_CODE_USE_VERTEX=1",
@@ -220,7 +225,7 @@ class OpenCodeHarness(Harness):
             ]
         project = os.environ.get(
             "GOOGLE_CLOUD_PROJECT",
-            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
+            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
         )
         location = os.environ.get(
             "VERTEX_LOCATION",
@@ -246,7 +251,7 @@ class OpenCodeHarness(Harness):
             ]
         project = os.environ.get(
             "GOOGLE_CLOUD_PROJECT",
-            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", ""),
+            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
         )
         location = os.environ.get(
             "VERTEX_LOCATION",

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -84,6 +84,22 @@ class TestClaudeCodeHarness:
         assert "DISABLE_AUTOUPDATER=1" in args
         assert "CLAUDE_CODE_USE_VERTEX=1" not in args
 
+    def test_build_env_args_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        harness = ClaudeCodeHarness()
+        args = harness.build_env_args()
+        assert "ANTHROPIC_VERTEX_PROJECT_ID=gcp-proj" in args
+
+    def test_build_env_script_lines_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert any("ANTHROPIC_VERTEX_PROJECT_ID=gcp-proj" in line for line in lines)
+
     def test_build_otel_exec_env(self):
         harness = ClaudeCodeHarness()
         args = harness.build_otel_exec_env(otel_port=4318)
@@ -191,6 +207,28 @@ class TestOpenCodeHarness:
         args = harness.build_env_args()
         assert "GOOGLE_CLOUD_PROJECT=fallback-proj" in args
         assert "VERTEX_LOCATION=eu-west1" in args
+
+    def test_build_env_args_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+        monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        harness = OpenCodeHarness()
+        args = harness.build_env_args()
+        assert "GOOGLE_CLOUD_PROJECT=gcp-proj" in args
+
+    def test_build_env_script_lines_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+        monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        harness = OpenCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert any("GOOGLE_CLOUD_PROJECT=gcp-proj" in line for line in lines)
 
     def test_build_otel_exec_env_always_empty(self):
         assert OpenCodeHarness().build_otel_exec_env(otel_port=4318) == []


### PR DESCRIPTION
## Description

- **Fix GCP project resolution in harnesses**: When only `GCP_PROJECT_ID` is set (the standard CI variable from `AIPCC_CICD_GCP_PROJECT_ID`), both `ClaudeCodeHarness` and `OpenCodeHarness` resolved the project to an empty string because they only checked `GOOGLE_CLOUD_PROJECT` and `ANTHROPIC_VERTEX_PROJECT_ID`. This caused OpenCode Vertex AI calls to fail with a 404. Added `GCP_PROJECT_ID` as a third fallback in `build_env_args()` and `build_env_script_lines()` for both harnesses, matching the fallback already used in `PodmanBackend._resolve_credentials()`. Claude Code was unaffected because it reads the project from the mounted gcloud config file.

- **Update e2e test skill**: Replaced hardcoded `ghcr.io` image references with configurable `$CLAUDE_IMAGE` / `$OPENCODE_IMAGE` variables backed by default `quay.io` images. Simplified model names (e.g. `claude-haiku-4-5-20251001` to `claude-haiku-4-5`). Removed the requirement to manually set `OPENCODE_CONTAINER_IMAGE` before running OpenCode tests.

## How Has This Been Tested?

Added new unit tests.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Podman E2E test skill documentation to standardize container image and model selection via environment variables.

* **Improvements**
  * Enhanced GCP project environment resolution with fallback support for improved configuration flexibility.

* **Tests**
  * Added test coverage verifying GCP environment variable fallback behavior in Claude Code and OpenCode harnesses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->