### PR TITLE
Native skill-hooks support in run_skill()

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,8 +333,12 @@ When `extra_skills` is non-empty, `run_skill()` writes
 }
 ```
 
-The agent skill reads this file and invokes each extension at the
-appropriate hook point. `context_dir` is validated to stay within
+**Important:** `run_skill()` only writes the config file — it does not
+execute the extra skills directly. The orchestrator skill (the one
+launched by `run_skill()`) must include instructions in its SKILL.md
+to read `{context_dir}/config.json` and invoke each extension at the
+appropriate hook point. The extra skills themselves don't need any
+awareness of this file. `context_dir` is validated to stay within
 `work_dir` (rejects path traversal and symlinks).
 
 ### Pipeline Flow

--- a/README.md
+++ b/README.md
@@ -304,6 +304,39 @@ All domain-specific behavior is injected via hooks on `SkillConfig`:
 | `cost_formatter` | `(cost_data) -> str \| None` | Format OTEL cost data for display |
 | `extension_config_writer` | `(ticket_key, ticket, config, work_dir, **kw) -> None` | Write extra config (e.g. Claude extensions) |
 
+### Extra Skills (Extension Hooks)
+
+`extra_skills` lets you configure additional skills that the agent should
+run at specific hook points during the pipeline (e.g., run a preflight
+review after implementing a fix).
+
+```python
+config = SkillConfig(
+    skill_name="autofix-resolve",
+    extra_skills=[
+        {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
+        "lint-check",  # plain string = all hooks, no args
+    ],
+    context_dir=".autofix-context",  # where config.json is written (default: ".context")
+)
+```
+
+When `extra_skills` is non-empty, `run_skill()` writes
+`{context_dir}/config.json` before launching the container:
+
+```json
+{
+  "extra_skills": [
+    {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
+    "lint-check"
+  ]
+}
+```
+
+The agent skill reads this file and invokes each extension at the
+appropriate hook point. `context_dir` is validated to stay within
+`work_dir` (rejects path traversal and symlinks).
+
 ### Pipeline Flow
 
 `run_skill()` executes this sequence:

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -60,7 +60,8 @@ class SkillConfig:
     pre_gates: list[Callable[..., str | None]] = field(default_factory=list)
     post_gates: list[Callable[..., tuple[dict | None, list[str]]]] = field(default_factory=list)
 
-    extra_skills: list[str] = field(default_factory=list)
+    extra_skills: list[str | dict] = field(default_factory=list)
+    context_dir: str = ".context"
     artifacts: list[str] = field(default_factory=list)
 
     max_retries: int = 1
@@ -164,6 +165,28 @@ def run_skill(
         work_dir=work_dir,
         **extra_kwargs,
     )
+
+    if config.extra_skills:
+        raw_ctx_dir = work_dir / config.context_dir
+        if raw_ctx_dir.is_symlink():
+            raise ValueError(f"context_dir is a symlink: {raw_ctx_dir}")
+        ctx_dir = raw_ctx_dir.resolve()
+        try:
+            ctx_dir.relative_to(work_dir.resolve())
+        except ValueError as exc:
+            raise ValueError(f"context_dir escapes work_dir: {config.context_dir!r}") from exc
+        ctx_dir.mkdir(parents=True, exist_ok=True)
+        config_path = ctx_dir / "config.json"
+        if config_path.is_symlink():
+            raise ValueError(f"config.json is a symlink: {config_path}")
+        config_path.write_text(
+            json.dumps(
+                {"extra_skills": config.extra_skills},
+                indent=2,
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
 
     config.extension_config_writer(
         ticket_key=ticket_key,

--- a/tests/test_skill_extra_skills.py
+++ b/tests/test_skill_extra_skills.py
@@ -1,0 +1,84 @@
+"""Tests for extra_skills config writing in run_skill()."""
+
+import json
+
+import pytest
+
+from agentic_ci.skill import SkillConfig, run_skill
+
+
+def _dry_run_skill(tmp_path, extra_skills, context_dir=".context"):
+    """Helper: run_skill in dry-run mode and return the work_dir."""
+    config = SkillConfig(
+        skill_name="test-skill",
+        extra_skills=extra_skills,
+        context_dir=context_dir,
+    )
+    run_skill(
+        config,
+        ticket_key="TEST-1",
+        work_dir=tmp_path,
+        config_dir=tmp_path,
+        dry_run=True,
+    )
+    return tmp_path
+
+
+class TestExtraSkillsConfigWriting:
+    def test_plain_strings_written(self, tmp_path):
+        _dry_run_skill(tmp_path, ["skill-a", "skill-b"])
+        config_file = tmp_path / ".context" / "config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
+        assert data == {"extra_skills": ["skill-a", "skill-b"]}
+
+    def test_structured_dicts_written(self, tmp_path):
+        hooks = [
+            {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
+        ]
+        _dry_run_skill(tmp_path, hooks)
+        data = json.loads((tmp_path / ".context" / "config.json").read_text())
+        assert data["extra_skills"] == hooks
+
+    def test_mixed_str_and_dict(self, tmp_path):
+        mixed = [
+            "simple-skill",
+            {"name": "preflight", "args": "--fix", "hooks": ["post_implement"]},
+        ]
+        _dry_run_skill(tmp_path, mixed)
+        data = json.loads((tmp_path / ".context" / "config.json").read_text())
+        assert data["extra_skills"] == mixed
+
+    def test_empty_extra_skills_no_file(self, tmp_path):
+        _dry_run_skill(tmp_path, [])
+        assert not (tmp_path / ".context" / "config.json").exists()
+
+    def test_custom_context_dir(self, tmp_path):
+        _dry_run_skill(tmp_path, ["s"], context_dir=".autofix-context")
+        assert (tmp_path / ".autofix-context" / "config.json").exists()
+        assert not (tmp_path / ".context" / "config.json").exists()
+
+    def test_path_traversal_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="escapes work_dir"):
+            _dry_run_skill(tmp_path, ["s"], context_dir="../escape")
+
+    def test_absolute_path_rejected(self, tmp_path):
+        with pytest.raises(ValueError, match="escapes work_dir"):
+            _dry_run_skill(tmp_path, ["s"], context_dir="/tmp/evil")
+
+    def test_symlinked_context_dir_rejected(self, tmp_path):
+        target = tmp_path / "real-dir"
+        target.mkdir()
+        link = tmp_path / ".context"
+        link.symlink_to(target)
+        with pytest.raises(ValueError, match="symlink"):
+            _dry_run_skill(tmp_path, ["s"])
+
+    def test_symlinked_config_json_rejected(self, tmp_path):
+        ctx_dir = tmp_path / ".context"
+        ctx_dir.mkdir()
+        target = tmp_path / "decoy.json"
+        target.write_text("{}")
+        (ctx_dir / "config.json").symlink_to(target)
+        with pytest.raises(ValueError, match="symlink"):
+            _dry_run_skill(tmp_path, ["s"])


### PR DESCRIPTION
## Summary

- Widen `SkillConfig.extra_skills` from `list[str]` to `list[str | dict]` so callers can pass structured hook entries with per-hook args and hook-point filtering
- Add configurable `context_dir` field (default `.context`) so downstream projects control where context files are written
- `run_skill()` writes `{context_dir}/config.json` with the raw `extra_skills` list when present — the agent skill reads this to discover extensions
- Path traversal and symlink validation on `context_dir` and `config.json` (CWE-22, CWE-59)

Supersedes https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/464 — the config writing now lives here in `agentic-ci` so any pipeline gets it for free.

## How to consume

### 1. Pass structured skills to `SkillConfig`

```python
config = SkillConfig(
    skill_name="autofix-resolve",
    extra_skills=[
        {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
    ],
    context_dir=".autofix-context",  # default is ".context"
)
```

Plain strings also work — they run at all hook points with no args:
```python
extra_skills=["preflight", "lint-check"]
```

### 2. What `run_skill()` does automatically

When `extra_skills` is non-empty, writes `{context_dir}/config.json`:
```json
{
  "extra_skills": [
    {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]}
  ]
}
```

The agent skill inside the container reads this file and invokes each extension at the appropriate hook point. `run_skill()` just writes the data — the skill's SKILL.md handles interpretation.

### 3. Security

- `context_dir` validated to resolve within `work_dir` (rejects `../`, absolute paths)
- Symlinks on both `context_dir` and `config.json` are rejected

## Test plan

- [x] 9 unit tests covering: plain strings, structured dicts, mixed formats, empty list, custom context_dir, path traversal, absolute paths, symlinked dir, symlinked file
- [x] All CI checks pass (py310-313, lint, format, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support extra-skills as plain names or structured entries; added configurable context directory (default ".context") and writing of extension config when non-empty; rejects unsafe paths and symlinked destinations.

* **Tests**
  * New tests for string/structured/mixed entries, custom context dirs, no-op when empty, and unsafe-path/symlink rejection.

* **Documentation**
  * README updated with usage, examples, and validation behavior for extra-skills and the context directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->