### PR TITLE
Fix entrypoint sleep passthrough

### DIFF
--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -38,6 +38,7 @@ def create(image=None, policy_path=None):
         "--name",
         SANDBOX_NAME,
         "--no-tty",
+        "--no-auto-providers",
         "--provider",
         PROVIDER_NAME,
     ]

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -99,8 +99,9 @@ class PodmanBackend(Backend):
             "--workdir",
             "/workspace",
             self.image,
-            "sleep",
-            str(self.timeout),
+            "bash",
+            "-c",
+            f"sleep {self.timeout}",
         ]
 
         subprocess.run(cmd, check=True, capture_output=True)

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -287,4 +287,4 @@ def test_setup_does_not_override_entrypoint(monkeypatch, tmp_path, claude_harnes
     run_cmd = run_calls[0]
     assert "--entrypoint" not in run_cmd
     image_idx = run_cmd.index("localhost/test:latest")
-    assert run_cmd[image_idx + 1] == "sleep"
+    assert run_cmd[image_idx + 1 : image_idx + 4] == ["bash", "-c", "sleep 1200"]


### PR DESCRIPTION
## Description

The entrypoint.sh in claude-runner only passes through known commands
(claude, bash, sh, etc.) via exec "$@". Bare "sleep" falls through to
the default case which prepends "claude", turning the keep-alive into
"claude sleep 1200". Claude Code exits quickly, PID 1 dies, and the
container SIGKILLs the real workload running via podman exec.

Use "bash -c sleep <timeout>" instead so the entrypoint recognises
bash and passes it through correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container startup logic in the Podman backend for more reliable timeout handling.

* **Changes**
  * Modified sandbox creation to disable automatic provider attachment during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->