### PR TITLE
Pass model name as env variable into the sandbox

### DIFF
--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import tempfile
 from typing import TYPE_CHECKING
@@ -66,7 +67,7 @@ class OpenShellBackend(Backend):
         otel_rate_file=None,
         extra_args=None,
     ):
-        self._write_env_script(otel_port, otel_rate_file)
+        self._write_env_script(model, otel_port, otel_rate_file)
         agent_args = self.harness.build_args(prompt, model, extra_args)
 
         cmd = ["bash", "-c", f'. {self._ENV_SCRIPT} && exec "$@"', "--", *agent_args]
@@ -76,9 +77,10 @@ class OpenShellBackend(Backend):
         self._wait_for_otel_flush(otel_port)
         return rc
 
-    def _write_env_script(self, otel_port=None, otel_rate_file=None):
+    def _write_env_script(self, model, otel_port=None, otel_rate_file=None):
         """Write env vars to a script inside the sandbox, sourced before the agent runs."""
         lines = self.harness.build_env_script_lines(otel_port, otel_rate_file)
+        lines.append(f"export AGENT_MODEL={shlex.quote(model)}")
         script = "\n".join(lines) + "\n"
         sandbox.exec_cmd(["bash", "-c", f"cat > {self._ENV_SCRIPT} << 'ENVEOF'\n{script}ENVEOF"])
 

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -124,7 +124,15 @@ class PodmanBackend(Backend):
         agent_args = self.harness.build_args(prompt, model, extra_args)
 
         proc = subprocess.Popen(
-            ["podman", "exec", *otel_env, CONTAINER_NAME, *agent_args],
+            [
+                "podman",
+                "exec",
+                "--env",
+                f"AGENT_MODEL={model}",
+                *otel_env,
+                CONTAINER_NAME,
+                *agent_args,
+            ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )


### PR DESCRIPTION
## Description
This can be useful in case the skill being executed within the agentic session needs to know what model is being used to run it. This is a best-effort piece of data since the model can change while the session is running, but at least it points to information as to what model initiated the session.

## How Has This Been Tested?
```
● Bash(CLAUDE_IMAGE="${CLAUDE_CONTAINER_IMAGE:-quay.io/aipcc/agentic-ci/claude-runner:latest}" && uv run --with . agentic-ci run 'Print the
      value of the AGENT_MODEL environment variable. Use echo $AGENT_MODEL in a bash command and tell me the result.' --image
      "$CLAUDE_IMAGE" --model claude-sonnet-4-6 --no-otel 2>&1)
  ⎿  [...]
     ▶ Podman container started
     ▶ Running Claude Code (claude-sonnet-4-6) via podman backend
     ▶ Executing Claude Code in container
     ▶ Claude Code v2.1.161
       Model: claude-sonnet-4-6
       Permissions: bypassPermissions
       Tools: 27 available
       MCP servers: none
       Agents: 7 available
       Plugins: [...]
       🔧 Bash $ echo $AGENT_MODEL  # Print AGENT_MODEL environment variable
       📊 TOKENS in=3 out=80 cache_r=0 cache_w=35838 total=35921
       💬 Claude The value of `AGENT_MODEL` is `claude-sonnet-4-6`.

     ▶ Result: success (end_turn)
       Duration: 4.7s (API: 5.6s, TTFT: 3.5s)
       Turns: 2
       Cost: $0.1483
       stream processor detected run complete (rc=-9), treating as success

     ▶ Agent exit code: 0
     ▶ Podman container stopped
  ⎿  (timeout 5m)
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Additional Info

See related MR where we use this information: https://github.com/opendatahub-io/code-review-skills/pull/3