### PR TITLE
Add update_comment, expand/rule ADF nodes, and comment ID exposure

### DIFF
--- a/src/agentic_ci/jira/adf.py
+++ b/src/agentic_ci/jira/adf.py
@@ -14,6 +14,8 @@ def text_to_adf(text: str) -> dict:
 
     Handles:
     - ```lang ... ``` fenced code blocks -> codeBlock nodes
+    - {expand:Title}...{expand} -> expand nodes (collapsible sections)
+    - ---- or --- on a line by itself -> rule nodes (horizontal dividers)
     - # through ###### headings -> heading nodes
     - - bullets -> bulletList nodes
     - **bold** and *italic* inline markup
@@ -24,32 +26,51 @@ def text_to_adf(text: str) -> dict:
         return {"type": "doc", "version": 1, "content": []}
 
     content: list[dict] = []
-    code_pattern = re.compile(r"```(\w*)\n(.*?)```", re.DOTALL)
+    block_pattern = re.compile(
+        r"```(\w*)\n(.*?)```"
+        r"|"
+        r"\{expand:([^}]*)\}\n?(.*?)\n?\{expand\}",
+        re.DOTALL,
+    )
 
     last_end = 0
-    for match in code_pattern.finditer(text):
+    for match in block_pattern.finditer(text):
         before = text[last_end : match.start()]
         if before.strip():
-            content.extend(_markdown_text_to_adf_blocks(before))
-        code_text = match.group(2)
-        if code_text.endswith("\n"):
-            code_text = code_text[:-1]
-        lang = match.group(1) or ""
-        node: dict = {"type": "text", "text": code_text}
-        block: dict = {"type": "codeBlock", "content": [node]}
-        if lang:
-            block["attrs"] = {"language": lang}
-        content.append(block)
+            content.extend(_markdown_text_to_adf_blocks(before.strip()))
+
+        if match.group(2) is not None:
+            code_text = match.group(2)
+            if code_text.endswith("\n"):
+                code_text = code_text[:-1]
+            lang = match.group(1) or ""
+            node: dict = {"type": "text", "text": code_text}
+            block: dict = {"type": "codeBlock", "content": [node]}
+            if lang:
+                block["attrs"] = {"language": lang}
+            content.append(block)
+        else:
+            title = match.group(3) or ""
+            inner_text = match.group(4) or ""
+            inner_blocks = text_to_adf(inner_text).get("content", []) if inner_text.strip() else []
+            expand_node: dict = {"type": "expand", "attrs": {"title": title}}
+            if inner_blocks:
+                expand_node["content"] = inner_blocks
+            content.append(expand_node)
+
         last_end = match.end()
 
     remaining = text[last_end:]
     if remaining.strip():
-        content.extend(_markdown_text_to_adf_blocks(remaining))
+        content.extend(_markdown_text_to_adf_blocks(remaining.strip()))
 
     if not content:
         content.append({"type": "paragraph", "content": [{"type": "text", "text": ""}]})
 
     return {"type": "doc", "version": 1, "content": content}
+
+
+_RULE_RE = re.compile(r"^-{3,}$")
 
 
 def _markdown_text_to_adf_blocks(text: str) -> list[dict]:
@@ -71,7 +92,15 @@ def _markdown_text_to_adf_blocks(text: str) -> list[dict]:
             m_h = heading_re.match(stripped)
             m_b = bullet_re.match(stripped)
 
-            if m_h:
+            if _RULE_RE.match(stripped):
+                if pending_bullets:
+                    blocks.append(_bullets_to_list(pending_bullets))
+                    pending_bullets = []
+                if pending_lines:
+                    blocks.append(_lines_to_paragraph(pending_lines))
+                    pending_lines = []
+                blocks.append({"type": "rule"})
+            elif m_h:
                 if pending_bullets:
                     blocks.append(_bullets_to_list(pending_bullets))
                     pending_bullets = []
@@ -186,6 +215,12 @@ def adf_to_text(adf: dict) -> str:
         elif node_type == "blockquote":
             lines = extract_children(node).rstrip("\n").split("\n")
             return "\n".join(f"> {line}" for line in lines) + "\n"
