### PR TITLE
Fix GitHub comment filtering and CI status detection

### DIFF
--- a/src/agentic_ci/forge/github.py
+++ b/src/agentic_ci/forge/github.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import time
+from datetime import datetime
 from pathlib import Path
 
 import requests
@@ -77,7 +78,12 @@ class GitHubForge(Forge):
         pipeline_status = "unknown"
         if head_sha:
             check_runs, accessible = self.check_runs(repo_path, head_sha)
-            pipeline_status = _derive_pipeline_status(check_runs, accessible)
+            statuses = self.commit_statuses(repo_path, head_sha)
+            pipeline_status = _derive_pipeline_status(
+                check_runs,
+                accessible,
+                commit_statuses=statuses,
+            )
         return {
             "state": state,
             "source_branch": pr.get("head", {}).get("ref", ""),
@@ -174,6 +180,12 @@ class GitHubForge(Forge):
         params: dict = {"per_page": 100}
         if since:
             params["since"] = since
+        since_dt = None
+        if since:
+            try:
+                since_dt = datetime.fromisoformat(since.replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                pass
         comments = []
         page = 1
         while True:
@@ -191,6 +203,15 @@ class GitHubForge(Forge):
                 body = c.get("body", "")
                 if any(pat in body for pat in skip_patterns):
                     continue
+                if since_dt:
+                    created = c.get("created_at", "")
+                    if created:
+                        try:
+                            created_dt = datetime.fromisoformat(created.replace("Z", "+00:00"))
+                            if created_dt < since_dt:
+                                continue
+                        except (ValueError, TypeError):
+                            pass
                 comments.append(
                     {
                         "author": c.get("user", {}).get("login", "Unknown"),
@@ -237,10 +258,26 @@ class GitHubForge(Forge):
         if not head_sha:
             return {"pipeline_status": "none", "failed_jobs": []}
         check_runs, accessible = self.check_runs(repo_path, head_sha)
-        pipeline_status = _derive_pipeline_status(check_runs, accessible)
+        statuses = self.commit_statuses(repo_path, head_sha)
+        pipeline_status = _derive_pipeline_status(
+            check_runs,
+            accessible,
+            commit_statuses=statuses,
+        )
         if pipeline_status in ("success", "none", "running", "unknown"):
             return {"pipeline_status": pipeline_status, "failed_jobs": []}
         failed_jobs = []
+        for s in statuses:
+            if _STATUS_STATE_MAP.get(s.get("state", "")) == "failure":
+                context = s.get("context", "unknown")
+                target_url = s.get("target_url", "")
+                description = s.get("description", "")
+                log_text = f"Status: {s.get('state')}\nContext: {context}"
+                if description:
+                    log_text += f"\nDescription: {description}"
+                if target_url:
+                    log_text += f"\nDetails: {target_url}"
+                failed_jobs.append({"name": context, "id": s.get("id", 0), "log": log_text})
         for cr in check_runs:
             if cr.get("status") != "completed":
                 continue
@@ -306,6 +343,47 @@ class GitHubForge(Forge):
             page += 1
         return all_runs, True
 
+    def commit_statuses(self, repo_path: str, sha: str) -> list[dict]:
+        """Fetch commit statuses for a SHA.
+
+        GitHub has two parallel CI reporting mechanisms: Check Runs
+        (used by GitHub Actions) and Commit Statuses (the older API
+        used by external CI like Prow, Jenkins, and other integrations).
+        ``check_runs()`` only covers the first; this method covers the
+        second so ``_derive_pipeline_status()`` sees the full picture.
+
+        Merge-management contexts (``tide``, ``Mergify``) are excluded
+        since they reflect merge policy, not CI results.
+
+        See https://docs.github.com/en/rest/commits/statuses
+        """
+        all_statuses: list[dict] = []
+        page = 1
+        while True:
+            resp = self._session.get(
+                f"https://api.github.com/repos/{repo_path}/commits/{sha}/statuses",
+                params={"per_page": 100, "page": page},
+            )
+            if resp.status_code == 403:
+                log.debug("statuses not accessible for %s: %s", sha, resp.text)
+                return []
+            if resp.status_code != 200:
+                log.warning("HTTP %d fetching commit statuses: %s", resp.status_code, resp.text)
+                return []
+            batch = resp.json()
+            if not batch:
+                break
+            all_statuses.extend(batch)
+            if len(batch) < 100:
+                break
+            page += 1
+        seen: dict[str, dict] = {}
+        for s in all_statuses:
+            ctx = s.get("context", "")
+            if ctx not in seen:
+                seen[ctx] = s
+        return [s for s in seen.values() if not _is_merge_management_status(s.get("context", ""))]
+
 
 _FAILED_CONCLUSIONS = frozenset(
     {
@@ -318,20 +396,53 @@ _FAILED_CONCLUSIONS = frozenset(
 )
 _PASSED_CONCLUSIONS = frozenset({"success", "neutral", "skipped"})
 
+_MERGE_MGMT_PATTERNS = re.compile(
+    r"^(tide$|Mergify)",
+    re.IGNORECASE,
+)
 
-def _derive_pipeline_status(check_runs: list[dict], accessible: bool = True) -> str:
-    """Derive overall pipeline status from GitHub check runs."""
+
+def _is_merge_management_status(context: str) -> bool:
+    """Return True for merge-management contexts (tide, Mergify)."""
+    return bool(_MERGE_MGMT_PATTERNS.search(context))
+
+
+_STATUS_STATE_MAP = {"success": "success", "failure": "failure", "error": "failure"}
+
+
+def _derive_pipeline_status(
+    check_runs: list[dict],
+    accessible: bool = True,
+    commit_statuses: list[dict] | None = None,
+) -> str:
+    """Derive overall pipeline status from check runs and commit statuses."""
     if not accessible:
         return "unknown"
-    if not check_runs:
+    if not check_runs and not commit_statuses:
         return "none"
     for cr in check_runs:
         if cr.get("status") != "completed":
             return "running"
+    for s in commit_statuses or []:
+        if s.get("state") == "pending":
+            return "running"
     for cr in check_runs:
         if cr.get("conclusion") in _FAILED_CONCLUSIONS:
             return "failed"
-    if all(cr.get("conclusion") in _PASSED_CONCLUSIONS for cr in check_runs):
+    for s in commit_statuses or []:
+        if _STATUS_STATE_MAP.get(s.get("state", "")) == "failure":
+            return "failed"
+    all_passed = (
+        all(cr.get("conclusion") in _PASSED_CONCLUSIONS for cr in check_runs)
+        if check_runs
+        else True
+    )
+    statuses_passed = (
+        all(s.get("state") == "success" for s in (commit_statuses or []))
+        if commit_statuses
+        else True
+    )
+    if all_passed and statuses_passed:
         return "success"
     return "unknown"
 

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agentic_ci.forge import ForgeError
-from agentic_ci.forge.github import GitHubForge, _derive_pipeline_status
+from agentic_ci.forge.github import (
+    GitHubForge,
+    _derive_pipeline_status,
+    _is_merge_management_status,
+)
 
 
 @pytest.fixture()
@@ -110,7 +114,8 @@ class TestMrStatus:
                 ]
             },
         )
-        mock_session.get.side_effect = [pr_resp, check_runs_resp]
+        statuses_resp = _make_response(200, [])
+        mock_session.get.side_effect = [pr_resp, check_runs_resp, statuses_resp]
 
         result = forge.mr_status("https://github.com/owner/repo/pull/10")
         assert result["state"] == "open"
@@ -127,7 +132,8 @@ class TestMrStatus:
             },
         )
         check_runs_resp = _make_response(200, {"check_runs": []})
-        mock_session.get.side_effect = [pr_resp, check_runs_resp]
+        statuses_resp = _make_response(200, [])
+        mock_session.get.side_effect = [pr_resp, check_runs_resp, statuses_resp]
 
         result = forge.mr_status("https://github.com/owner/repo/pull/10")
         assert result["state"] == "merged"
@@ -250,6 +256,58 @@ class TestGeneralComments:
         assert len(comments) == 1
         assert comments[0]["body"] == "Keep this one"
 
+    def test_since_filters_by_created_at(self, forge, mock_session):
+        """Comments created before ``since`` are excluded even if updated after."""
+        page1 = _make_response(
+            200,
+            [
+                {
+                    "body": "Old comment, recently updated",
+                    "user": {"login": "coderabbitai[bot]"},
+                    "created_at": "2025-01-01T00:00:00Z",
+                    "updated_at": "2025-06-10T00:00:00Z",
+                },
+                {
+                    "body": "New feedback",
+                    "user": {"login": "reviewer"},
+                    "created_at": "2025-06-05T12:00:00Z",
+                    "updated_at": "2025-06-05T12:00:00Z",
+                },
+            ],
+        )
+        mock_session.get.return_value = page1
+
+        comments = forge.general_comments(
+            "https://github.com/owner/repo/pull/5",
+            since="2025-06-01T00:00:00+00:00",
+        )
+        assert len(comments) == 1
+        assert comments[0]["body"] == "New feedback"
+
+    def test_since_none_returns_all(self, forge, mock_session):
+        page1 = _make_response(
+            200,
+            [
+                {
+                    "body": "Old comment",
+                    "user": {"login": "user1"},
+                    "created_at": "2025-01-01T00:00:00Z",
+                },
+                {
+                    "body": "New comment",
+                    "user": {"login": "user2"},
+                    "created_at": "2025-06-05T00:00:00Z",
+                },
+            ],
+        )
+        mock_session.get.return_value = page1
+
+        comments = forge.general_comments(
+            "https://github.com/owner/repo/pull/5",
+            since=None,
+        )
+        assert len(comments) == 2
+
 
 class TestReply:
     def test_calls_graphql_mutation(self, forge, mock_session):
@@ -310,9 +368,10 @@ class TestPipelineFailures:
                 ]
             },
         )
