### PR TITLE
Rename claude-output.txt to agent-output.txt

### DIFF
--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -179,7 +179,8 @@ def run_skill(
         skill_name=config.skill_name,
         **extra_kwargs,
     )
-    output_file = work_dir / "claude-output.txt"
+    output_file = work_dir / "agent-output.txt"
+    _deprecated_output = work_dir / "claude-output.txt"
 
     runner = config.container_runner or _default_run_container
 
@@ -208,6 +209,13 @@ def run_skill(
                 config.max_retries,
             )
             rc = runner(work_dir, prompt, output_file, image=config.container_image)
+
+    if output_file.exists() and not _deprecated_output.exists():
+        _deprecated_output.symlink_to(output_file.name)
+        log.warning(
+            "claude-output.txt is deprecated; use agent-output.txt instead. "
+            "The symlink will be removed in a future release.",
+        )
 
     if rc != 0:
         log.error("[%s] Container exited with code %d", ticket_key, rc)


### PR DESCRIPTION
## Summary

- Renames the hardcoded `claude-output.txt` output file to `agent-output.txt` to be harness-agnostic (we support OpenCode in addition to Claude Code).
- Creates a backward-compat symlink `claude-output.txt -> agent-output.txt` with a deprecation warning so existing consumers continue to work.
- The symlink will be removed in a future release.

## Test plan

- [x] All 411 tests pass
- [x] Lint, format, and typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)