+        elif node_type == "expand":
+            title = node.get("attrs", {}).get("title", "")
+            inner = extract_children(node).rstrip("\n")
+            return f"{{expand:{title}}}\n{inner}\n{{expand}}\n"
+        elif node_type == "rule":
+            return "----\n"
         elif node_type == "doc":
             return extract_children(node)
         else:

--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -284,6 +284,7 @@ class JiraClient:
             body = adf_to_text(body_field) if isinstance(body_field, dict) else body_field
             comments.append(
                 {
+                    "id": c.get("id", ""),
                     "author": c.get("author", {}).get("displayName", "Unknown"),
                     "author_email": c.get("author", {}).get("emailAddress", ""),
                     "body": body,
@@ -332,6 +333,7 @@ class JiraClient:
                     body = adf_to_text(body_field) if isinstance(body_field, dict) else body_field
                     comments.append(
                         {
+                            "id": c.get("id", ""),
                             "author": c.get("author", {}).get("displayName", "Unknown"),
                             "author_email": c.get("author", {}).get("emailAddress", ""),
                             "body": body,
@@ -564,6 +566,63 @@ class JiraClient:
             log.info("Commented on %s", key)
             return True
         log.warning("Failed to comment on %s: HTTP %d", key, resp.status_code)
+        return False
+
+    def update_comment(
+        self,
+        key: str,
+        comment_id: str,
+        body: str,
+        *,
+        visibility_group: str | None = None,
+    ) -> bool:
+        """Update an existing comment by ID.
+
+        Same ADF conversion and visibility semantics as ``add_comment``.
+        Returns True on success, False on failure.
+        """
+        if self._acli_available and not visibility_group:
+            import tempfile
+
+            adf_json = json.dumps(text_to_adf(body))
+            try:
+                with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
+                    tmp.write(adf_json)
+                    tmp_path = tmp.name
+                try:
+                    acli_mod.run_acli(
+                        "jira",
+                        "workitem",
+                        "comment",
+                        "update",
+                        "--key",
+                        key,
+                        "--id",
+                        comment_id,
+                        "--body-adf",
+                        tmp_path,
+                    )
+                finally:
+                    os.unlink(tmp_path)
+                log.info("Updated comment %s on %s (via acli)", comment_id, key)
+                return True
+            except acli_mod.AcliError as exc:
+                log.warning("acli update_comment failed, falling back to REST: %s", exc)
+
+        payload: dict = {"body": text_to_adf(body)}
+        if visibility_group:
+            payload["visibility"] = {"type": "group", "value": visibility_group}
+
+        resp = self._request(
+            "put",
+            self._api_url(f"issue/{key}/comment/{comment_id}"),
+            headers=self._headers(),
+            json=payload,
+        )
+        if resp.status_code == 200:
+            log.info("Updated comment %s on %s", comment_id, key)
+            return True
+        log.warning("Failed to update comment %s on %s: HTTP %d", comment_id, key, resp.status_code)
         return False
 
     def edit_labels(

--- a/tests/test_acli_client.py
+++ b/tests/test_acli_client.py
@@ -121,6 +121,28 @@ class TestCommentAcli:
         assert call_json["visibility"]["value"] == "Red Hat Employee"
 
 
+class TestUpdateCommentAcli:
+    @patch("agentic_ci.jira.client.acli_mod.run_acli")
+    def test_uses_acli_without_visibility(self, mock_run, acli_client):
+        result = acli_client.update_comment("TEST-1", "10001", "Updated text")
+        assert result is True
+        args = mock_run.call_args[0]
+        assert args[:6] == ("jira", "workitem", "comment", "update", "--key", "TEST-1")
+        assert args[6:8] == ("--id", "10001")
+        assert args[8] == "--body-adf"
+        assert args[9].endswith(".json")
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_uses_rest_with_visibility(self, mock_requests, acli_client):
+        resp = MagicMock()
+        resp.status_code = 200
+        mock_requests.put.return_value = resp
+
+        acli_client.update_comment("TEST-1", "10001", "Secret", visibility_group="Red Hat Employee")
+        call_json = mock_requests.put.call_args.kwargs["json"]
+        assert call_json["visibility"]["value"] == "Red Hat Employee"
+
+
 class TestLinkAcli:
     @patch("agentic_ci.jira.client.acli_mod.run_acli")
     def test_uses_acli(self, mock_run, acli_client):

--- a/tests/test_adf.py
+++ b/tests/test_adf.py
@@ -145,6 +145,87 @@ def test_adf_to_text_empty():
     assert adf_to_text(None) == ""
 
 
+def test_expand_block():
+    result = text_to_adf("{expand:Details}\nSome content\n{expand}")
+    expand = result["content"][0]
+    assert expand["type"] == "expand"
+    assert expand["attrs"]["title"] == "Details"
+    assert len(expand["content"]) == 1
+    assert expand["content"][0]["type"] == "paragraph"
+
+
+def test_expand_with_code_block():
+    text = "{expand:Code}\n```python\nx = 1\n```\n{expand}"
+    result = text_to_adf(text)
+    expand = result["content"][0]
+    assert expand["type"] == "expand"
+    code = expand["content"][0]
+    assert code["type"] == "codeBlock"
+    assert code["attrs"]["language"] == "python"
+    assert code["content"][0]["text"] == "x = 1"
+
+
+def test_expand_empty():
+    result = text_to_adf("{expand:Empty}\n{expand}")
+    expand = result["content"][0]
+    assert expand["type"] == "expand"
+    assert "content" not in expand
+
+
+def test_rule():
+    result = text_to_adf("----")
+    assert result["content"][0] == {"type": "rule"}
+
+
+def test_rule_three_dashes():
+    result = text_to_adf("---")
+    assert result["content"][0] == {"type": "rule"}
+
+
+def test_adf_to_text_expand():
+    adf = {
+        "type": "doc",
+        "version": 1,
+        "content": [
+            {
+                "type": "expand",
+                "attrs": {"title": "Details"},
+                "content": [
+                    {
+                        "type": "paragraph",
+                        "content": [{"type": "text", "text": "inner"}],
+                    }
+                ],
+            }
+        ],
+    }
+    result = adf_to_text(adf)
+    assert result == "{expand:Details}\ninner\n{expand}"
+
+
+def test_adf_to_text_rule():
+    adf = {
+        "type": "doc",
+        "version": 1,
+        "content": [{"type": "rule"}],
+    }
+    assert adf_to_text(adf) == "----"
+
+
+def test_roundtrip_expand():
+    text = "{expand:My Section}\nHello world\n{expand}"
+    adf = text_to_adf(text)
+    recovered = adf_to_text(adf)
+    assert recovered == text
+
+
+def test_roundtrip_rule():
+    text = "----"
+    adf = text_to_adf(text)
+    recovered = adf_to_text(adf)
+    assert recovered == text
+
+
 def test_roundtrip_plain():
     text = "Simple paragraph"
     adf = text_to_adf(text)

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -168,6 +168,34 @@ class TestAddComment:
         assert client.add_comment("TEST-1", "Nope") is False
 
 
+class TestUpdateComment:
+    @patch("agentic_ci.jira.client.requests")
+    def test_update_success(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        mock_requests.put.return_value = resp
+
+        assert client.update_comment("TEST-1", "10001", "Updated text") is True
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_update_with_visibility(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        mock_requests.put.return_value = resp
+
+        client.update_comment("TEST-1", "10001", "Internal", visibility_group="Red Hat Employee")
+        call_json = mock_requests.put.call_args.kwargs["json"]
+        assert call_json["visibility"]["value"] == "Red Hat Employee"
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_update_failure(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 403
+        mock_requests.put.return_value = resp
+
+        assert client.update_comment("TEST-1", "10001", "Nope") is False
+
+
 class TestTransition:
     @patch("agentic_ci.jira.client.requests")
     def test_transition_success(self, mock_requests, client):


### PR DESCRIPTION
## Description
Support collapsible sections ({expand:Title}...{expand}) and horizontal rules (---/----) in ADF conversion. Expand inner content is processed through the full text_to_adf pipeline so code blocks and nested structures render correctly inside collapsible sections.

Add update_comment() to JiraClient with acli delegation (using --body-adf for proper ADF rendering) and REST API fallback. Expose comment IDs in _fetch_comments and search results to enable updates.

## How Has This Been Tested?
Test comments submitted to: https://redhat.atlassian.net/browse/TP-5960

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for expandable/collapsible sections and horizontal rules in Jira comments for improved formatting and content organization
  * Users can now update existing Jira comments with optional visibility settings for better comment management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->