### PR TITLE
Add API documentation with MkDocs and GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+      - run: pip install -e '.[docs]'
+      - run: mkdocs build --strict
+      - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: mkdocs gh-deploy --force

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ tox -e lint-fix                  # ruff lint with auto-fix
 tox -e check-format              # ruff format check
 tox -e format                    # ruff format with auto-fix
 tox -e typecheck                 # mypy type check
+tox -e docs                      # build API docs
 ```
 
 ## Verification

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/opendatahub-io/agentic-ci/actions/workflows/ci.yml/badge.svg)](https://github.com/opendatahub-io/agentic-ci/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/opendatahub-io/agentic-ci)](https://github.com/opendatahub-io/agentic-ci/blob/main/LICENSE)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/agentic-ci)](https://pypi.org/project/agentic-ci/)
+[![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://opendatahub-io.github.io/agentic-ci/)
 
 Run AI coding agents in sandboxed CI environments with streaming output
 and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
@@ -334,5 +335,22 @@ config = SkillConfig(
     cost_formatter=_format_otel_cost,     # Formats cost for Jira comments
     post_gates=[_autofix_post_gate],      # Commit author check, sensitive files, gitleaks
 )
+```
+
+## Documentation
+
+API reference documentation is auto-generated from docstrings and
+published to [GitHub Pages](https://opendatahub-io.github.io/agentic-ci/).
+
+To build the docs locally:
+
+```bash
+tox -e docs
+```
+
+Or to preview with live reload:
+
+```bash
+uv run --with '.[docs]' mkdocs serve
 ```
 

--- a/docs/api/backend.md
+++ b/docs/api/backend.md
@@ -1,0 +1,3 @@
+# Backend
+
+::: agentic_ci.backend

--- a/docs/api/backends.md
+++ b/docs/api/backends.md
@@ -1,0 +1,9 @@
+# Factory & Podman
+
+## Backend Factory
+
+::: agentic_ci.backends
+
+## Podman Backend
+
+::: agentic_ci.backends.podman

--- a/docs/api/cli.md
+++ b/docs/api/cli.md
@@ -1,0 +1,3 @@
+# CLI
+
+::: agentic_ci.cli

--- a/docs/api/forge.md
+++ b/docs/api/forge.md
@@ -1,0 +1,21 @@
+# Forge (GitHub/GitLab)
+
+## Forge ABC
+
+::: agentic_ci.forge
+
+## GitHub
+
+::: agentic_ci.forge.github
+
+## GitLab
+
+::: agentic_ci.forge.gitlab
+
+## CLI
+
+::: agentic_ci.forge.cli
+
+## Session
+
+::: agentic_ci.forge.session

--- a/docs/api/gates.md
+++ b/docs/api/gates.md
@@ -1,0 +1,3 @@
+# Gates
+
+::: agentic_ci.gates

--- a/docs/api/git.md
+++ b/docs/api/git.md
@@ -1,0 +1,3 @@
+# Git Operations
+
+::: agentic_ci.git

--- a/docs/api/harness.md
+++ b/docs/api/harness.md
@@ -1,0 +1,3 @@
+# Harness
+
+::: agentic_ci.harness

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,44 @@
+# API Reference
+
+Auto-generated reference documentation for all public modules in `agentic-ci`.
+
+## Core
+
+| Module | Description |
+|--------|-------------|
+| [CLI](cli.md) | Entry point, backend/harness selection, OTEL orchestration |
+| [Backend](backend.md) | Abstract base class for sandbox backends |
+| [Harness](harness.md) | Harness abstraction for AI agent CLI tools |
+| [Stream Processors](stream.md) | Parsers for Claude Code and OpenCode output |
+| [OTEL Collector](otel.md) | OTLP HTTP/JSON receiver and token/cost summary |
+
+## Backends
+
+| Module | Description |
+|--------|-------------|
+| [Factory & Podman](backends.md) | Backend registry, factory, and Podman container backend |
+| [OpenShell](openshell.md) | OpenShell sandbox backend, gateway, and policy |
+
+## Pipeline
+
+| Module | Description |
+|--------|-------------|
+| [Gates](gates.md) | Pre- and post-agent validation gates |
+| [Skill Runner](skill.md) | Generic skill runner framework |
+| [Verdict](verdict.md) | Structured verdict JSON validation |
+| [Git Operations](git.md) | Git operations for CI pipelines |
+| [Pipeline Generation](pipeline.md) | GitLab child pipeline YAML generation |
+
+## Integrations
+
+| Module | Description |
+|--------|-------------|
+| [Forge](forge.md) | Git forge abstraction for GitHub and GitLab |
+| [Jira](jira.md) | Jira REST client, ADF conversion, acli wrapper |
+
+## Utilities
+
+| Module | Description |
+|--------|-------------|
+| [Logging](log.md) | Colored CLI output helpers |
+| [Skill Metadata](skill_metadata.md) | YAML frontmatter parser for SKILL.md files |

--- a/docs/api/jira.md
+++ b/docs/api/jira.md
@@ -1,0 +1,13 @@
+# Jira
+
+## Client
+
+::: agentic_ci.jira.client
+
+## ADF Conversion
+
+::: agentic_ci.jira.adf
+
+## acli Wrapper
+
+::: agentic_ci.jira.acli

--- a/docs/api/log.md
+++ b/docs/api/log.md
@@ -1,0 +1,3 @@
+# Logging
+
+::: agentic_ci.log

--- a/docs/api/openshell.md
+++ b/docs/api/openshell.md
@@ -1,0 +1,17 @@
+# OpenShell
+
+## Backend
+
+::: agentic_ci.backends.openshell
+
+## Gateway
+
+::: agentic_ci.backends.openshell.gateway
+
+## Sandbox
+
+::: agentic_ci.backends.openshell.sandbox
+
+## Policy
+
+::: agentic_ci.backends.openshell.policy

--- a/docs/api/otel.md
+++ b/docs/api/otel.md
@@ -1,0 +1,3 @@
+# OTEL Collector
+
+::: agentic_ci.otel

--- a/docs/api/pipeline.md
+++ b/docs/api/pipeline.md
@@ -1,0 +1,3 @@
+# Pipeline Generation
+
+::: agentic_ci.pipeline

--- a/docs/api/skill.md
+++ b/docs/api/skill.md
@@ -1,0 +1,3 @@
+# Skill Runner
+
+::: agentic_ci.skill

--- a/docs/api/skill_metadata.md
+++ b/docs/api/skill_metadata.md
@@ -1,0 +1,3 @@
+# Skill Metadata
+
+::: agentic_ci.skill_metadata

--- a/docs/api/stream.md
+++ b/docs/api/stream.md
@@ -1,0 +1,3 @@
+# Stream Processors
+
+::: agentic_ci.stream

--- a/docs/api/verdict.md
+++ b/docs/api/verdict.md
@@ -1,0 +1,3 @@
+# Verdict
+
+::: agentic_ci.verdict

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,58 @@
+# agentic-ci
+
+Run AI coding agents in sandboxed CI environments with streaming output
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and isolation backends so you can choose the right tradeoff between
+simplicity and security.
+
+## Features
+
+- **Multiple backends**: Podman containers or OpenShell sandboxes with network policy enforcement
+- **Multiple harnesses**: Claude Code and OpenCode agent CLIs
+- **Streaming output**: Colored, parsed CI logs with tool call summaries and token tracking
+- **OTEL telemetry**: Token usage, cost tracking, and metrics collection
+- **Gates**: Pre- and post-agent validation (sensitive files, commit checks, secret scanning)
+- **Skill runner**: Generic framework for building AI-powered CI pipelines
+
+## Install
+
+```bash
+uv tool install agentic-ci
+# OR
+pip install agentic-ci
+```
+
+## Quick start
+
+```bash
+# Run with Podman (default)
+agentic-ci run "Fix the flaky test in test_auth.py" \
+    --image ghcr.io/opendatahub-io/ai-helpers:latest
+
+# Run with OpenShell sandbox
+agentic-ci run --backend openshell "Fix the flaky test in test_auth.py"
+```
+
+## Python API
+
+```python
+from agentic_ci.backends import create_backend
+from agentic_ci.harness import create_harness
+
+harness = create_harness("claude-code")
+backend = create_backend(
+    "podman",
+    harness=harness,
+    workdir="/path/to/repo",
+    image="my-image:latest",
+)
+backend.setup()
+rc = backend.run(prompt="Fix the bug", model="claude-sonnet-4-6")
+backend.stop()
+```
+
+## Learn more
+
+- [API Reference](api/index.md) -- auto-generated from source docstrings
+- [GitHub Repository](https://github.com/opendatahub-io/agentic-ci)
+- [PyPI Package](https://pypi.org/project/agentic-ci/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,80 @@
+site_name: agentic-ci
+site_description: Run AI coding agents in sandboxed CI environments
+site_url: https://opendatahub-io.github.io/agentic-ci/
+repo_url: https://github.com/opendatahub-io/agentic-ci
+repo_name: opendatahub-io/agentic-ci
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - content.code.copy
+    - navigation.sections
+    - navigation.expand
+    - search.highlight
+    - toc.follow
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          options:
+            show_source: true
+            show_root_heading: true
+            show_root_full_path: false
+            members_order: source
+            docstring_style: google
+            merge_init_into_class: true
+            show_if_no_docstring: false
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - API Reference:
+      - Overview: api/index.md
+      - Core:
+          - CLI: api/cli.md
+          - Backend: api/backend.md
+          - Harness: api/harness.md
+          - Stream Processors: api/stream.md
+          - OTEL Collector: api/otel.md
+      - Backends:
+          - Factory & Podman: api/backends.md
+          - OpenShell: api/openshell.md
+      - Pipeline:
+          - Gates: api/gates.md
+          - Skill Runner: api/skill.md
+          - Verdict: api/verdict.md
+          - Git Operations: api/git.md
+          - Pipeline Generation: api/pipeline.md
+      - Integrations:
+          - Forge (GitHub/GitLab): api/forge.md
+          - Jira: api/jira.md
+      - Utilities:
+          - Logging: api/log.md
+          - Skill Metadata: api/skill_metadata.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,12 +33,18 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/opendatahub-io/agentic-ci"
 Repository = "https://github.com/opendatahub-io/agentic-ci"
+Documentation = "https://opendatahub-io.github.io/agentic-ci/"
 Issues = "https://github.com/opendatahub-io/agentic-ci/issues"
 
 [project.optional-dependencies]
 forge = [
     "PyJWT>=2.0",
     "cryptography>=3.4",
+]
+docs = [
+    "mkdocs>=1.6",
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.25",
 ]
 
 [project.scripts]

--- a/src/agentic_ci/backends/__init__.py
+++ b/src/agentic_ci/backends/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from agentic_ci.harness import Harness
 
 
-def create_backend(name: str, *, harness: Harness, **kwargs) -> Backend:
+def create_backend(name: str, *, harness: Harness, **kwargs: Any) -> Backend:
     """Create a backend instance by name.
 
     Args:

--- a/tox.ini
+++ b/tox.ini
@@ -32,3 +32,11 @@ commands = mypy src/
 description = Format code
 deps = ruff
 commands = ruff format .
+
+[testenv:docs]
+description = Build documentation
+deps =
+    mkdocs
+    mkdocs-material
+    mkdocstrings[python]
+commands = mkdocs build --strict


### PR DESCRIPTION
## Summary

- Set up auto-generated API reference documentation using MkDocs with Material theme and mkdocstrings-python
- Documentation is built from existing source docstrings and published to GitHub Pages on push to main
- Added `tox -e docs` environment, `[docs]` optional dependency group, and GitHub Actions workflow for deployment

## Details

- **MkDocs + Material theme**: modern Python docs standard with dark/light mode, search, and code copy
- **mkdocstrings-python**: auto-generates API reference from all 28 source modules' docstrings
- **GitHub Pages**: `docs.yml` workflow builds on PRs, deploys on push to main via `mkdocs gh-deploy`
- **`tox -e docs`**: local docs build for development
- Updated README with docs badge and Documentation section
- Updated AGENTS.md with `tox -e docs` command
- Added Documentation URL to `pyproject.toml` project URLs

## Test plan

- [x] `tox -e docs` builds successfully
- [x] `tox -e lint` passes
- [x] `tox -e check-format` passes
- [x] `tox -e typecheck` passes
- [x] `tox -e py313` passes (412 tests)
- [ ] After merge, verify GitHub Pages deploys at https://opendatahub-io.github.io/agentic-ci/
- [ ] Enable GitHub Pages in repo settings (Settings > Pages > Source: Deploy from a branch, Branch: gh-pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive API reference documentation auto-generated from code docstrings
  * Documentation site automatically deployed to GitHub Pages on main branch updates
  * Site includes feature overview, installation guide, and quick-start CLI examples  
  * Local documentation building and live preview available via tox

<!-- end of auto-generated comment: release notes by coderabbit.ai -->