+        statuses_resp = _make_response(200, [])
         log_resp = _make_response(200)
         log_resp.text = "ERROR: test_foo failed"
-        mock_session.get.side_effect = [pr_resp, check_runs_resp, log_resp]
+        mock_session.get.side_effect = [pr_resp, check_runs_resp, statuses_resp, log_resp]
 
         result = forge.pipeline_failures("https://github.com/owner/repo/pull/5")
         assert result["pipeline_status"] == "failed"
@@ -338,7 +397,8 @@ class TestPipelineFailures:
                 ]
             },
         )
-        mock_session.get.side_effect = [pr_resp, check_runs_resp]
+        statuses_resp = _make_response(200, [])
+        mock_session.get.side_effect = [pr_resp, check_runs_resp, statuses_resp]
 
         result = forge.pipeline_failures("https://github.com/owner/repo/pull/5")
         assert result["pipeline_status"] == "success"
@@ -369,6 +429,59 @@ class TestCheckRuns:
         mock_session.get.return_value = _make_response(500, text="Server error")
         with pytest.raises(ForgeError, match="HTTP 500"):
             forge.check_runs("owner/repo", "sha123")
+
+
+class TestCommitStatuses:
+    def test_returns_filtered_statuses(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(
+            200,
+            [
+                {"id": 1, "context": "Cypress E2E Tests", "state": "failure"},
+                {"id": 2, "context": "tide", "state": "pending"},
+                {"id": 3, "context": "CodeRabbit", "state": "success"},
+            ],
+        )
+        statuses = forge.commit_statuses("owner/repo", "sha123")
+        contexts = [s["context"] for s in statuses]
+        assert "Cypress E2E Tests" in contexts
+        assert "CodeRabbit" in contexts
+        assert "tide" not in contexts
+
+    def test_deduplicates_by_context(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(
+            200,
+            [
+                {"id": 2, "context": "ci/test", "state": "success"},
+                {"id": 1, "context": "ci/test", "state": "failure"},
+            ],
+        )
+        statuses = forge.commit_statuses("owner/repo", "sha123")
+        assert len(statuses) == 1
+        assert statuses[0]["state"] == "success"
+
+    def test_handles_403(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(403, text="Forbidden")
+        statuses = forge.commit_statuses("owner/repo", "sha123")
+        assert statuses == []
+
+    def test_handles_error(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(500, text="Error")
+        statuses = forge.commit_statuses("owner/repo", "sha123")
+        assert statuses == []
+
+
+class TestMergeManagementStatus:
+    def test_tide_is_merge_management(self):
+        assert _is_merge_management_status("tide") is True
+
+    def test_mergify_is_merge_management(self):
+        assert _is_merge_management_status("Mergify Merge Protections") is True
+        assert _is_merge_management_status("Mergify — Summary") is True
+
+    def test_ci_is_not_merge_management(self):
+        assert _is_merge_management_status("Cypress E2E Tests") is False
+        assert _is_merge_management_status("CodeRabbit") is False
+        assert _is_merge_management_status("ci/build") is False
 
 
 class TestDerivePipelineStatus:
@@ -419,6 +532,63 @@ class TestDerivePipelineStatus:
     def test_unknown_conclusion(self):
         runs = [{"status": "completed", "conclusion": "some_new_state"}]
         assert _derive_pipeline_status(runs) == "unknown"
+
+    def test_commit_status_failure(self):
+        runs = [{"status": "completed", "conclusion": "success"}]
+        statuses = [{"context": "Cypress E2E", "state": "failure"}]
+        assert _derive_pipeline_status(runs, commit_statuses=statuses) == "failed"
+
+    def test_commit_status_pending_is_running(self):
+        runs = [{"status": "completed", "conclusion": "success"}]
+        statuses = [{"context": "ci/test", "state": "pending"}]
+        assert _derive_pipeline_status(runs, commit_statuses=statuses) == "running"
+
+    def test_commit_status_error_is_failed(self):
+        runs = [{"status": "completed", "conclusion": "success"}]
+        statuses = [{"context": "ci/test", "state": "error"}]
+        assert _derive_pipeline_status(runs, commit_statuses=statuses) == "failed"
+
+    def test_all_success_with_statuses(self):
+        runs = [{"status": "completed", "conclusion": "success"}]
+        statuses = [{"context": "ci/test", "state": "success"}]
+        assert _derive_pipeline_status(runs, commit_statuses=statuses) == "success"
+
+    def test_no_check_runs_with_failing_status(self):
+        statuses = [{"context": "Cypress E2E", "state": "failure"}]
+        assert _derive_pipeline_status([], commit_statuses=statuses) == "failed"
+
+    def test_no_check_runs_with_passing_status(self):
+        statuses = [{"context": "ci/test", "state": "success"}]
+        assert _derive_pipeline_status([], commit_statuses=statuses) == "success"
+
+
+class TestPipelineFailuresWithStatuses:
+    def test_includes_failed_commit_statuses(self, forge, mock_session):
+        pr_resp = _make_response(200, {"head": {"sha": "abc123"}})
+        check_runs_resp = _make_response(
+            200,
+            {"check_runs": [{"status": "completed", "conclusion": "success"}]},
+        )
+        statuses_resp = _make_response(
+            200,
+            [
+                {
+                    "id": 10,
+                    "context": "Cypress E2E Tests",
+                    "state": "failure",
+                    "description": "4 tests failed",
+                    "target_url": "https://example.com/run/1",
+                },
+                {"id": 11, "context": "tide", "state": "pending"},
+            ],
+        )
+        mock_session.get.side_effect = [pr_resp, check_runs_resp, statuses_resp]
+
+        result = forge.pipeline_failures("https://github.com/owner/repo/pull/5")
+        assert result["pipeline_status"] == "failed"
+        assert len(result["failed_jobs"]) == 1
+        assert result["failed_jobs"][0]["name"] == "Cypress E2E Tests"
+        assert "4 tests failed" in result["failed_jobs"][0]["log"]
 
 
 class TestFindPrivateKey:


### PR DESCRIPTION
## Summary

- **Comment filtering**: GitHub's `since` API parameter filters by `updated_at`, not `created_at`. Bot comments from CodeRabbit and Codecov auto-update on each push, causing them to reappear as "new feedback" in iterations even though they were created days ago. Added client-side `created_at` filtering to match GitLab's behavior.
- **CI status detection**: Pipeline status only checked the Check Runs API, missing CI systems that report via commit statuses (Prow/tide, Cypress E2E Tests). Added `commit_statuses()` method to also query the Status API. Merge-management contexts (`tide`, `Mergify`) are excluded.

Observed on https://github.com/opendatahub-io/odh-dashboard/pull/7868 (RHOAIENG-66493):
- 83 check runs all passing, but 3 commit statuses had `failure` (Cypress E2E) and `pending` (tide)
- 2 "general comments" from 4 days ago were picked up because CodeRabbit/Codecov updated their comments today

## Test plan

- [x] All existing tests updated for new `commit_statuses()` call
- [x] New tests: `created_at` filtering, commit status integration, merge-management filtering, pipeline status with statuses
- [x] `tox -e py313,lint,check-format,typecheck` all pass
- [x] autofix package tests also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pipeline status detection using multiple sources for improved accuracy
  * Added date-based filtering capability for comments
  * Expanded failure detection to capture additional failure states in pipeline reporting

* **Tests**
  * Comprehensive test coverage added for new status detection and comment filtering features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->