### PR TITLE
Add description-editors pre-agent gate

### DIFF
--- a/src/agentic_ci/gates.py
+++ b/src/agentic_ci/gates.py
@@ -25,6 +25,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
+from agentic_ci.git import GitDiffError, get_changed_files, get_commit_info
+from agentic_ci.jira.client import JiraClient
+
 log = logging.getLogger(__name__)
 
 
@@ -227,6 +230,32 @@ def filter_bot_comments(
     return [c for c in comments if not any(s in c.get("body", "") for s in sentinel_phrases)]
 
 
+def check_description_editors(
+    editors: list[str],
+    reporter_email: str,
+    internal_domain_re: re.Pattern[str],
+) -> list[str]:
+    """Check if any description editors are outside the trusted domain.
+
+    Validates the reporter (original author) and all changelog editors.
+    Returns a list of untrusted email addresses (empty means all clear).
+    Treats empty or missing emails as untrusted.
+    """
+    untrusted: list[str] = []
+    if not reporter_email:
+        untrusted.append("missing-email:reporter")
+    elif not internal_domain_re.search(reporter_email):
+        untrusted.append(reporter_email)
+
+    for email in editors:
+        normalized = email or "missing-email:unknown"
+        if normalized.startswith("missing-email:") or not internal_domain_re.search(normalized):
+            if normalized not in untrusted:
+                untrusted.append(normalized)
+
+    return untrusted
+
+
 def check_external_reporter(
     ticket: dict,
     internal_domain_re: re.Pattern[str],
@@ -271,8 +300,6 @@ def check_label_author_email(
 
 def _run_sensitive_files(workdir: str, **_kw: object) -> list[str]:
     """CLI runner for the sensitive-files gate."""
-    from agentic_ci.git import GitDiffError, get_changed_files
-
     try:
         changed = get_changed_files(Path(workdir), base_ref="origin/HEAD")
     except GitDiffError as exc:
@@ -286,8 +313,6 @@ def _run_sensitive_files(workdir: str, **_kw: object) -> list[str]:
 
 def _run_commit_author(workdir: str, **_kw: object) -> list[str]:
     """CLI runner for the commit-author gate."""
-    from agentic_ci.git import get_commit_info
-
     expected = os.environ.get("BOT_EMAIL", "")
     try:
         info = get_commit_info(Path(workdir))
@@ -304,8 +329,56 @@ def _run_gitleaks(workdir: str, **_kw: object) -> list[str]:
     return gitleaks_scan(Path(workdir))
 
 
+def _run_jira_description_editors(**_kw: object) -> str | None:
+    """CLI runner for the description-editors gate (pre-gate contract)."""
+    ticket_key = os.environ.get("TICKET_KEY", "")
+    if not ticket_key:
+        return "TICKET_KEY env var not set; cannot check description editors"
+
+    domain_pattern = os.environ.get("INTERNAL_DOMAIN_RE", "")
+    if not domain_pattern:
+        return "INTERNAL_DOMAIN_RE env var not set; cannot validate editor emails"
+    if not domain_pattern.endswith("$"):
+        return "INTERNAL_DOMAIN_RE must be end-anchored ($) to prevent partial matches"
+
+    try:
+        internal_re = re.compile(domain_pattern, re.IGNORECASE)
+    except re.error as exc:
+        return f"Invalid INTERNAL_DOMAIN_RE pattern: {exc}"
+
+    try:
+        client = JiraClient.from_env()
+    except Exception as exc:
+        return f"Could not create Jira client: {exc}"
+
+    try:
+        issue = client.get_issue(ticket_key)
+    except Exception as exc:
+        return f"Could not fetch issue {ticket_key}: {exc}"
+
+    reporter_email = issue.get("reporter_email", "")
+    try:
+        editors = client.get_description_editors(ticket_key)
+    except Exception as exc:
+        return f"Could not fetch changelog for {ticket_key}: {exc}"
+
+    untrusted = check_description_editors(editors, reporter_email, internal_re)
+    if untrusted:
+        return (
+            f"Description edited by untrusted user(s): {', '.join(untrusted)}. "
+            f"Only users matching {domain_pattern} may author or edit the ticket description."
+        )
+    return None
+
+
 # -- Register built-in gates -------------------------------------------------
 
 _register("sensitive-files", _run_sensitive_files, phase="post")
 _register("commit-author", _run_commit_author, phase="post", required_env=["BOT_EMAIL"])
 _register("gitleaks", _run_gitleaks, phase="post")
+_register(
+    "jira-description-editors",
+    _run_jira_description_editors,
+    phase="pre",
+    required_env=["JIRA_URL", "JIRA_API_TOKEN", "TICKET_KEY", "INTERNAL_DOMAIN_RE"],
+)

--- a/tests/test_gate_registry.py
+++ b/tests/test_gate_registry.py
@@ -71,13 +71,13 @@ class TestValidateGateEnv:
 class TestRunSensitiveFiles:
     def test_no_changes_passes(self):
         gate = GATE_REGISTRY["sensitive-files"]
-        with patch("agentic_ci.git.get_changed_files", return_value=[]):
+        with patch("agentic_ci.gates.get_changed_files", return_value=[]):
             errors = gate.fn(workdir="/tmp/test")
         assert errors == []
 
     def test_sensitive_file_blocked(self):
         gate = GATE_REGISTRY["sensitive-files"]
-        with patch("agentic_ci.git.get_changed_files", return_value=[".env", "main.py"]):
+        with patch("agentic_ci.gates.get_changed_files", return_value=[".env", "main.py"]):
             errors = gate.fn(workdir="/tmp/test")
         assert len(errors) == 1
         assert ".env" in errors[0]
@@ -89,7 +89,7 @@ class TestRunCommitAuthor:
         with (
             patch.dict(os.environ, {"BOT_EMAIL": "bot@ci.com"}),
             patch(
-                "agentic_ci.git.get_commit_info",
+                "agentic_ci.gates.get_commit_info",
                 return_value={"email": "bot@ci.com", "subject": "fix"},
             ),
         ):
@@ -101,7 +101,7 @@ class TestRunCommitAuthor:
         with (
             patch.dict(os.environ, {"BOT_EMAIL": "bot@ci.com"}),
             patch(
-                "agentic_ci.git.get_commit_info",
+                "agentic_ci.gates.get_commit_info",
                 return_value={"email": "human@ci.com", "subject": "fix"},
             ),
         ):

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -4,6 +4,7 @@ import re
 
 from agentic_ci.gates import (
     check_commit_identity,
+    check_description_editors,
     check_external_reporter,
     check_label_author_email,
     check_sensitive_files,
@@ -82,6 +83,50 @@ class TestCheckExternalReporter:
     def test_already_labeled(self):
         ticket = {"reporter_email": "user@gmail.com", "labels": ["triage-external"]}
         assert check_external_reporter(ticket, REDHAT_RE, external_label="triage-external") is None
+
+
+class TestCheckDescriptionEditors:
+    def test_all_internal(self):
+        result = check_description_editors(["dev2@redhat.com"], "dev1@redhat.com", REDHAT_RE)
+        assert result == []
+
+    def test_external_editor(self):
+        result = check_description_editors(["attacker@gmail.com"], "dev@redhat.com", REDHAT_RE)
+        assert result == ["attacker@gmail.com"]
+
+    def test_external_reporter(self):
+        result = check_description_editors([], "user@external.com", REDHAT_RE)
+        assert result == ["user@external.com"]
+
+    def test_empty_reporter_email(self):
+        result = check_description_editors([], "", REDHAT_RE)
+        assert result == ["missing-email:reporter"]
+
+    def test_missing_editor_email(self):
+        result = check_description_editors(["missing-email:abc123"], "dev@redhat.com", REDHAT_RE)
+        assert result == ["missing-email:abc123"]
+
+    def test_mixed_editors(self):
+        result = check_description_editors(
+            ["dev2@redhat.com", "attacker@evil.com", "dev3@redhat.com"],
+            "dev1@redhat.com",
+            REDHAT_RE,
+        )
+        assert result == ["attacker@evil.com"]
+
+    def test_no_editors_internal_reporter(self):
+        result = check_description_editors([], "dev@redhat.com", REDHAT_RE)
+        assert result == []
+
+    def test_deduplicates(self):
+        result = check_description_editors(
+            ["bad@evil.com", "bad@evil.com"], "bad@evil.com", REDHAT_RE
+        )
+        assert result == ["bad@evil.com"]
+
+    def test_empty_email_normalized_and_deduplicated(self):
+        result = check_description_editors(["", ""], "dev@redhat.com", REDHAT_RE)
+        assert result == ["missing-email:unknown"]
 
 
 class TestLogChangedFiles:


### PR DESCRIPTION
## Summary

Adds a `description-editors` pre-agent gate to `agentic_ci.gates` that verifies all Jira ticket description authors/editors have internal email addresses. Blocks tickets where external users authored or edited the description to prevent prompt injection via ticket content.

### Core function

- `check_description_editors(editors, reporter_email, internal_domain_re)`: stateless, tracker-agnostic. Validates reporter + changelog editor emails against a compiled regex. Returns list of untrusted emails (empty = all clear). Treats empty/missing emails as untrusted (fail-closed).

### CLI gate runner

- `_run_description_editors()`: pre-gate contract (`str | None`). Uses `JiraClient.get_description_editors()` for changelog access.
- Enforces end-anchored (`$`) domain pattern to prevent partial matches
- Validates regex with `try/except re.error`

### Required environment variables

| Variable | Description |
|----------|-------------|
| `JIRA_URL` | Jira instance URL |
| `JIRA_EMAIL` or `JIRA_USER` | Jira account email (either works, handled by `JiraClient.from_env()`) |
| `JIRA_API_TOKEN` | Jira API token |
| `TICKET_KEY` | Jira ticket key to check |
| `INTERNAL_DOMAIN_RE` | End-anchored regex for trusted email domain (e.g. `@redhat\.com$`) |

### Usage

```bash
agentic-ci run --pre-gates description-editors "fix the bug"
```

Or via `SkillConfig`:

```python
config = SkillConfig(
    pre_gates=[_run_description_editors],
    ...
)
```

Part of RHOAIENG-62667.

## Test plan

- [x] 9 test cases: all internal, external editor, external reporter, empty email, missing email, mixed, no editors, deduplication, empty email normalization
- [x] All 29 gate tests pass
- [x] ruff lint clean
- [x] ruff format clean
- [x] mypy clean