### PR TITLE
RHAIFIRST-50: Add BranchResolver module for version-aware branch routing

### DIFF
--- a/src/agentic_ci/branch.py
+++ b/src/agentic_ci/branch.py
@@ -1,0 +1,108 @@
+"""Branch resolution for version-aware CI workflows.
+
+This module provides functionality to resolve target branches from Jira tickets
+using fixVersion fields and component configuration overrides.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from agentic_ci.git import validate_branch_exists
+
+log = logging.getLogger(__name__)
+
+
+class BranchResolutionError(Exception):
+    """Raised when branch resolution or validation fails critically."""
+
+
+def resolve_branch_from_jira(
+    ticket: dict[str, Any],
+    component_config: dict[str, Any] | None = None,
+    repo_url: str | None = None,
+) -> str | None:
+    """Resolve target branch for a Jira ticket using fixVersion and component config.
+
+    Checks the ticket's fixVersions field against the component's
+    version_branches map to determine the correct target branch for MRs/PRs.
+
+    Resolution order:
+    1. fixVersion[0] mapped through component_config.version_branches
+    2. fixVersion[0] used directly as branch name
+    3. component_config.branch static fallback
+    4. None (caller uses repo default branch)
+
+    Each candidate is validated against the remote (if repo_url is provided)
+    before being returned. Returns None on validation failure so the caller
+    can fall back to the repository default branch.
+    """
+    log.info(
+        "Branch resolution started: fixVersions=%s, component=%s, repo=%s",
+        ticket.get("fixVersions", []),
+        component_config.get("name") if component_config else None,
+        repo_url,
+    )
+
+    # Step 1: Extract fixVersion[0]
+    fix_versions = ticket.get("fixVersions", [])
+    fix_version_name = None
+
+    if fix_versions:
+        first_version = fix_versions[0]
+        if isinstance(first_version, dict) and "name" in first_version:
+            fix_version_name = first_version["name"]
+            if fix_version_name:  # Ensure it's not empty
+                log.info("Found fixVersion: %s", fix_version_name)
+            else:
+                log.debug("fixVersion name is empty, will try fallback")
+                fix_version_name = None
+        else:
+            log.debug("fixVersion object missing 'name' field, will try fallback")
+    else:
+        log.debug("No fixVersions found in ticket, will try fallback")
+
+    resolved_branch = None
+
+    if fix_version_name:
+        # Step 2: Check version_branches override
+        if component_config and "version_branches" in component_config:
+            version_branches = component_config["version_branches"]
+            if fix_version_name in version_branches:
+                resolved_branch = version_branches[fix_version_name]
+                log.info(
+                    "Using version_branches override: %s -> %s", fix_version_name, resolved_branch
+                )
+            else:
+                # Step 3: Use fixVersion directly
+                resolved_branch = fix_version_name
+                log.info("Using fixVersion directly as branch: %s", resolved_branch)
+        else:
+            # Step 3: Use fixVersion directly (no component config or version_branches)
+            resolved_branch = fix_version_name
+            log.info("Using fixVersion directly as branch: %s", resolved_branch)
+
+    # Step 4: Fall back to component.branch
+    if not resolved_branch and component_config and "branch" in component_config:
+        resolved_branch = component_config["branch"]
+        log.info("Falling back to component branch: %s", resolved_branch)
+
+    if not resolved_branch:
+        log.info("No branch could be resolved from ticket or component config")
+        return None
+
+    # Step 5: Validate branch exists (if repo_url provided)
+    if repo_url:
+        if not validate_branch_exists(repo_url, resolved_branch):
+            log.warning(
+                "Resolved branch %s does not exist on remote %s, returning None",
+                resolved_branch,
+                repo_url,
+            )
+            return None
+    else:
+        log.debug("No repo URL provided, skipping branch validation")
+
+    log.info("Successfully resolved branch: %s", resolved_branch)
+    return resolved_branch

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -151,6 +151,55 @@ def _validate_ref(name: str) -> bool:
     return bool(_SAFE_REF_RE.match(name))
 
 
+def validate_branch_exists(repo_url: str, branch: str) -> bool:
+    """Check if a branch exists on the remote repository.
+
+    Args:
+        repo_url: HTTPS URL of the git repository
+        branch: Branch name to validate
+
+    Returns:
+        True if the branch exists on the remote, False otherwise
+
+    Note:
+        Returns False for any error condition (network issues, invalid refs, etc.)
+        to allow graceful fallback in the resolution chain.
+    """
+    if not _validate_ref(branch):
+        log.warning("Invalid branch name rejected: %s", branch)
+        return False
+
+    try:
+        result = subprocess.run(
+            ["git", "ls-remote", "--heads", repo_url, branch],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            stdin=_DEVNULL,
+        )
+
+        if result.returncode != 0:
+            log.debug(
+                "git ls-remote failed for %s branch %s: %s", repo_url, branch, result.stderr.strip()
+            )
+            return False
+
+        output = result.stdout.strip()
+        if not output:
+            log.debug("Branch %s does not exist on remote %s", branch, repo_url)
+            return False
+
+        log.debug("Branch %s exists on remote %s", branch, repo_url)
+        return True
+
+    except subprocess.TimeoutExpired:
+        log.warning("Branch validation timed out for %s branch %s", repo_url, branch)
+        return False
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        log.debug("Branch validation failed for %s branch %s: %s", repo_url, branch, exc)
+        return False
+
+
 def clone_repo(url: str, dest: Path, branch: str | None = None, depth: int | None = None) -> bool:
     """Clone a repository. Returns True on success."""
     if not validate_repo_url(url):

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -1,0 +1,331 @@
+"""Tests for branch resolution module."""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from agentic_ci.branch import (
+    BranchResolutionError,
+    resolve_branch_from_jira,
+)
+from agentic_ci.git import _validate_ref, validate_branch_exists
+
+
+class TestValidateRef:
+    """Test _validate_ref function for git ref injection protection."""
+
+    def test_valid_names(self):
+        """Valid branch names should pass validation."""
+        assert _validate_ref("main") is True
+        assert _validate_ref("develop") is True
+        assert _validate_ref("feature/my-branch") is True
+        assert _validate_ref("release/v1.0.0") is True
+        assert _validate_ref("v2.3.1") is True
+        assert _validate_ref("user/name/fix-123") is True
+        assert _validate_ref("branch_with_underscores") is True
+        assert _validate_ref("branch-with-dashes") is True
+        assert _validate_ref("Branch.With.Dots") is True
+        assert _validate_ref("~branch") is True
+        assert _validate_ref("branch^") is True
+
+    def test_invalid_names(self):
+        """Invalid or dangerous branch names should fail validation."""
+        # Empty or starting with dash
+        assert _validate_ref("") is False
+        assert _validate_ref("--evil") is False
+        assert _validate_ref("-branch") is False
+
+        # Injection patterns
+        assert _validate_ref("foo..bar") is False
+        assert _validate_ref("branch@{1}") is False
+        assert _validate_ref("@{HEAD}") is False
+
+        # Special characters that could be used for injection
+        assert _validate_ref("branch;rm -rf /") is False
+        assert _validate_ref("branch && ls") is False
+        assert _validate_ref("branch|cat /etc/passwd") is False
+        assert _validate_ref("branch\nls") is False
+        assert _validate_ref("branch\0") is False
+
+
+class TestValidateBranchExists:
+    """Test validate_branch_exists function."""
+
+    def test_branch_exists(self):
+        """Should return True when branch exists on remote."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "ls-remote"],
+                returncode=0,
+                stdout="abc123\trefs/heads/main\n",
+                stderr="",
+            )
+            assert validate_branch_exists("https://github.com/test/repo.git", "main") is True
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args == [
+                "git",
+                "ls-remote",
+                "--heads",
+                "https://github.com/test/repo.git",
+                "main",
+            ]
+
+    def test_branch_does_not_exist(self):
+        """Should return False when branch does not exist (empty output)."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "ls-remote"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+            result = validate_branch_exists("https://github.com/test/repo.git", "nonexistent")
+            assert result is False
+
+    def test_git_command_fails(self):
+        """Should return False when git ls-remote fails."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "ls-remote"],
+                returncode=128,
+                stdout="",
+                stderr="fatal: unable to access repository",
+            )
+            assert validate_branch_exists("https://github.com/test/repo.git", "main") is False
+
+    def test_timeout(self):
+        """Should return False when git ls-remote times out."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=30)
+            assert validate_branch_exists("https://github.com/test/repo.git", "main") is False
+
+    def test_git_not_found(self):
+        """Should return False when git is not installed."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("git not found")
+            assert validate_branch_exists("https://github.com/test/repo.git", "main") is False
+
+    def test_invalid_ref_rejected(self):
+        """Should return False and not call git for invalid ref names."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            assert validate_branch_exists("https://github.com/test/repo.git", "..") is False
+            assert validate_branch_exists("https://github.com/test/repo.git", "--evil") is False
+            mock_run.assert_not_called()
+
+    def test_subprocess_timeout_param(self):
+        """Should pass timeout=30 to subprocess.run."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "ls-remote"],
+                returncode=0,
+                stdout="abc123\trefs/heads/main\n",
+                stderr="",
+            )
+            validate_branch_exists("https://github.com/test/repo.git", "main")
+            assert mock_run.call_args[1]["timeout"] == 30
+
+    def test_subprocess_stdin_devnull(self):
+        """Should pass stdin=subprocess.DEVNULL to prevent blocking."""
+        with patch("agentic_ci.git.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["git", "ls-remote"],
+                returncode=0,
+                stdout="abc123\trefs/heads/main\n",
+                stderr="",
+            )
+            validate_branch_exists("https://github.com/test/repo.git", "main")
+            assert mock_run.call_args[1]["stdin"] == subprocess.DEVNULL
+
+
+class TestResolveBranch:
+    """Test resolve_branch_from_jira function."""
+
+    def test_fixversion_only(self):
+        """Should return fixVersion directly when no version_branches map exists."""
+        ticket = {"fixVersions": [{"name": "v1.0.0"}]}
+
+        component_config = {}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "v1.0.0"
+
+    def test_version_branches_override(self):
+        """Should use version_branches map when fixVersion matches a key."""
+        ticket = {"fixVersions": [{"name": "2.0"}]}
+
+        component_config = {
+            "version_branches": {
+                "2.0": "release/2.0.x",
+                "1.0": "release/1.0.x",
+            }
+        }
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "release/2.0.x"
+
+    def test_fixversion_not_in_version_branches(self):
+        """Should use fixVersion directly when not in version_branches map."""
+        ticket = {"fixVersions": [{"name": "v3.0.0"}]}
+
+        component_config = {
+            "version_branches": {
+                "2.0": "release/2.0.x",
+                "1.0": "release/1.0.x",
+            }
+        }
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "v3.0.0"
+
+    def test_static_branch_fallback(self):
+        """Should fall back to component.branch when no fixVersion exists."""
+        ticket = {}
+
+        component_config = {"branch": "develop"}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "develop"
+
+    def test_no_resolution_returns_none(self):
+        """Should return None when no branch can be resolved."""
+        ticket = {}
+
+        component_config = {}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result is None
+
+    def test_empty_fixversions_list(self):
+        """Should fall back when fixVersions is an empty list."""
+        ticket = {"fixVersions": []}
+
+        component_config = {"branch": "main"}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "main"
+
+    def test_fixversion_empty_name(self):
+        """Should fall back when fixVersion has empty name."""
+        ticket = {"fixVersions": [{"name": ""}]}
+
+        component_config = {"branch": "develop"}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "develop"
+
+    def test_fixversion_missing_name_key(self):
+        """Should fall back when fixVersion dict is missing 'name' key."""
+        ticket = {"fixVersions": [{"id": "12345"}]}
+
+        component_config = {"branch": "main"}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "main"
+
+    def test_none_component_config(self):
+        """Should work when component_config is None."""
+        ticket = {"fixVersions": [{"name": "v2.0"}]}
+
+        result = resolve_branch_from_jira(ticket, component_config=None)
+        assert result == "v2.0"
+
+    def test_with_repo_url_validation_succeeds(self):
+        """Should return branch when validation succeeds."""
+        ticket = {"fixVersions": [{"name": "v1.0"}]}
+
+        component_config = {}
+
+        with patch("agentic_ci.branch.validate_branch_exists") as mock_validate:
+            mock_validate.return_value = True
+            result = resolve_branch_from_jira(
+                ticket,
+                component_config,
+                repo_url="https://github.com/test/repo.git",
+            )
+
+        assert result == "v1.0"
+        mock_validate.assert_called_once_with("https://github.com/test/repo.git", "v1.0")
+
+    def test_with_repo_url_validation_fails(self):
+        """Should return None when validation fails."""
+        ticket = {"fixVersions": [{"name": "v1.0"}]}
+
+        component_config = {}
+
+        with patch("agentic_ci.branch.validate_branch_exists") as mock_validate:
+            mock_validate.return_value = False
+            result = resolve_branch_from_jira(
+                ticket,
+                component_config,
+                repo_url="https://github.com/test/repo.git",
+            )
+
+        assert result is None
+        mock_validate.assert_called_once_with("https://github.com/test/repo.git", "v1.0")
+
+    def test_no_repo_url_skips_validation(self):
+        """Should skip validation and return branch when no repo_url provided."""
+        ticket = {"fixVersions": [{"name": "v1.0"}]}
+
+        component_config = {}
+
+        with patch("agentic_ci.branch.validate_branch_exists") as mock_validate:
+            result = resolve_branch_from_jira(ticket, component_config, repo_url=None)
+
+        assert result == "v1.0"
+        mock_validate.assert_not_called()
+
+    def test_multiple_fixversions_uses_first(self):
+        """Should use only the first fixVersion when multiple exist."""
+        ticket = {
+            "fixVersions": [
+                {"name": "v2.0"},
+                {"name": "v1.0"},
+            ]
+        }
+
+        component_config = {}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "v2.0"
+
+    def test_version_branches_preferred_over_static_branch(self):
+        """Should use version_branches override even when static branch exists."""
+        ticket = {"fixVersions": [{"name": "2.0"}]}
+
+        component_config = {
+            "version_branches": {"2.0": "release/2.0.x"},
+            "branch": "main",
+        }
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "release/2.0.x"
+
+    def test_fixversion_preferred_over_static_branch(self):
+        """Should use fixVersion even when static branch exists."""
+        ticket = {"fixVersions": [{"name": "v3.0"}]}
+
+        component_config = {"branch": "main"}
+
+        result = resolve_branch_from_jira(ticket, component_config)
+        assert result == "v3.0"
+
+
+class TestBranchResolutionError:
+    """Test BranchResolutionError exception class."""
+
+    def test_is_exception(self):
+        """Should be a proper Exception subclass."""
+        assert issubclass(BranchResolutionError, Exception)
+
+    def test_can_be_raised(self):
+        """Should be raiseable and catchable."""
+        with pytest.raises(BranchResolutionError, match="test error"):
+            raise BranchResolutionError("test error")
+
+    def test_can_be_instantiated(self):
+        """Should be instantiable with a message."""
+        error = BranchResolutionError("something went wrong")
+        assert str(error) == "something went wrong"


### PR DESCRIPTION
## Summary

- Add `agentic_ci.branch` module with `resolve_branch_from_jira()`, `validate_branch_exists()`, and `BranchResolutionError`
- Resolution chain: fixVersion → version_branches map → direct fixVersion → static branch field → None
- Validates resolved branch exists on remote via `git ls-remote`
- Imports `_validate_ref` from `git.py` (no duplication)

## Test plan

- [x] 28 unit tests covering all resolution paths, edge cases, and validation
- [x] `tox -e py313 -e lint -e check-format` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CI now derives target branches from Jira fix versions and optionally verifies the branch exists in the remote repository.
  * Branch name validation added to reject unsafe or malformed branch refs.

* **Tests**
  * Comprehensive unit tests covering branch resolution logic, remote validation behavior, and validation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->