### PR TITLE
Verify verdict file exists before promoting SIGKILL to success

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,7 @@ Fix any failures before moving on. Do not skip any of these checks.
 
 - Python 3.10+, uv for local dev. Minimal runtime dependencies (`requests`, `tenacity`).
 - `ruff` for lint and format. Config in `pyproject.toml`. `tox` orchestrates all checks.
+- Always place imports at the top of the file. No function-level or inline imports.
 - Fix lint errors at the source. Don't suppress with `# noqa` or exclude files from linting.
 - All tests live under `tests/`.
 - `pytest` for tests.

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -7,6 +7,7 @@ import sys
 import threading
 import time
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentic_ci import log
@@ -26,6 +27,7 @@ class Backend(ABC):
         self.workdir = os.path.abspath(workdir)
         self.image = image
         self.harness = harness
+        self.verdict_path: Path | None = None
 
     @abstractmethod
     def setup(self):
@@ -94,8 +96,14 @@ class Backend(ABC):
             processor.flush_errors()
 
         if stream_complete and rc != 0:
-            log.info(f"stream processor detected run complete (rc={rc}), treating as success")
-            rc = 0
+            if self.verdict_path is not None and not self.verdict_path.exists():
+                log.info(
+                    f"stream completed (rc={rc}) but verdict file "
+                    f"{self.verdict_path} missing; keeping original exit code"
+                )
+            else:
+                log.info(f"stream processor detected run complete (rc={rc}), treating as success")
+                rc = 0
 
         if rc != 0 and stderr_buf:
             filtered = self._filter_stderr_noise(stderr_buf)

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -28,6 +28,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable
 
+from agentic_ci.backends.podman import PodmanBackend
+from agentic_ci.harness import ClaudeCodeHarness
+from agentic_ci.otel import parse_metrics
+
 log = logging.getLogger(__name__)
 
 TRANSIENT_EXIT_CODES = frozenset({124, 137, 143})
@@ -82,8 +86,6 @@ def _load_otel_cost(work_dir: Path) -> dict | None:
     if not otel_log.exists():
         return None
     try:
-        from agentic_ci.otel import parse_metrics
-
         records = []
         with open(otel_log, encoding="utf-8") as f:
             for line in f:
@@ -104,14 +106,13 @@ def _load_otel_cost(work_dir: Path) -> dict | None:
         return None
 
 
-def _default_run_container(work_dir, prompt, output_file, *, image=None):
+def _default_run_container(work_dir, prompt, output_file, *, image=None, verdict_path=None):
     """Default container runner using PodmanBackend."""
-    from agentic_ci.backends.podman import PodmanBackend
-    from agentic_ci.harness import ClaudeCodeHarness
-
     harness = ClaudeCodeHarness()
     model = os.environ.get(harness.model_env_var()) or harness.default_model()
     backend = PodmanBackend(workdir=str(work_dir), image=image, harness=harness)
+    if verdict_path is not None:
+        backend.verdict_path = verdict_path
     try:
         backend.setup()
         return backend.run(prompt, model=model)
