### PR TITLE
Coerce string verdict list fields to arrays instead of rejecting

### DIFF
--- a/src/agentic_ci/verdict.py
+++ b/src/agentic_ci/verdict.py
@@ -9,7 +9,12 @@ handles file I/O, JSON parsing, and schema validation.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_LIST_FIELDS = ("files_changed", "risks", "blockers", "observations")
 
 
 class VerdictError(Exception):
@@ -71,11 +76,19 @@ def load_verdict(
                 f"{name} verdict field {bool_field} must be bool or null, got {type(val)}"
             )
 
-    for list_field in ("files_changed", "risks", "blockers", "observations"):
+    for list_field in _LIST_FIELDS:
         val = data.get(list_field)
         if val is not None and not isinstance(val, list):
-            raise VerdictError(
-                f"{name} verdict field {list_field} must be an array or null, got {type(val)}"
-            )
+            if isinstance(val, str):
+                log.warning(
+                    "%s verdict field %s is a string, coercing to array",
+                    name,
+                    list_field,
+                )
+                data[list_field] = [val]
+            else:
+                raise VerdictError(
+                    f"{name} verdict field {list_field} must be an array or null, got {type(val)}"
+                )
 
     return data

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -86,8 +86,17 @@ class TestLoadVerdict:
                 allowed_verdicts=frozenset({"ok"}),
             )
 
-    def test_list_field_validation(self, verdict_file):
-        path = verdict_file({"verdict": "ok", "files_changed": "not-a-list"})
+    def test_list_field_string_coerced(self, verdict_file):
+        path = verdict_file({"verdict": "ok", "risks": "some risk"})
+        result = load_verdict(
+            path,
+            required_fields={"verdict"},
+            allowed_verdicts=frozenset({"ok"}),
+        )
+        assert result["risks"] == ["some risk"]
+
+    def test_list_field_non_string_rejected(self, verdict_file):
+        path = verdict_file({"verdict": "ok", "files_changed": 42})
         with pytest.raises(VerdictError, match="must be an array"):
             load_verdict(
                 path,


### PR DESCRIPTION
## Summary

- LLM agents occasionally produce a string instead of an array for verdict fields like `risks`, `blockers`, `files_changed`, and `observations` ([CI job failure](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14766356420#L215))
- Rather than failing validation entirely with `VerdictError`, coerce the string to a single-element array with a warning log
- Non-string, non-list values (e.g. integers) still raise `VerdictError`

## Test plan

- [x] `test_list_field_string_coerced` — string value is wrapped in an array
- [x] `test_list_field_non_string_rejected` — non-string/non-list value still raises VerdictError
- [x] `tox -e py3` passes
- [x] `tox -e lint` passes
- [x] `tox -e check-format` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation handling for list-based input fields to more gracefully process string values by automatically converting them to single-element lists while logging an informative warning for transparency. This enhancement maintains strict validation for non-string/non-list values, ensuring clear and actionable error messages are provided to help users understand and resolve validation issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->