### PR TITLE
Add strip_committed_files() to remove artifact files from commits

### DIFF
--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -6,6 +6,7 @@ All operations use subprocess calls to git.
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import os
 import re
@@ -458,6 +459,55 @@ def get_changed_files(repo_dir: Path, base_ref: str = "HEAD~1") -> list[str]:
         raise GitDiffError(
             f"git diff failed for base_ref={base_ref}: {exc.stderr.strip()}"
         ) from exc
+
+
+def strip_committed_files(
+    repo_dir: Path,
+    patterns: list[str],
+    base_ref: str = "origin/HEAD",
+) -> list[str]:
+    """Remove files matching *patterns* from the latest commit.
+
+    Agents can bypass ``.git/info/exclude`` by explicitly naming files in
+    ``git add``.  This function detects any committed files that match the
+    given fnmatch *patterns* and amends the commit to remove them, keeping
+    the working-tree copies intact.
+
+    Returns the list of file paths that were stripped (empty if none matched).
+    """
+    try:
+        changed = get_changed_files(repo_dir, base_ref=base_ref)
+    except GitDiffError:
+        return []
+
+    to_remove = []
+    for filepath in changed:
+        name = Path(filepath).name
+        for pattern in patterns:
+            if fnmatch.fnmatch(name, pattern) or fnmatch.fnmatch(filepath, pattern):
+                to_remove.append(filepath)
+                break
+
+    if not to_remove:
+        return []
+
+    log.warning(
+        "Stripping %d artifact file(s) from commit: %s",
+        len(to_remove),
+        ", ".join(to_remove),
+    )
+    for filepath in to_remove:
+        subprocess.run(
+            ["git", "rm", "--cached", "--quiet", filepath],
+            cwd=str(repo_dir),
+            capture_output=True,
+        )
+    subprocess.run(
+        ["git", "commit", "--amend", "--no-edit", "--allow-empty"],
+        cwd=str(repo_dir),
+        capture_output=True,
+    )
+    return to_remove
 
 
 # -- Git credential setup ----------------------------------------------------

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,7 +4,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from agentic_ci.git import checkout_branch, get_default_branch, git_output
+from agentic_ci.git import checkout_branch, get_default_branch, git_output, strip_committed_files
 
 
 class TestCheckoutBranch:
@@ -96,3 +96,90 @@ class TestGitOutput:
             git_output(tmp_path, "log", "--oneline", "-5")
             args = mock_run.call_args
             assert args[0][0] == ["git", "log", "--oneline", "-5"]
+
+
+def _init_repo(path: Path) -> Path:
+    """Create a minimal git repo with one commit and an origin/HEAD ref."""
+    subprocess.run(["git", "init", str(path)], capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=str(path), capture_output=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(path), capture_output=True)
+    (path / "README.md").write_text("init\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(path), capture_output=True, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(path), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(path)], cwd=str(path), capture_output=True
+    )
+    subprocess.run(
+        ["git", "update-ref", "refs/remotes/origin/HEAD", "HEAD"],
+        cwd=str(path),
+        capture_output=True,
+        check=True,
+    )
+    return path
+
+
+class TestStripCommittedFiles:
+    def test_removes_matching_files_from_commit(self, tmp_path: Path):
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "autofix-output").mkdir()
+        (repo / "autofix-output" / "verdict.json").write_text("{}")
+        (repo / "fix.py").write_text("print('fix')\n")
+        subprocess.run(
+            ["git", "add", "-f", "autofix-output/verdict.json", "fix.py"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "fix"], cwd=str(repo), capture_output=True, check=True
+        )
+
+        stripped = strip_committed_files(repo, ["autofix-output/*"])
+
+        assert stripped == ["autofix-output/verdict.json"]
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "origin/HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        changed = [f for f in result.stdout.strip().split("\n") if f]
+        assert "fix.py" in changed
+        assert "autofix-output/verdict.json" not in changed
+
+    def test_noop_when_no_matches(self, tmp_path: Path):
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "fix.py").write_text("print('fix')\n")
+        subprocess.run(["git", "add", "fix.py"], cwd=str(repo), capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "fix"], cwd=str(repo), capture_output=True, check=True
+        )
+
+        stripped = strip_committed_files(repo, ["autofix-output/*"])
+
+        assert stripped == []
+
+    def test_preserves_working_tree_copy(self, tmp_path: Path):
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "output").mkdir()
+        verdict = repo / "output" / "result.json"
+        verdict.write_text("{}")
+        subprocess.run(
+            ["git", "add", "-f", "output/result.json"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "with output"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+
+        strip_committed_files(repo, ["output/*"])
+
+        assert verdict.exists()


### PR DESCRIPTION
## Summary

- Adds `strip_committed_files(repo_dir, patterns, base_ref)` to `agentic_ci.git` that detects committed files matching fnmatch patterns and amends them out of the commit, keeping working-tree copies intact
- Generic and reusable: callers pass their own patterns (e.g. scaffold artifact globs), not tied to any specific skill
- 3 tests covering: stripping matching files, no-op when clean, working-tree preservation

## Problem

Agents can bypass `.git/info/exclude` by explicitly running `git add <file>` on an ignored path. Once tracked, gitignore no longer protects the file. This caused a [pipeline failure](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14750658123) when `autofix-output/.autofix-verdict.json` ended up in the source commit and the sensitive-files post-gate blocked it.

## Approach

A deterministic code-level fix. The autofix runner (or any skill runner) calls `strip_committed_files()` with the scaffold artifact patterns after the container exits and before post-gates validate the commit. The function uses the same fnmatch logic as `check_sensitive_files()` to identify matches, then `git rm --cached` + `git commit --amend` to strip them.

## Test plan

- [x] `test_removes_matching_files_from_commit` -- verifies artifact is stripped, source file remains
- [x] `test_noop_when_no_matches` -- no commit amendment when nothing matches
- [x] `test_preserves_working_tree_copy` -- working-tree file preserved after stripping from commit
- [x] `tox -e py,lint,check-format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)