@@ -205,6 +206,11 @@ def run_skill(
     output_file = work_dir / "agent-output.txt"
 
     runner = config.container_runner or _default_run_container
+    # verdict_path is only passed to the default runner so _process_stream
+    # can verify the verdict file exists before promoting SIGKILL to success.
+    runner_kwargs: dict = {"image": config.container_image}
+    if config.container_runner is None:
+        runner_kwargs["verdict_path"] = config.verdict_path_fn(work_dir)
 
     if dry_run:
         if dry_run_verdict_path:
@@ -213,7 +219,7 @@ def run_skill(
             shutil.copy2(dry_run_verdict_path, verdict_dest)
         rc = 0
     else:
-        rc = runner(work_dir, prompt, output_file, image=config.container_image)
+        rc = runner(work_dir, prompt, output_file, **runner_kwargs)
 
         attempt = 0
         while (
@@ -230,7 +236,7 @@ def run_skill(
                 attempt,
                 config.max_retries,
             )
-            rc = runner(work_dir, prompt, output_file, image=config.container_image)
+            rc = runner(work_dir, prompt, output_file, **runner_kwargs)
 
     if rc != 0:
         log.error("[%s] Container exited with code %d", ticket_key, rc)
@@ -274,12 +280,7 @@ def run_skill(
             verdict_error = exc
             if not dry_run and mode in config.retryable_modes and config.max_retries > 0:
                 log.warning("[%s] Verdict missing (%s), retrying once", ticket_key, exc)
-                rc = runner(
-                    work_dir,
-                    prompt,
-                    output_file,
-                    image=config.container_image,
-                )
+                rc = runner(work_dir, prompt, output_file, **runner_kwargs)
                 if rc != 0:
                     log.error("[%s] Retry container also failed (exit %d)", ticket_key, rc)
                     config.label_applier(

--- a/tests/test_completion_validator.py
+++ b/tests/test_completion_validator.py
@@ -1,0 +1,171 @@
+"""Tests for verdict-path guard on SIGKILL promotion.
+
+When an agent is SIGKILL'd but the stream processor detected completion,
+_process_stream checks whether the verdict file exists before promoting
+the exit code to 0.  If the file is missing, the original exit code is
+preserved so run_skill does not treat the run as successful.
+"""
+
+import io
+import json
+import subprocess
+from unittest import mock
+
+from agentic_ci.backend import Backend
+from agentic_ci.skill import SkillConfig, run_skill
+
+
+class FakeHarness:
+    name = "test"
+    auth_mode = "api-key"
+
+    def create_stream_processor(self, pid=0):
+        return FakeStreamProcessor()
+
+    def model_env_var(self):
+        return "TEST_MODEL"
+
+    def default_model(self):
+        return "test-model"
+
+
+class FakeStreamProcessor:
+    def process_line(self, line):
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return False
+        if msg.get("type") == "user":
+            for block in msg.get("message", {}).get("content", []):
+                if block.get("type") == "tool_result":
+                    content = block.get("content", "")
+                    if isinstance(content, str) and "FULL RUN COMPLETE" in content:
+                        return True
+        return False
+
+    def flush_errors(self):
+        pass
+
+
+class ConcreteBackend(Backend):
+    """Minimal concrete backend for testing _process_stream."""
+
+    def setup(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def run(
+        self, prompt, model, streaming=True, otel_port=None, otel_rate_file=None, extra_args=None
+    ):
+        return 0
+
+
+def _make_proc(stdout_lines, returncode=-9):
+    """Build a mock subprocess.Popen with given stdout and returncode."""
+    proc = mock.MagicMock(spec=subprocess.Popen)
+    proc.pid = 12345
+    encoded_lines = [line.encode("utf-8") for line in stdout_lines]
+    proc.stdout = iter(encoded_lines)
+    proc.stderr = io.BytesIO(b"")
+    proc.returncode = returncode
+    proc.kill = mock.MagicMock()
+    proc.wait = mock.MagicMock()
+    return proc
+
+
+FULL_RUN_MSG = json.dumps(
+    {
+        "type": "user",
+        "message": {"content": [{"type": "tool_result", "content": "FULL RUN COMPLETE"}]},
+    }
+)
+
+
+class TestVerdictPathGuard:
+    def test_no_verdict_path_promotes_rc(self):
+        """Without a verdict_path set, stream_complete promotes rc to 0."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        rc = backend._process_stream(proc, streaming=True)
+        assert rc == 0
+
+    def test_verdict_exists_promotes_rc(self, tmp_path):
+        """With verdict_path pointing to an existing file, rc is promoted to 0."""
+        verdict = tmp_path / "verdict.json"
+        verdict.write_text('{"verdict": "committed"}')
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.verdict_path = verdict
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        rc = backend._process_stream(proc, streaming=True)
+        assert rc == 0
+
+    def test_verdict_missing_keeps_original_rc(self, tmp_path):
+        """With verdict_path pointing to a missing file, original rc is preserved."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.verdict_path = tmp_path / "verdict.json"
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        rc = backend._process_stream(proc, streaming=True)
+        assert rc == -9
+
+    def test_no_stream_complete_no_promotion(self):
+        """Without stream completion, rc is preserved regardless of verdict_path."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.verdict_path = None
+        proc = _make_proc(['{"type": "system"}\n'], returncode=1)
+        rc = backend._process_stream(proc, streaming=True)
+        assert rc == 1
+
+
+class TestRunSkillVerdictWiring:
+    def test_default_runner_receives_verdict_path(self, tmp_path):
+        """run_skill passes verdict_path to the default runner."""
+        received_kwargs = {}
+
+        def capture_runner(work_dir, prompt, output_file, **kwargs):
+            received_kwargs.update(kwargs)
+            (work_dir / "verdict.json").write_text('{"verdict": "committed"}')
+            return 0
+
+        config = SkillConfig(
+            skill_name="test-skill",
+            verdict_path_fn=lambda wd: wd / "verdict.json",
+            verdict_loader=lambda wd: json.loads((wd / "verdict.json").read_text()),
+        )
+
+        with mock.patch("agentic_ci.skill._default_run_container", capture_runner):
+            run_skill(
+                config,
+                ticket_key="TEST-1",
+                work_dir=tmp_path,
+                config_dir=tmp_path,
+                dry_run=False,
+            )
+
+        assert "verdict_path" in received_kwargs
+        assert received_kwargs["verdict_path"] == tmp_path / "verdict.json"
+
+    def test_custom_runner_no_verdict_path(self, tmp_path):
+        """Custom container_runner does not receive verdict_path."""
+        received_kwargs = {}
+
+        def custom_runner(work_dir, prompt, output_file, **kwargs):
+            received_kwargs.update(kwargs)
+            return 0
+
+        config = SkillConfig(
+            skill_name="test-skill",
+            container_runner=custom_runner,
+            verdict_loader=lambda wd: {"verdict": "committed"},
+        )
+
+        run_skill(
+            config,
+            ticket_key="TEST-1",
+            work_dir=tmp_path,
+            config_dir=tmp_path,
+            dry_run=False,
+        )
+
+        assert "verdict_path" not in received_kwargs


### PR DESCRIPTION
## Summary

- Add `verdict_path` attribute to `Backend` — `_process_stream` checks whether the verdict file exists before promoting a non-zero exit code to 0 on stream completion
- `run_skill` wires up the verdict path via `verdict_path_fn` when using the default runner; custom `container_runner` callables are unaffected
- Move function-level imports in `skill.py` to module level
- Add module-level import convention to AGENTS.md

## Context

All 15 agent runs in [pipeline 2580823479](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14723539130) exited with rc=-9 (SIGKILL). The stream processor treated every one as success because agents had already written verdicts before being killed. This blanket override could mask real failures where the agent is killed mid-work before writing a verdict. The stream processor should verify the verdict file exists before promoting to success.

## Impact

That specific pipeline would behave identically with this change: agents had written their verdict files before being killed, so `verdict_path.exists()` returns `True` and `_process_stream` still promotes rc=-9 to 0. The fix protects against the opposite scenario: an agent gets SIGKILL'd mid-work before writing a verdict. Without this guard, that run silently becomes rc=0 and `run_skill` either wastes a retry on the verdict loader or picks up a stale verdict from a previous run. With this guard, the original exit code is preserved and the run fails fast.

## Changes in detail

### `backend.py`

- **`verdict_path` attribute** (`Path | None`, default `None`): added to `Backend.__init__`. When set, `_process_stream` uses it to verify the verdict file exists before promoting rc to 0.
- **Guard in `_process_stream`**: when both `stream_complete` and `rc != 0`, the promotion to `rc = 0` now checks `self.verdict_path`. If the path is set and the file is missing, the original exit code is preserved and a log message includes the missing path. If verdict_path is `None` (backwards compat) or the file exists, promotion proceeds as before.

### `skill.py`

- **Module-level imports**: moved `PodmanBackend`, `ClaudeCodeHarness`, and `parse_metrics` imports from inside `_default_run_container` to the top of the file.
- **`_default_run_container` accepts `verdict_path`**: optional keyword argument sets `backend.verdict_path` before the run, so `_process_stream` can check it.
- **`runner_kwargs` dict in `run_skill`**: verdict_path is only included when using the default runner (`config.container_runner is None`). Custom runners don't receive it since they have different execution semantics and may not use `_process_stream`.

### `tests/test_completion_validator.py` (new)

- **`TestVerdictPathGuard`**: four tests covering the `_process_stream` guard: no verdict_path promotes, verdict exists promotes, verdict missing preserves rc, no stream_complete skips promotion.
- **`TestRunSkillVerdictWiring`**: two tests verifying `run_skill` passes verdict_path to the default runner and omits it for custom runners.

### `AGENTS.md`

- Added import convention: "Always place imports at the top of the file. No function-level or inline imports."

## Test plan

- [x] `_process_stream` without verdict_path still promotes rc (backwards compat)
- [x] `_process_stream` with verdict_path pointing to existing file promotes rc
- [x] `_process_stream` with verdict_path pointing to missing file preserves original rc
- [x] No promotion when stream is not complete
- [x] `run_skill` passes verdict_path to default runner
- [x] Custom `container_runner` does not receive verdict_path
- [x] All 488 tests pass
- [x] Lint, format, and type checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)