### PR TITLE
Stop bypassing container entrypoint in PodmanBackend

### DIFF
--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -98,9 +98,8 @@ class PodmanBackend(Backend):
             *vol_args,
             "--workdir",
             "/workspace",
-            "--entrypoint",
-            "sleep",
             self.image,
+            "sleep",
             str(self.timeout),
         ]
 

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -252,3 +252,39 @@ def test_build_env_args_api_key(monkeypatch, tmp_path, claude_harness):
     assert "ANTHROPIC_API_KEY" in args
     assert "ANTHROPIC_API_KEY=sk-test-key" not in args
     assert "CLAUDE_CODE_USE_VERTEX=1" not in args
+
+
+def test_setup_does_not_override_entrypoint(monkeypatch, tmp_path, claude_harness):
+    """setup() passes sleep as the command, not --entrypoint, so the image entrypoint runs."""
+    import subprocess as _subprocess
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        image="localhost/test:latest",
+        harness=claude_harness,
+    )
+
+    calls = []
+    original_run = _subprocess.run
+
+    def mock_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:2] == ["podman", "rm"]:
+            return _subprocess.CompletedProcess(cmd, 0)
+        if cmd[:2] == ["podman", "run"]:
+            return _subprocess.CompletedProcess(cmd, 0)
+        if cmd[:3] == ["podman", "container", "inspect"]:
+            return _subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+        return original_run(cmd, **kwargs)
+
+    monkeypatch.setattr(_subprocess, "run", mock_run)
+
+    backend.setup()
+
+    run_calls = [c for c in calls if c[:2] == ["podman", "run"]]
+    assert len(run_calls) == 1
+    run_cmd = run_calls[0]
+    assert "--entrypoint" not in run_cmd
+    image_idx = run_cmd.index("localhost/test:latest")
+    assert run_cmd[image_idx + 1] == "sleep"


### PR DESCRIPTION
## Summary

- Remove `--entrypoint sleep` override so the image's real entrypoint runs naturally
- Pass `sleep` as the command argument instead, letting the entrypoint execute its setup (including plugin enablement) before sleeping
- No workarounds needed: env vars from `extra_env` (like `AGENT_ENABLED_PLUGINS`) are already set at container startup, so the entrypoint picks them up

## Related

- Companion to #70 which adds `container_env` to `SkillConfig` for passing env vars into the container

## Test plan

- [x] New test verifies `--entrypoint` is not in the `podman run` command
- [x] Existing tests pass (`tox -e py313`)
- [x] Lint, format, and typecheck all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container initialization to properly respect default entrypoint configuration during startup, improving container reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->