### PR TITLE
RHAIFIRST-76: Fix iterate pipeline picking up AI review as new feedback

### DIFF
--- a/src/agentic_ci/forge/__init__.py
+++ b/src/agentic_ci/forge/__init__.py
@@ -141,6 +141,7 @@ _GITHUB_PR_RE = re.compile(
 
 DEFAULT_SKIP_PATTERNS: list[str] = [
     "<!-- agentic-ci",
+    "<!-- ai-review",
     "Addressed in the latest revision",
 ]
 

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -271,6 +271,39 @@ class TestGeneralComments:
         assert len(comments) == 1
         assert comments[0]["body"] == "Real feedback here"
 
+    def test_filters_ai_review_marker(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        discussions = [
+            {
+                "notes": [
+                    {
+                        "body": (
+                            "## AI Code Review Summary\n\n"
+                            "Looks good.\n\n"
+                            "<!-- ai-review sha:abc123 -->"
+                        ),
+                        "author": {"name": "Bot"},
+                        "created_at": "2025-01-01T00:00:00Z",
+                    }
+                ],
+            },
+            {
+                "notes": [
+                    {
+                        "body": "Please fix the typo on line 42",
+                        "author": {"name": "Alice"},
+                        "created_at": "2025-01-02T00:00:00Z",
+                    }
+                ],
+            },
+        ]
+        disc_resp = _make_response(200, discussions)
+        mock_session.get.side_effect = [project_resp, disc_resp]
+
+        comments = forge.general_comments("https://gitlab.com/org/repo/-/merge_requests/1")
+        assert len(comments) == 1
+        assert comments[0]["body"] == "Please fix the typo on line 42"
+
     def test_since_filter(self, forge, mock_session):
         project_resp = _make_response(200, {"id": 1})
         discussions = [


### PR DESCRIPTION
## Summary

- Add `<!-- ai-review` to `DEFAULT_SKIP_PATTERNS` so AI review summary comments are excluded from iterate feedback detection. This was the root cause: the AI review marker (`<!-- ai-review`) didn't match the existing skip pattern (`<!-- agentic-ci`), causing every iterate cycle to treat the review summary as new human feedback and trigger unnecessary agent runs.

## Test plan

- [x] New test `test_filters_ai_review_marker` verifies that comments containing `<!-- ai-review sha:xxx -->` are filtered by `general_comments()`
- [x] Existing `test_filters_skip_patterns` continues to pass for `<!-- agentic-ci` marker
- [x] `tox -e py313,lint,check-format` all pass

Closes RHAIFIRST-76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced default comment filtering configuration to properly exclude marked comments from merge request and pull request discussions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->