### PR TITLE
RHAIFIRST-59: Add skill artifact declarations to SkillConfig

### DIFF
--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -61,6 +61,7 @@ class SkillConfig:
     post_gates: list[Callable[..., tuple[dict | None, list[str]]]] = field(default_factory=list)
 
     extra_skills: list[str] = field(default_factory=list)
+    artifacts: list[str] = field(default_factory=list)
 
     max_retries: int = 1
     retryable_modes: frozenset[str] = frozenset({"resolve"})

--- a/src/agentic_ci/skill_metadata.py
+++ b/src/agentic_ci/skill_metadata.py
@@ -1,0 +1,155 @@
+"""Parse YAML frontmatter from SKILL.md files without requiring pyyaml."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_FRONTMATTER_RE = re.compile(r"\A---\n(.*?\n)---\n", re.DOTALL)
+_KEY_VALUE_RE = re.compile(r"^([a-z][a-z0-9-]*)\s*:\s*(.*)", re.IGNORECASE)
+_LIST_ITEM_RE = re.compile(r"^\s+-\s+(.*)")
+_CONTINUATION_RE = re.compile(r"^\s+\S")
+_NESTED_KV_RE = re.compile(r"^\s+([a-z][a-z0-9-]*)\s*:\s*(.*)", re.IGNORECASE)
+
+# "x-" prefix follows the convention for custom extension fields (like HTTP
+# headers and OpenAPI), avoiding collisions if the Agent Skills spec ever
+# adds an official "artifacts" key with different semantics.
+_METADATA_ARTIFACTS_KEY = "x-artifacts"
+
+
+def _strip_quotes(s: str) -> str:
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
+        return s[1:-1]
+    return s
+
+
+def parse_frontmatter(text: str) -> dict[str, str | list[str] | dict[str, str]]:
+    """Parse YAML frontmatter from markdown text.
+
+    Handles the subset of YAML used in SKILL.md files: simple key-value pairs,
+    folded scalars (>-), block lists (- item), and one-level nested maps.
+    """
+    text = text.replace("\r\n", "\n")
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}
+
+    result: dict[str, str | list[str] | dict[str, str]] = {}
+    lines = m.group(1).splitlines()
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+        kv = _KEY_VALUE_RE.match(line)
+        if not kv:
+            i += 1
+            continue
+
+        key = kv.group(1)
+        value = _strip_quotes(kv.group(2).strip())
+
+        if value == ">-":
+            parts: list[str] = []
+            i += 1
+            while i < len(lines) and _CONTINUATION_RE.match(lines[i]):
+                parts.append(lines[i].strip())
+                i += 1
+            result[key] = " ".join(parts)
+        elif value == "":
+            i += 1
+            if i < len(lines) and _LIST_ITEM_RE.match(lines[i]):
+                items: list[str] = []
+                while i < len(lines):
+                    item_match = _LIST_ITEM_RE.match(lines[i])
+                    if item_match:
+                        items.append(item_match.group(1).strip())
+                        i += 1
+                    else:
+                        break
+                result[key] = items
+            elif i < len(lines) and _NESTED_KV_RE.match(lines[i]):
+                nested: dict[str, str] = {}
+                while i < len(lines):
+                    nkv = _NESTED_KV_RE.match(lines[i])
+                    if nkv:
+                        nested[nkv.group(1)] = _strip_quotes(nkv.group(2).strip())
+                        i += 1
+                    else:
+                        break
+                result[key] = nested
+            else:
+                result[key] = []
+        else:
+            result[key] = value
+            i += 1
+
+    return result
+
+
+@dataclass
+class SkillMetadata:
+    """Parsed metadata from a SKILL.md frontmatter block."""
+
+    name: str
+    description: str = ""
+    allowed_tools: list[str] = field(default_factory=list)
+    user_invocable: bool = False
+    metadata: dict[str, str] = field(default_factory=dict)
+    artifacts: list[str] = field(default_factory=list)
+
+
+def load_skill_metadata(skill_md_path: Path) -> SkillMetadata:
+    """Read a SKILL.md file and return parsed metadata.
+
+    Raises FileNotFoundError if the file does not exist.
+    """
+    text = skill_md_path.read_text(encoding="utf-8")
+    data = parse_frontmatter(text)
+
+    tools_raw = data.get("allowed-tools", "")
+    if isinstance(tools_raw, str) and tools_raw:
+        allowed_tools = tools_raw.split()
+    else:
+        allowed_tools = []
+
+    invocable_raw = data.get("user-invocable", "")
+    user_invocable = isinstance(invocable_raw, str) and invocable_raw.lower() == "true"
+
+    raw_metadata = data.get("metadata", {})
+    metadata = raw_metadata if isinstance(raw_metadata, dict) else {}
+
+    artifacts_str = metadata.get(_METADATA_ARTIFACTS_KEY, "")
+    artifacts = artifacts_str.split() if artifacts_str else []
+
+    description = data.get("description", "")
+    if not isinstance(description, str):
+        description = ""
+
+    return SkillMetadata(
+        name=str(data.get("name", "")),
+        description=description,
+        allowed_tools=allowed_tools,
+        user_invocable=user_invocable,
+        metadata=metadata,
+        artifacts=artifacts,
+    )
+
+
+def collect_artifacts(*skill_md_paths: Path) -> list[str]:
+    """Load each SKILL.md, extract artifacts, deduplicate, and return sorted.
+
+    Logs warnings for missing or unreadable files but does not raise.
+    """
+    seen: set[str] = set()
+    for path in skill_md_paths:
+        try:
+            meta = load_skill_metadata(path)
+        except (FileNotFoundError, OSError) as exc:
+            log.warning("Skipping %s: %s", path, exc)
+            continue
+        seen.update(meta.artifacts)
+    return sorted(seen)

--- a/tests/test_skill_metadata.py
+++ b/tests/test_skill_metadata.py
@@ -1,0 +1,250 @@
+"""Tests for skill metadata parsing."""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from agentic_ci.skill_metadata import (
+    collect_artifacts,
+    load_skill_metadata,
+    parse_frontmatter,
+)
+
+_ARTIFACTS_STR = "claude-output.txt autofix-output/ .autofix-context/ tmp/orchestrator-state.yaml"
+
+FULL_SKILL_MD = """\
+---
+name: autofix-resolve
+description: >-
+  Use when orchestrating a Jira ticket fix end-to-end. Dispatches to implement
+  and review prompt agents in a loop, uses state.py for persistence, and
+  evaluates findings to decide iteration. Never writes code directly.
+allowed-tools: Read Write Bash Skill
+user-invocable: true
+metadata:
+  x-artifacts: "claude-output.txt autofix-output/ .autofix-context/ tmp/orchestrator-state.yaml"
+  author: aipcc-team
+---
+
+# Skill: Resolve / Iterate Orchestrator
+
+Orchestrate the fix for a Jira ticket...
+"""
+
+SIMPLE_SKILL_MD = """\
+---
+name: autofix-triage
+description: >-
+  Use when assessing a Jira bug ticket for AI autofix readiness. Produces a
+  structured JSON verdict.
+allowed-tools: Read Grep Glob Write
+---
+
+# Skill: Triage Bug Readiness
+"""
+
+
+class TestParseFrontmatter:
+    def test_basic_key_value(self):
+        text = "---\nname: my-skill\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"name": "my-skill"}
+
+    def test_multiple_key_values(self):
+        text = "---\nname: my-skill\nallowed-tools: Read Write\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"name": "my-skill", "allowed-tools": "Read Write"}
+
+    def test_block_list(self):
+        text = "---\nitems:\n  - file1.txt\n  - dir/\n  - file2.yaml\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"items": ["file1.txt", "dir/", "file2.yaml"]}
+
+    def test_nested_map(self):
+        text = "---\nmetadata:\n  author: team-a\n  version: 1.0\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"metadata": {"author": "team-a", "version": "1.0"}}
+
+    def test_nested_map_with_x_artifacts(self):
+        text = '---\nmetadata:\n  x-artifacts: "output.txt data/"\n  author: test\n---\n'
+        result = parse_frontmatter(text)
+        assert result == {
+            "metadata": {"x-artifacts": "output.txt data/", "author": "test"},
+        }
+
+    def test_folded_scalar(self):
+        text = (
+            "---\n"
+            "description: >-\n"
+            "  This is a long description that\n"
+            "  spans multiple lines.\n"
+            "---\n"
+        )
+        result = parse_frontmatter(text)
+        assert result == {"description": "This is a long description that spans multiple lines."}
+
+    def test_no_frontmatter(self):
+        text = "# Just a heading\n\nSome body text.\n"
+        result = parse_frontmatter(text)
+        assert result == {}
+
+    def test_empty_value_returns_empty_list(self):
+        text = "---\nitems:\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"items": []}
+
+    def test_boolean_string_value(self):
+        text = "---\nuser-invocable: true\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"user-invocable": "true"}
+
+    def test_false_boolean_string(self):
+        text = "---\nuser-invocable: false\n---\n"
+        result = parse_frontmatter(text)
+        assert result == {"user-invocable": "false"}
+
+    def test_body_after_frontmatter_ignored(self):
+        text = "---\nname: test\n---\n\n# Heading\n\nBody content here.\n"
+        result = parse_frontmatter(text)
+        assert result == {"name": "test"}
+
+    def test_full_skill_md(self):
+        result = parse_frontmatter(FULL_SKILL_MD)
+        assert result["name"] == "autofix-resolve"
+        assert "end-to-end" in result["description"]
+        assert "Never writes code directly." in result["description"]
+        assert result["allowed-tools"] == "Read Write Bash Skill"
+        assert result["user-invocable"] == "true"
+        assert result["metadata"] == {
+            "x-artifacts": _ARTIFACTS_STR,
+            "author": "aipcc-team",
+        }
+
+    def test_simple_skill_md(self):
+        result = parse_frontmatter(SIMPLE_SKILL_MD)
+        assert result["name"] == "autofix-triage"
+        assert "structured JSON verdict" in result["description"]
+        assert result["allowed-tools"] == "Read Grep Glob Write"
+        assert "metadata" not in result
+
+    def test_empty_string(self):
+        assert parse_frontmatter("") == {}
+
+    def test_single_delimiter_no_close(self):
+        text = "---\nname: test\n"
+        assert parse_frontmatter(text) == {}
+
+    def test_folded_scalar_followed_by_key(self):
+        text = (
+            "---\n"
+            "description: >-\n"
+            "  Line one of desc\n"
+            "  line two of desc.\n"
+            "name: after-folded\n"
+            "---\n"
+        )
+        result = parse_frontmatter(text)
+        assert result["description"] == "Line one of desc line two of desc."
+        assert result["name"] == "after-folded"
+
+    def test_nested_map_followed_by_key(self):
+        text = "---\nmetadata:\n  author: team-a\nname: after-metadata\n---\n"
+        result = parse_frontmatter(text)
+        assert result["metadata"] == {"author": "team-a"}
+        assert result["name"] == "after-metadata"
+
+    def test_crlf_line_endings(self):
+        text = "---\r\nname: crlf-skill\r\n---\r\n"
+        result = parse_frontmatter(text)
+        assert result == {"name": "crlf-skill"}
+
+
+class TestLoadSkillMetadata:
+    def test_full_round_trip(self, tmp_path: Path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(FULL_SKILL_MD)
+        meta = load_skill_metadata(skill_file)
+        assert meta.name == "autofix-resolve"
+        assert "end-to-end" in meta.description
+        assert meta.allowed_tools == ["Read", "Write", "Bash", "Skill"]
+        assert meta.user_invocable is True
+        assert meta.metadata == {
+            "x-artifacts": _ARTIFACTS_STR,
+            "author": "aipcc-team",
+        }
+        assert meta.artifacts == [
+            "claude-output.txt",
+            "autofix-output/",
+            ".autofix-context/",
+            "tmp/orchestrator-state.yaml",
+        ]
+
+    def test_missing_metadata_defaults_empty(self, tmp_path: Path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text(SIMPLE_SKILL_MD)
+        meta = load_skill_metadata(skill_file)
+        assert meta.metadata == {}
+        assert meta.artifacts == []
+
+    def test_metadata_without_artifacts(self, tmp_path: Path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text("---\nname: test\nmetadata:\n  author: me\n---\n")
+        meta = load_skill_metadata(skill_file)
+        assert meta.metadata == {"author": "me"}
+        assert meta.artifacts == []
+
+    def test_missing_optional_fields_get_defaults(self, tmp_path: Path):
+        skill_file = tmp_path / "SKILL.md"
+        skill_file.write_text("---\nname: minimal\n---\n")
+        meta = load_skill_metadata(skill_file)
+        assert meta.name == "minimal"
+        assert meta.description == ""
+        assert meta.allowed_tools == []
+        assert meta.user_invocable is False
+        assert meta.metadata == {}
+        assert meta.artifacts == []
+
+    def test_file_not_found_raises(self):
+        with pytest.raises(FileNotFoundError):
+            load_skill_metadata(Path("/nonexistent/SKILL.md"))
+
+
+class TestCollectArtifacts:
+    def _write_skill(self, tmp_path: Path, name: str, artifacts: str) -> Path:
+        skill_dir = tmp_path / name
+        skill_dir.mkdir()
+        skill_file = skill_dir / "SKILL.md"
+        content = f"---\nname: {name}\n"
+        if artifacts:
+            content += f'metadata:\n  x-artifacts: "{artifacts}"\n'
+        content += "---\n"
+        skill_file.write_text(content)
+        return skill_file
+
+    def test_deduplicates_across_skills(self, tmp_path: Path):
+        skill_a = self._write_skill(tmp_path, "skill-a", "output.txt shared.log")
+        skill_b = self._write_skill(tmp_path, "skill-b", "shared.log report.json")
+        result = collect_artifacts(skill_a, skill_b)
+        assert result == ["output.txt", "report.json", "shared.log"]
+
+    def test_returns_sorted(self, tmp_path: Path):
+        skill_file = self._write_skill(tmp_path, "z-skill", "z.txt a.txt m.txt")
+        result = collect_artifacts(skill_file)
+        assert result == ["a.txt", "m.txt", "z.txt"]
+
+    def test_skips_missing_files(self, tmp_path: Path, caplog: pytest.LogCaptureFixture):
+        missing = tmp_path / "missing" / "SKILL.md"
+        existing = self._write_skill(tmp_path, "ok", "keep.txt")
+        with caplog.at_level(logging.WARNING):
+            result = collect_artifacts(missing, existing)
+        assert result == ["keep.txt"]
+        assert "missing" in caplog.text.lower() or str(missing) in caplog.text
+
+    def test_empty_input(self):
+        assert collect_artifacts() == []
+
+    def test_skill_with_no_artifacts(self, tmp_path: Path):
+        skill_file = self._write_skill(tmp_path, "no-artifacts", "")
+        result = collect_artifacts(skill_file)
+        assert result == []


### PR DESCRIPTION
## Summary

- Adds an `artifacts: list[str]` field to `SkillConfig` so skills can declare the files/directories they create during execution
- Adds a new `skill_metadata` module with a lightweight YAML frontmatter parser (stdlib only, no pyyaml) that extracts metadata from SKILL.md files
- Artifacts are declared via the [Agent Skills spec](https://agentskills.io/specification) `metadata` field using the `x-artifacts` key (space-separated paths), keeping the format spec-compliant
- Includes `parse_frontmatter()`, `SkillMetadata` dataclass, `load_skill_metadata()`, and `collect_artifacts()` APIs for downstream consumers

This is Phase 1 of [RHAIFIRST-59](https://redhat.atlassian.net/browse/RHAIFIRST-59), which replaces the hardcoded `_SCAFFOLD_EXCLUDES` / `_SCAFFOLD_BLOCKLIST` in [autofix](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix) with dynamic lists derived from skill metadata.

### SKILL.md format

```yaml
metadata:
  x-artifacts: "claude-output.txt autofix-output/ .autofix-context/"
```

The `x-` prefix follows the convention for custom extension fields (HTTP headers, OpenAPI), avoiding collisions if the Agent Skills spec ever adds an official `artifacts` key.

## Backward compatibility

This PR is fully compatible with existing SKILL.md files that don't declare artifacts yet:

- `SkillConfig.artifacts` defaults to `[]`, so existing `_make_config()` calls in autofix work unchanged
- `load_skill_metadata()` returns `SkillMetadata(artifacts=[])` when the `metadata` field is missing or has no `x-artifacts` key
- `collect_artifacts()` returns `[]` when no skills declare artifacts

The autofix-skills and autofix consumer changes can land independently after this.

## Remaining phases (separate PRs in other repos)

- **autofix-skills**: Add `metadata.x-artifacts` to each SKILL.md frontmatter
- **autofix**: Replace `_SCAFFOLD_EXCLUDES` / `_SCAFFOLD_BLOCKLIST` with `collect_artifacts()` calls, using `AUTOFIX_SKILLS_DIR` env var to locate skill definitions

## Test plan

- [x] 28 tests covering frontmatter parsing (key-value, folded scalars, block lists, nested maps, CRLF, edge cases), metadata loading, and multi-skill artifact collection
- [x] All 407 tests pass (`tox -e py313`)
- [x] Lint, format, and typecheck clean (`tox -e lint -e check-format -e typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can declare artifacts in their configuration.
  * Added Markdown frontmatter parsing for SKILL.md to load skill metadata (name, description, allowlist, user-invocable, and artifacts).
  * Collects artifacts from multiple skill files, skipping unreadable files with warnings, deduplicating and returning a sorted list.

* **Tests**
  * Added comprehensive tests for frontmatter parsing, metadata loading, artifact collection, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->