### PR TITLE
Move container images, CI jobs, and Renovate from ai-agentic-lib

### DIFF
--- a/.github/workflows/images-pr.yml
+++ b/.github/workflows/images-pr.yml
@@ -1,0 +1,71 @@
+# PR validation for container images: lint, build, and test.
+name: Image PR Checks
+
+on:
+  pull_request:
+    paths:
+      - 'images/**'
+      - 'scripts/bump-versions.py'
+      - 'tests/images/**'
+      - 'tests/e2e/**'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: images-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  # --------------------------------------------------------------------------
+  # Lint shell scripts and Python files related to images
+  # --------------------------------------------------------------------------
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Run shellcheck
+        run: |
+          shellcheck --severity=warning \
+            images/runner/shared/*.sh \
+            tests/images/*.sh \
+            tests/e2e/*.sh
+
+      - name: Run ruff
+        run: |
+          uv run --with ruff ruff check --select=E,F,W \
+            images/runner/claude-code/*.py \
+            images/runner/opencode/*.py \
+            scripts/bump-versions.py
+
+  # --------------------------------------------------------------------------
+  # Run image unit tests
+  # --------------------------------------------------------------------------
+  test:
+    name: Image tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run entrypoint tests
+        run: bash tests/images/test_entrypoint.sh
+
+      - name: Run install plugin tests
+        run: bash tests/images/test_install_plugin.sh
+
+      - name: Run install skills tests
+        run: bash tests/images/test_install_skills.sh

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -1,0 +1,542 @@
+# Build, push, and test container images.
+#
+# All events: build and push ci-<sha> tagged images to quay.io.
+# Push to main / schedule / dispatch: also push latest + epoch tags.
+# PRs: ci-<sha> images auto-expire after 3 days.
+# E2E tests run after builds complete, pulling the ci-<sha> images.
+name: Container Images
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'images/**'
+      - 'src/agentic_ci/**'
+  pull_request:
+    paths:
+      - 'images/**'
+      - 'tests/images/**'
+      - 'tests/e2e/**'
+      - 'src/agentic_ci/**'
+      - 'Makefile'
+  schedule:
+    # Daily at 6am UTC
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      push_images:
+        description: 'Push images to quay.io'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+# Cancel in-progress runs for the same ref, except on main where we always
+# want the full build to complete.
+concurrency:
+  group: images-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  REGISTRY: quay.io
+  IMAGE_PREFIX: quay.io/aipcc/agentic-ci
+  # ci-<sha> tag used across build and e2e jobs
+  CI_TAG: ci-${{ github.sha }}
+  # Secrets are not available for fork PRs. Guard login/push/e2e on this.
+  HAS_SECRETS: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+  # Only push latest+epoch on non-PR events (main push, schedule, dispatch).
+  PUSH_RELEASE_TAGS: ${{ github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.push_images) }}
+
+jobs:
+  # --------------------------------------------------------------------------
+  # claude-runner: requires the shared base image built first
+  # --------------------------------------------------------------------------
+  build-claude-runner:
+    name: Build claude-runner
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/claude-runner:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build base image
+        run: |
+          podman build -t localhost/base:latest \
+            -f images/runner/shared/Containerfile.base \
+            images/runner/shared/
+
+      - name: Build claude-runner
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/claude-runner"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/claude-code/Containerfile \
+            images/runner/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/claude-runner:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/claude-runner"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # opencode-runner: requires the shared base image built first
+  # --------------------------------------------------------------------------
+  build-opencode-runner:
+    name: Build opencode-runner
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/opencode-runner:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build base image
+        run: |
+          podman build -t localhost/base:latest \
+            -f images/runner/shared/Containerfile.base \
+            images/runner/shared/
+
+      - name: Build opencode-runner
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/opencode-runner"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/opencode/Containerfile \
+            images/runner/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/opencode-runner:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/opencode-runner"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # ci-podman: standalone, no base image dependency
+  # --------------------------------------------------------------------------
+  build-ci-podman:
+    name: Build ci-podman
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build ci-podman
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/podman"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/ci/Containerfile.podman \
+            images/ci/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/podman:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/podman"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # claude-sandbox: OpenShell sandbox, requires openshell-base built first
+  # --------------------------------------------------------------------------
+  build-claude-sandbox:
+    name: Build claude-sandbox
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/claude-sandbox:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build openshell-base
+        run: podman build -t localhost/openshell-base:latest -f images/runner/shared/Containerfile.openshell-base images/runner/shared/
+
+      - name: Build claude-sandbox
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/claude-sandbox"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/claude-code/Containerfile.openshell \
+            images/runner/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/claude-sandbox:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/claude-sandbox"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # opencode-sandbox: OpenShell sandbox, requires openshell-base built first
+  # --------------------------------------------------------------------------
+  build-opencode-sandbox:
+    name: Build opencode-sandbox
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/opencode-sandbox:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build openshell-base
+        run: podman build -t localhost/openshell-base:latest -f images/runner/shared/Containerfile.openshell-base images/runner/shared/
+
+      - name: Build opencode-sandbox
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/opencode-sandbox"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/opencode/Containerfile.openshell \
+            images/runner/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/opencode-sandbox:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/opencode-sandbox"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # ci-openshell: standalone CI image with OpenShell gateway
+  # --------------------------------------------------------------------------
+  build-ci-openshell:
+    name: Build ci-openshell
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/openshell:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build ci-openshell
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/openshell"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/ci/Containerfile.openshell \
+            images/ci/
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/openshell:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/openshell"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+  # --------------------------------------------------------------------------
+  # Image tests: lint scripts and run unit tests (PRs only)
+  # --------------------------------------------------------------------------
+  image-lint:
+    name: Lint image scripts
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Install tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq shellcheck
+          pip install --quiet uv
+      - name: Run image-lint
+        run: make image-lint
+
+  image-test:
+    name: Test image scripts
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - name: Run image-test
+        run: make image-test
+
+  # --------------------------------------------------------------------------
+  # E2E tests: pull pre-built ci-<sha> images and run agent prompts
+  #
+  # These tests consume LLM API credits and require GCP credentials.
+  # Skipped for fork PRs (no access to secrets).
+  # --------------------------------------------------------------------------
+  e2e-claude-runner:
+    name: E2E claude-runner
+    needs: build-claude-runner
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Install agentic-ci
+        run: uv tool install .
+
+      - name: Run e2e tests
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          CLAUDE_CONTAINER_IMAGE: ${{ needs.build-claude-runner.outputs.image }}
+        run: bash tests/e2e/e2e-claude-runner.sh
+
+  e2e-opencode-runner:
+    name: E2E opencode-runner
+    needs: build-opencode-runner
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+
+      - name: Install agentic-ci
+        run: uv tool install .
+
+      - name: Run e2e tests
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          OPENCODE_CONTAINER_IMAGE: ${{ needs.build-opencode-runner.outputs.image }}
+        run: bash tests/e2e/e2e-opencode-runner.sh
+
+  e2e-openshell-sandbox:
+    name: E2E openshell-sandbox
+    needs: [build-claude-sandbox, build-opencode-sandbox, build-ci-openshell]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-ci-openshell.outputs.image }}
+      options: --privileged
+      credentials:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Configure podman for container environment
+        run: |
+          printf '[storage]\ndriver = "overlay"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' \
+            > /etc/containers/storage.conf
+
+      - name: Install agentic-ci from repo
+        run: uv tool install .
+
+      - name: Run e2e tests
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          CLAUDE_SANDBOX_IMAGE: ${{ needs.build-claude-sandbox.outputs.image }}
+          OPENCODE_SANDBOX_IMAGE: ${{ needs.build-opencode-sandbox.outputs.image }}
+        run: bash tests/e2e/e2e-openshell-sandbox.sh

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,7 @@ __marimo__/
 
 # Agentic files
 .claude/settings.local.json
+
+# Renovate JSON output
+public/
+__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,57 @@ src/agentic_ci/
 - **Authentication** is auto-detected: if `ANTHROPIC_API_KEY` is set, direct API auth is used (no gcloud credentials needed); otherwise Vertex AI with gcloud ADC files.
 - **OTEL collector runs on the host**, not inside the sandbox/container. Currently only Claude Code emits OTEL metrics; OpenCode provides token/cost data via its JSON output.
 
+## Container images
+
+Pre-built container images for running AI coding agents in CI. Published
+to `quay.io/aipcc/agentic-ci/`.
+
+```text
+images/
+  runner/
+    shared/
+      Containerfile.base            — Runner base image (UBI10 + common tools)
+      Containerfile.openshell-base  — OpenShell sandbox base image
+      entrypoint.sh                 — Container entrypoint (credential setup + exec)
+    claude-code/
+      Containerfile                 — Claude Code runner image
+      Containerfile.openshell       — Claude Code sandbox image (OpenShell)
+      install-plugin.py             — Non-interactive Claude Code plugin installer
+      claude-settings.json          — Seed settings with skills-registry marketplace
+    opencode/
+      Containerfile                 — OpenCode runner image
+      Containerfile.openshell       — OpenCode sandbox image (OpenShell)
+      install-skills.py             — Non-interactive OpenCode skill installer
+      opencode.json                 — Seed config for CI headless mode
+  ci/
+    Containerfile.podman            — CI environment image (podman + tools)
+    Containerfile.openshell         — CI environment image (OpenShell + podman)
+  openshell-supervisor/
+    Containerfile                   — Custom OpenShell supervisor (temporary)
+scripts/
+  bump-versions.py                  — Bump pinned dependency versions in Containerfiles
+```
+
+The runner-base Containerfile (`images/runner/shared/Containerfile.base`)
+is pre-built as `localhost/base:latest` before building the Claude and
+OpenCode runner images. It is NOT published to any registry as a
+standalone image. Do not add a CI job to push runner-base separately.
+
+### Building locally
+
+```bash
+make base-build              # build runner base image locally
+make claude-build            # build Claude Code runner image (includes base)
+make opencode-build          # build OpenCode runner image (includes base)
+make ci-build                # build CI podman image
+make openshell-base-build    # build OpenShell sandbox base image
+make openshell-claude-build  # build Claude sandbox (includes openshell-base)
+make openshell-opencode-build # build OpenCode sandbox (includes openshell-base)
+make openshell-ci-build      # build OpenShell CI image
+make image-lint              # shellcheck + ruff on image scripts
+make image-test              # run image unit tests
+```
+
 ## Commands
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+.PHONY: base-build
+base-build: ## Build the runner base image locally
+	podman build -t localhost/base:latest -f images/runner/shared/Containerfile.base images/runner/shared/
+
+.PHONY: claude-build
+claude-build: base-build ## Build the Claude Code runner image locally
+	podman build -t localhost/claude-runner:latest -f images/runner/claude-code/Containerfile images/runner/
+
+.PHONY: opencode-build
+opencode-build: base-build ## Build the OpenCode runner image locally
+	podman build -t localhost/opencode-runner:latest -f images/runner/opencode/Containerfile images/runner/
+
+.PHONY: ci-build
+ci-build: ## Build the CI podman image locally
+	podman build -t ci-podman:latest -f images/ci/Containerfile.podman images/ci/
+
+.PHONY: openshell-base-build
+openshell-base-build: ## Build the OpenShell sandbox base image locally
+	podman build -t localhost/openshell-base:latest -f images/runner/shared/Containerfile.openshell-base images/runner/shared/
+
+.PHONY: openshell-claude-build
+openshell-claude-build: openshell-base-build ## Build the OpenShell Claude sandbox image locally
+	podman build -t localhost/claude-sandbox:latest -f images/runner/claude-code/Containerfile.openshell images/runner/
+
+.PHONY: openshell-opencode-build
+openshell-opencode-build: openshell-base-build ## Build the OpenShell OpenCode sandbox image locally
+	podman build -t localhost/opencode-sandbox:latest -f images/runner/opencode/Containerfile.openshell images/runner/
+
+.PHONY: openshell-ci-build
+openshell-ci-build: ## Build the OpenShell CI image locally
+	podman build -t openshell:latest -f images/ci/Containerfile.openshell images/ci/
+
+.PHONY: bump-versions
+bump-versions: ## Bump pinned dependency versions in Containerfiles
+	python3 scripts/bump-versions.py
+
+.PHONY: check-versions
+check-versions: ## Check for available dependency updates
+	python3 scripts/bump-versions.py --check
+
+.PHONY: image-lint
+image-lint: ## Run linting checks on image scripts
+	shellcheck --severity=warning images/runner/shared/*.sh tests/images/*.sh tests/e2e/*.sh
+	@uv run --with ruff ruff check --select=E,F,W images/runner/claude-code/*.py images/runner/opencode/*.py scripts/bump-versions.py
+
+.PHONY: image-test
+image-test: ## Run image unit tests
+	bash tests/images/test_entrypoint.sh
+	bash tests/images/test_install_plugin.sh
+	bash tests/images/test_install_skills.sh
+
+.PHONY: e2e-claude
+e2e-claude: ## Run Claude Code runner e2e tests
+	bash tests/e2e/e2e-claude-runner.sh
+
+.PHONY: e2e-opencode
+e2e-opencode: ## Run OpenCode runner e2e tests
+	bash tests/e2e/e2e-opencode-runner.sh
+
+.PHONY: e2e-openshell
+e2e-openshell: ## Run OpenShell sandbox e2e tests
+	bash tests/e2e/e2e-openshell-sandbox.sh

--- a/README.md
+++ b/README.md
@@ -374,6 +374,33 @@ config = SkillConfig(
 )
 ```
 
+## Container Images
+
+Pre-built container images for running AI coding agents in CI are
+published to `quay.io/aipcc/agentic-ci/`:
+
+| Image | Description |
+|-------|-------------|
+| `claude-runner` | Claude Code CLI with pre-installed skills |
+| `opencode-runner` | OpenCode CLI with pre-installed skills |
+| `claude-sandbox` | Claude Code sandbox for OpenShell |
+| `opencode-sandbox` | OpenCode sandbox for OpenShell |
+| `podman` | CI environment with podman, gh, glab, gitleaks, acli |
+| `openshell` | CI environment with OpenShell gateway + podman |
+
+Images are rebuilt daily via GitHub Actions and version-managed by
+Renovate. See [Container Image docs](https://opendatahub-io.github.io/agentic-ci/image/)
+for usage details.
+
+```bash
+make claude-build              # build Claude Code runner image locally
+make opencode-build            # build OpenCode runner image locally
+make ci-build                  # build CI podman image locally
+make openshell-claude-build    # build Claude sandbox locally
+make openshell-opencode-build  # build OpenCode sandbox locally
+make openshell-ci-build        # build OpenShell CI image locally
+```
+
 ## Documentation
 
 API reference documentation is auto-generated from docstrings and

--- a/docs/image/build.md
+++ b/docs/image/build.md
@@ -1,0 +1,36 @@
+# Image Build Pipeline
+
+All container images are built by GitHub Actions and pushed to
+`quay.io/aipcc/agentic-ci/`.
+
+## Tag strategy
+
+Every push to main (when `images/**` changes), tag push, and daily
+schedule triggers builds. Images are tagged with:
+
+- `latest` and an epoch timestamp on every build
+- The git tag name on tag pushes (semver pattern)
+
+## Images
+
+| Image | Containerfile | Description |
+|-------|---------------|-------------|
+| `podman` | `images/ci/Containerfile.podman` | CI env with podman |
+| `openshell` | `images/ci/Containerfile.openshell` | CI env with OpenShell gateway |
+| `claude-runner` | `images/runner/claude-code/Containerfile` | Claude Code runner |
+| `opencode-runner` | `images/runner/opencode/Containerfile` | OpenCode runner |
+| `claude-sandbox` | `images/runner/claude-code/Containerfile.openshell` | Claude Code sandbox |
+| `opencode-sandbox` | `images/runner/opencode/Containerfile.openshell` | OpenCode sandbox |
+
+## Local builds
+
+```bash
+make ci-build                  # podman CI image
+make openshell-ci-build        # openshell CI image
+make base-build                # runner base
+make claude-build              # claude-runner (depends on base-build)
+make opencode-build            # opencode-runner (depends on base-build)
+make openshell-base-build      # sandbox base
+make openshell-claude-build    # claude-sandbox
+make openshell-opencode-build  # opencode-sandbox
+```

--- a/docs/image/extending.md
+++ b/docs/image/extending.md
@@ -1,0 +1,83 @@
+# Extending the Image
+
+The base image is designed to be used as a `FROM` target for
+workflow-specific images that need additional tools or skills.
+
+## Adding tools
+
+```dockerfile
+FROM quay.io/aipcc/agentic-ci/claude-runner:latest
+
+USER root
+RUN microdnf install -y --nodocs my-tool && microdnf clean all
+
+USER agent-ci
+```
+
+Common additions:
+
+| Tool | Install command |
+|------|----------------|
+| OpenShift CLI | See example below |
+| Atlassian CLI | See example below |
+
+**OpenShift CLI:**
+
+```bash
+OCP_URL="https://mirror.openshift.com/pub/openshift-v4"
+curl -LsSf "$OCP_URL/clients/ocp/stable/openshift-client-linux.tar.gz" \
+  | tar xzf - -C /usr/local/bin/ oc
+```
+
+**Atlassian CLI:**
+
+```bash
+curl -fsSL \
+  "https://acli.atlassian.com/linux/latest/acli_linux_amd64/acli" \
+  -o /usr/local/bin/acli && chmod +x /usr/local/bin/acli
+```
+
+## Adding skills
+
+### From a git repository
+
+```dockerfile
+FROM quay.io/aipcc/agentic-ci/claude-runner:latest
+
+USER agent-ci
+RUN install-plugin --repo https://github.com/opendatahub-io/knowledge-skills.git
+```
+
+### From the skills registry (by name)
+
+If the plugin is listed in the registered
+[skills-registry](https://github.com/opendatahub-io/skills-registry)
+marketplace:
+
+```dockerfile
+FROM quay.io/aipcc/agentic-ci/claude-runner:latest
+
+USER agent-ci
+RUN install-plugin my-new-plugin
+```
+
+### From a different marketplace
+
+Register an additional marketplace, then install from it:
+
+```dockerfile
+FROM quay.io/aipcc/agentic-ci/claude-runner:latest
+
+USER agent-ci
+RUN install-plugin --marketplace-repo my-org/my-skills-registry && \
+    install-plugin --all
+```
+
+## Important notes
+
+- Run `install-plugin` as `agent-ci` (not root) so plugins are
+  written to the correct home directory
+- The base image already has all 8 skills-registry plugins installed;
+  downstream images only need to add extras
+- Tools that require root (e.g. `microdnf install`) must switch to
+  `USER root` and back to `USER agent-ci`

--- a/docs/image/index.md
+++ b/docs/image/index.md
@@ -1,0 +1,170 @@
+# Container Image
+
+`quay.io/aipcc/agentic-ci/claude-runner`
+
+Production container image for running Claude Code in agentic CI
+workflows. Rebuilt daily to pick up fresh skill versions and security
+patches.
+
+## Architecture
+
+```mermaid
+graph LR
+    subgraph Host / CI Runner
+        A[agentic-ci CLI]
+        A1[Credential resolve]
+        A2[Container lifecycle]
+        A3[Stream processing]
+        A4[OTEL collection]
+        A --> A1
+        A --> A2
+        A --> A3
+        A --> A4
+    end
+
+    subgraph Container
+        B[Claude Code CLI]
+        C[Skills from registry]
+        D[Tools: gh, glab, ...]
+        E[agentic-ci library]
+        F[entrypoint.sh]
+    end
+
+    A2 -- "podman exec /<br/>openshell sandbox exec" --> B
+
+    style A fill:#e8e8e8,stroke:#333
+    style A1 fill:#e8e8e8,stroke:#999
+    style A2 fill:#e8e8e8,stroke:#999
+    style A3 fill:#e8e8e8,stroke:#999
+    style A4 fill:#e8e8e8,stroke:#999
+    style B fill:#dceefb,stroke:#333
+    style C fill:#dceefb,stroke:#333
+    style D fill:#dceefb,stroke:#333
+    style E fill:#dceefb,stroke:#333
+    style F fill:#dceefb,stroke:#333
+```
+
+The **agentic-ci** orchestrator runs on the host. It creates the
+container with `--entrypoint sleep`, then calls `podman exec` or
+`openshell sandbox exec` to run Claude inside it. Credentials are
+mounted read-only from the host. OTEL metrics are collected on the host.
+
+The **container image** is a toolbox: Claude Code + skills + tools. The
+entrypoint handles credential setup only for standalone use (direct
+`podman run` without agentic-ci).
+
+## What's included
+
+### System tools
+
+| Category | Tools |
+|----------|-------|
+| Runtime | python3, git |
+| HTTP | curl, jq |
+| Build | make, which, tar, xz |
+| VCS CLIs | gh (GitHub), glab (GitLab) |
+| Linting | shellcheck, ruff |
+| Python | uv |
+| Library | agentic-ci |
+
+### Pre-installed skills
+
+All plugins from the
+[opendatahub-io/skills-registry](https://github.com/opendatahub-io/skills-registry)
+are pre-installed:
+
+| Plugin | Description |
+|--------|-------------|
+| odh-ai-helpers | Python packaging, CI/CD debugging, Jira, ADR review |
+| rfe-creator | RFE creation, review, and submission pipeline |
+| assess-rfe | RFE quality assessment with structured rubric |
+| rhoai-security-reviewer | Consensus-based security review for STRATs |
+| test-plan | Test planning, generation, and automation |
+| quality-tooling | Repository analysis and build validation |
+| agent-eval-harness | Agentic evaluation with MLflow support |
+| meeting-quality-skills | Pre-meeting quality checks |
+
+## Dependency pinning
+
+Every binary tool is pinned to a specific version and verified with a
+SHA256 checksum. Only x86_64 binaries are included.
+
+| Tool | Pinning |
+|------|---------|
+| ShellCheck | Version + SHA256 |
+| gh | Version + SHA256 |
+| glab | Version + SHA256 |
+| uv | Version + SHA256 |
+| Python packages | Version-pinned via `uv pip install` |
+
+The image is rebuilt daily on a schedule, refreshing all skill versions
+and picking up base image security patches. Date-stamped tags
+(`YYYYMMDD`) provide rollback points.
+
+## Usage
+
+### Standalone (direct podman run)
+
+Pass GCP credentials as environment variables. The entrypoint normalizes
+them and writes gcloud config automatically:
+
+```bash
+podman run --rm \
+  -e GCLOUD_CREDENTIALS="$GCLOUD_CREDENTIALS" \
+  -v ./workspace:/workspace \
+  quay.io/aipcc/agentic-ci/claude-runner:latest \
+  claude -p "fix the failing test" \
+    --model claude-opus-4-6 \
+    --permission-mode bypassPermissions
+```
+
+### With agentic-ci (recommended)
+
+The agentic-ci CLI handles container lifecycle, credential injection,
+streaming output, and OTEL telemetry:
+
+```bash
+agentic-ci run "fix the failing test" --workdir ./workspace
+```
+
+### Shell access
+
+```bash
+podman run --rm -it \
+  quay.io/aipcc/agentic-ci/claude-runner:latest \
+  bash
+```
+
+## Entrypoint behavior
+
+| Command | Result |
+|---------|--------|
+| `podman run image` | Runs `claude` interactively |
+| `podman run image claude -p "prompt"` | Runs a prompt |
+| `podman run image bash` | Shell access for debugging |
+| `podman run --entrypoint sleep image 1200` | agentic-ci mode |
+
+The entrypoint supports two credential sources (checked in order):
+
+1. `GCLOUD_CREDENTIALS` — raw JSON or base64-encoded GCP credentials
+2. `GCP_SERVICE_ACCOUNT_KEY` — base64-encoded credentials (fallback)
+
+If neither is set, `ANTHROPIC_API_KEY` is used directly (no gcloud
+config needed).
+
+## Tags
+
+| Tag | Description |
+|-----|-------------|
+| `latest` | Most recent build |
+| `YYYYMMDD` | Date-stamped build (e.g. `20260514`) |
+
+## CI pipeline
+
+The image is built by a GitHub Actions workflow
+(`.github/workflows/images.yml`) that triggers on:
+
+1. Push to main when `images/**` files change
+2. Daily schedule (6am UTC)
+3. Tag pushes
+4. Manual dispatch via `workflow_dispatch`

--- a/docs/image/skills.md
+++ b/docs/image/skills.md
@@ -1,0 +1,108 @@
+# Skill Loading
+
+The container image uses `install-plugin`, a pure-Python script that
+populates Claude Code's plugin cache non-interactively at build time.
+
+## How it works
+
+1. A marketplace repo (e.g. `opendatahub-io/skills-registry`) is
+   registered — the script clones it and records it in Claude Code's
+   settings
+2. For each plugin in the marketplace, the script:
+    - Shallow-clones the plugin's source repository
+    - Copies skills, agents, commands, and gems into the plugin cache
+    - Writes an `.in_use` marker
+    - Updates `installed_plugins.json` with version metadata
+    - Adds the plugin to `enabledPlugins` in `settings.json`
+
+## Plugin cache structure
+
+```text
+~/.claude/
+  settings.json                              # enabledPlugins
+  plugins/
+    known_marketplaces.json                  # marketplace registry
+    installed_plugins.json                   # plugin version tracking
+    marketplaces/
+      opendatahub-skills/
+        marketplace.json                     # from skills-registry
+    cache/
+      opendatahub-skills/
+        odh-ai-helpers/
+          0.1.0/
+            skills/
+            agents/
+            .in_use
+        rfe-creator/
+          0.1.0/
+            skills/
+            .in_use
+        ...
+```
+
+## CLI reference
+
+### Register a marketplace
+
+```bash
+install-plugin --marketplace-repo opendatahub-io/skills-registry
+```
+
+Clones the GitHub repo containing `.claude-plugin/marketplace.json` and
+records it as a known marketplace.
+
+### Install all plugins from a marketplace
+
+```bash
+install-plugin --all
+```
+
+Iterates every registered marketplace and installs all listed plugins.
+
+### Install specific plugins by name
+
+```bash
+install-plugin odh-ai-helpers rfe-creator
+```
+
+Looks up the named plugins in registered marketplaces and installs them.
+
+### Install from a git URL
+
+```bash
+install-plugin --repo https://github.com/org/my-plugin.git
+```
+
+Clones the repo directly (no marketplace needed) and installs any
+skills, agents, commands, or gems found in standard locations
+(`.claude/skills/`, `.claude/agents/`, etc.).
+
+## Skill discovery
+
+For plugins listed in a marketplace, the script uses the `skills` and
+`agents` arrays from the marketplace entry to locate content in the
+source repo. For example:
+
+```json
+{
+  "name": "odh-ai-helpers",
+  "skills": ["./helpers/skills"],
+  "agents": ["./helpers/agents/python-packaging-investigator.md"]
+}
+```
+
+If no arrays are provided, the script falls back to standard
+directories: `.claude/skills/`, `.claude/agents/`, `.claude/commands/`,
+`.claude/gems/`.
+
+## Runtime skill injection
+
+For ad-hoc skill additions without rebuilding the image, mount a
+directory and set the seed environment variable:
+
+```bash
+podman run \
+  -e CLAUDE_CODE_PLUGIN_SEED_DIR=/opt/extra-skills \
+  -v ./my-skills:/opt/extra-skills:ro \
+  quay.io/aipcc/agentic-ci/claude-runner:latest
+```

--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -1,0 +1,112 @@
+# CI environment image for running agentic workflows via OpenShell.
+#
+# This image is the "outer" layer that runs on the CI runner. It has
+# openshell (gateway + CLI) with podman as the compute driver, and
+# includes tooling for pre/post workflow steps like creating
+# MRs/PRs and interacting with Jira.
+#
+# OpenShell manages sandbox lifecycle, credential proxying (via
+# inference.local), and network policy enforcement. Agents run
+# inside OpenShell sandboxes (containers managed by podman).
+#
+# x86_64 only.
+
+FROM registry.access.redhat.com/ubi10/ubi:10.1
+
+ARG GH_VERSION=2.93.0
+ARG GH_SHA256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+
+ARG GLAB_VERSION=1.100.0
+ARG GLAB_SHA256=d2a8ccffe924d3ad22feb2d1338840e9a610041c6ea6fd76e9aeda3744f210c2
+
+ARG GITLEAKS_VERSION=8.30.1
+ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
+# System packages (podman is needed as the OpenShell compute driver)
+RUN dnf install -y --nodocs \
+        podman \
+        fuse-overlayfs \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        jq \
+        make \
+        which \
+    && dnf clean all
+
+# OpenShell gateway + CLI from Copr (manual repo config for UBI10)
+RUN printf '[copr:maxamillion:nvidia-openshell]\n\
+name=Copr repo for nvidia-openshell owned by maxamillion\n\
+baseurl=https://download.copr.fedorainfracloud.org/results/maxamillion/nvidia-openshell/rhel+epel-10-$basearch/\n\
+type=rpm-md\n\
+skip_if_unavailable=True\n\
+gpgcheck=0\n\
+repo_gpgcheck=0\n\
+enabled=1\n' > /etc/yum.repos.d/copr-nvidia-openshell.repo \
+    && dnf install -y --nodocs \
+        openshell-gateway-0.0.55-1.20260605134545513516.devrobertsturlagce.metadata.emulator.11.gaada3da8.el10 \
+        openshell-0.0.55-1.20260605134545513516.devrobertsturlagce.metadata.emulator.11.gaada3da8.el10 \
+    && dnf clean all
+# Pinned to 0.0.55 (Copr build from PR #1763 branch). The upstream
+# supervisor image doesn't have google-cloud provider support yet, so
+# we build a custom supervisor in e2e tests. Bump to >= 0.0.56 once
+# PR #1763 merges and remove the custom supervisor build.
+# Tracking: https://github.com/NVIDIA/OpenShell/pull/1763
+
+# GitHub CLI (pinned)
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+# GitLab CLI (pinned)
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# Gitleaks (pinned)
+RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
+        "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+    && echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
+    && mkdir /tmp/gitleaks && tar -xzf /tmp/gitleaks.tar.gz -C /tmp/gitleaks \
+    && mv /tmp/gitleaks/gitleaks /usr/local/bin/gitleaks \
+    && chmod +x /usr/local/bin/gitleaks \
+    && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
+
+# Atlassian CLI (acli, pinned via RPM)
+ARG ACLI_VERSION=1.3.19~stable-1
+RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
+        https://acli.atlassian.com/linux/rpm/acli.repo \
+    && dnf install -y --nodocs "acli-${ACLI_VERSION}" \
+    && dnf clean all
+
+# uv
+ARG UV_VERSION=0.11.16
+ARG UV_SHA256=1bc4be1be0a000f893b0d1db97906cf392b63fa22fda9a0ecf33d0d4bbb4bc9a
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+# Python packages
+RUN uv pip install --system --no-cache \
+        agentic-ci==0.2.22
+
+# Rootless podman config: storage driver and subordinate UID/GID
+# mappings so nested podman can pull images with mixed file ownership.
+RUN mkdir -p /etc/containers && \
+    printf '[storage]\ndriver = "overlay"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' \
+        > /etc/containers/storage.conf && \
+    echo "root:100000:65536" >> /etc/subuid && \
+    echo "root:100000:65536" >> /etc/subgid

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -1,0 +1,86 @@
+# CI environment image for running agentic workflows via podman.
+#
+# This image is the "outer" layer that runs on the CI runner. It has
+# podman installed to launch runner containers (claude-code, opencode)
+# and includes tooling for pre/post workflow steps like creating
+# MRs/PRs and interacting with Jira.
+#
+# x86_64 only.
+
+FROM registry.access.redhat.com/ubi10/ubi:10.1
+
+ARG GH_VERSION=2.93.0
+ARG GH_SHA256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+
+ARG GLAB_VERSION=1.101.0
+ARG GLAB_SHA256=f8f40309a622416b769a455a85509bae7800070cd023466f2d33d8ee82f3fc61
+
+ARG GITLEAKS_VERSION=8.30.1
+ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+
+# System packages
+RUN dnf install -y --nodocs \
+        podman \
+        fuse-overlayfs \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        jq \
+        make \
+        which \
+    && dnf clean all
+
+# GitHub CLI (pinned)
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+# GitLab CLI (pinned)
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# Gitleaks (pinned)
+RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
+        "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+    && echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c - \
+    && mkdir /tmp/gitleaks && tar -xzf /tmp/gitleaks.tar.gz -C /tmp/gitleaks \
+    && mv /tmp/gitleaks/gitleaks /usr/local/bin/gitleaks \
+    && chmod +x /usr/local/bin/gitleaks \
+    && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
+
+# Atlassian CLI (acli, pinned via RPM)
+ARG ACLI_VERSION=1.3.19~stable-1
+RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
+        https://acli.atlassian.com/linux/rpm/acli.repo \
+    && dnf install -y --nodocs "acli-${ACLI_VERSION}" \
+    && dnf clean all
+
+# uv
+ARG UV_VERSION=0.11.18
+ARG UV_SHA256=a095a969fc8357f42e35652e0554525a47a29010ddb814bd82650c2ffa7d6d62
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+# Python packages
+RUN uv pip install --system --no-cache \
+        agentic-ci==0.2.22
+
+# Rootless podman storage config
+RUN mkdir -p /etc/containers && \
+    printf '[storage]\ndriver = "overlay"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' \
+        > /etc/containers/storage.conf

--- a/images/openshell-supervisor/Containerfile
+++ b/images/openshell-supervisor/Containerfile
@@ -1,0 +1,38 @@
+# OpenShell supervisor built from PR #1763 (google-cloud provider + GCE
+# metadata emulator). The upstream supervisor image
+# (ghcr.io/nvidia/openshell/supervisor:latest) does not include these
+# changes yet. Once PR #1763 merges and supervisor:latest is rebuilt,
+# this Containerfile can be removed and the OPENSHELL_SUPERVISOR_IMAGE
+# override dropped.
+#
+# Tracking: https://github.com/NVIDIA/OpenShell/pull/1763
+# Pinned to openshell RPM 0.0.55 (devrobertsturlagce.metadata.emulator branch).
+# When openshell >= 0.0.56 ships with the merged PR, this build is obsolete.
+#
+# Usage:
+#   git clone --depth 1 --branch dev/robertsturla/gce-metadata-emulator \
+#     https://github.com/p5/OpenShell.git openshell-src
+#   podman build -t openshell-supervisor:pr1763 \
+#     -f images/openshell-supervisor/Containerfile .
+
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1 AS builder
+
+RUN microdnf install -y gcc gcc-c++ make openssl-devel unzip && microdnf clean all
+
+RUN curl -sSfL https://github.com/protocolbuffers/protobuf/releases/download/v29.5/protoc-29.5-linux-x86_64.zip \
+      -o /tmp/protoc.zip \
+    && unzip -q /tmp/protoc.zip -d /usr/local \
+    && rm /tmp/protoc.zip
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain 1.95.0
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /src
+COPY openshell-src/ .
+
+RUN cargo build --release --package openshell-sandbox
+
+FROM registry.access.redhat.com/ubi10/ubi-micro:10.1
+COPY --from=builder --chmod=0550 /src/target/release/openshell-sandbox /openshell-sandbox
+ENTRYPOINT ["/openshell-sandbox"]

--- a/images/openshell-supervisor/README.md
+++ b/images/openshell-supervisor/README.md
@@ -1,0 +1,8 @@
+This Containerfile is built manually and pushed to:
+
+quay.io/mprpic/openshell-supervisor:pr1763
+
+This is in place until the following PR merges and official images
+(or our Red Hat flavors of them) exist to use here instead:
+
+https://github.com/NVIDIA/OpenShell/pull/1763/

--- a/images/runner/claude-code/Containerfile
+++ b/images/runner/claude-code/Containerfile
@@ -1,0 +1,36 @@
+FROM localhost/base:latest
+
+ARG CLAUDE_VERSION=2.1.169
+ARG CLAUDE_SHA256=cf066bf360cbf7b51abeb8cb230012fc0f2fed4253b2ce305de48ccd6d49a39c
+
+USER root
+
+# nodejs is needed by Claude Code
+RUN microdnf install -y --nodocs nodejs npm && microdnf clean all
+
+RUN curl -fsSL -o /usr/bin/claude \
+        "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/linux-x64/claude" \
+    && echo "${CLAUDE_SHA256}  /usr/bin/claude" | sha256sum -c - \
+    && chmod +x /usr/bin/claude
+
+COPY claude-code/install-plugin.py /usr/local/bin/install-plugin
+RUN chmod +x /usr/local/bin/install-plugin
+
+COPY claude-code/claude-settings.json /home/agent-ci/.claude/settings.json
+RUN chown -R agent-ci:agent-ci /home/agent-ci/.claude
+
+USER agent-ci
+RUN install-plugin --marketplace-repo opendatahub-io/skills-registry \
+    && install-plugin --all
+
+USER root
+COPY shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER agent-ci
+ENV AGENT_TOOL=claude
+ENV CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1
+ENV CLAUDE_CONFIG_DIR=/home/agent-ci/.claude
+WORKDIR /home/agent-ci
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["claude"]

--- a/images/runner/claude-code/Containerfile.openshell
+++ b/images/runner/claude-code/Containerfile.openshell
@@ -1,0 +1,39 @@
+# Claude Code sandbox image for OpenShell.
+#
+# Use with: agentic-ci run --backend openshell --image <this-image> ...
+# Or:       openshell sandbox create --from <this-image> --provider ...
+#
+# Build:
+#   podman build -t openshell-base -f images/runner/shared/Containerfile.openshell-base images/runner/
+#   podman build -t openshell-claude -f images/runner/claude-code/Containerfile.openshell images/runner/
+
+FROM localhost/openshell-base:latest
+
+ARG CLAUDE_VERSION=2.1.162
+ARG CLAUDE_SHA256=947a49b0de8688f6a74a6e753c24771ff3ddd17b2a6dae85f36304ec514e61d1
+
+USER root
+
+# nodejs is needed by Claude Code
+RUN microdnf install -y --nodocs nodejs npm && microdnf clean all
+
+RUN curl -fsSL -o /usr/local/bin/claude \
+        "https://downloads.claude.ai/claude-code-releases/${CLAUDE_VERSION}/linux-x64/claude" \
+    && echo "${CLAUDE_SHA256}  /usr/local/bin/claude" | sha256sum -c - \
+    && chmod +x /usr/local/bin/claude
+
+COPY claude-code/install-plugin.py /usr/local/bin/install-plugin
+RUN chmod +x /usr/local/bin/install-plugin
+
+COPY claude-code/claude-settings.json /sandbox/.claude/settings.json
+RUN chown -R sandbox:sandbox /sandbox/.claude
+
+COPY shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER sandbox
+RUN install-plugin --marketplace-repo opendatahub-io/skills-registry \
+    && install-plugin --all
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["claude"]

--- a/images/runner/claude-code/claude-settings.json
+++ b/images/runner/claude-code/claude-settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "opendatahub-skills": {
+      "source": {
+        "source": "github",
+        "repo": "opendatahub-io/skills-registry"
+      }
+    }
+  }
+}

--- a/images/runner/claude-code/install-plugin.py
+++ b/images/runner/claude-code/install-plugin.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+"""Install Claude Code plugins from a marketplace non-interactively.
+
+Populates ~/.claude/plugins/ cache and metadata files so the container
+image ships with pre-cached skills, agents, commands, and gems.
+
+Usage:
+    install-plugin.py --marketplace-repo opendatahub-io/skills-registry
+    install-plugin.py --all [--no-enable]
+    install-plugin.py plugin-a plugin-b [--no-enable]
+    install-plugin.py --repo https://github.com/org/repo.git [--no-enable]
+
+Options:
+    --no-enable  Cache plugins without enabling in settings.json.
+                 Plugins can be enabled at runtime via AGENT_ENABLED_PLUGINS.
+
+Environment:
+    CLAUDE_HOME  Override ~/.claude (default: $HOME/.claude)
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _claude_home():
+    return Path(os.environ.get("CLAUDE_HOME", Path.home() / ".claude"))
+
+
+def _plugins_dir():
+    return _claude_home() / "plugins"
+
+
+def _settings_path():
+    return _claude_home() / "settings.json"
+
+
+def _now_iso():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+
+
+def _git(*args, **kwargs):
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+
+
+def _read_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+        f.write("\n")
+
+
+def _ensure_settings():
+    path = _settings_path()
+    if not path.exists():
+        _write_json(path, {})
+    return path
+
+
+def _ensure_installed_json():
+    path = _plugins_dir() / "installed_plugins.json"
+    if not path.exists():
+        _write_json(path, {"version": 2, "plugins": {}})
+    return path
+
+
+# ── marketplace registration ────────────────────────────────────────────
+
+
+def register_marketplace(repo):
+    url = f"https://github.com/{repo}.git"
+    print(f"==> Registering marketplace from {repo}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "registry"
+        _git("clone", "--depth", "1", "--quiet", url, str(clone_dir))
+
+        mkt_json_path = clone_dir / ".claude-plugin" / "marketplace.json"
+        if not mkt_json_path.exists():
+            print(f"ERROR: {repo} has no .claude-plugin/marketplace.json", file=sys.stderr)
+            sys.exit(1)
+
+        mkt_data = _read_json(mkt_json_path)
+        mkt_name = mkt_data.get("name") or os.path.basename(repo)
+
+        mkt_dir = _plugins_dir() / "marketplaces" / mkt_name
+        mkt_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(mkt_json_path, mkt_dir / "marketplace.json")
+
+    settings = _read_json(_ensure_settings())
+    mk = settings.setdefault("extraKnownMarketplaces", {})
+    mk[mkt_name] = {"source": {"source": "github", "repo": repo}}
+    _write_json(_settings_path(), settings)
+
+    print(f"==> Marketplace '{mkt_name}' registered")
+
+
+# ── plugin installation ─────────────────────────────────────────────────
+
+
+def _clone_source(repo, ref, dest):
+    """Clone a source repo.  Full SHA refs need clone+checkout; branches
+    and tags can use --branch with --depth 1."""
+    url = f"https://github.com/{repo}.git"
+    if len(ref) == 40 and all(c in "0123456789abcdef" for c in ref):
+        _git("clone", "--quiet", url, str(dest))
+        _git("-C", str(dest), "checkout", "--quiet", ref)
+    else:
+        _git("clone", "--depth", "1", "--branch", ref, "--quiet", url, str(dest))
+
+
+def _copy_content(src, dest, plugin_entry):
+    """Copy skills, agents, commands, gems from cloned source into cache.
+
+    When explicit paths are declared in the marketplace entry, preserve
+    the original relative path so Claude Code finds them where it expects.
+    """
+    src = Path(src)
+    dest = Path(dest)
+
+    # skills
+    skills_paths = plugin_entry.get("skills", [])
+    if skills_paths:
+        for sp in skills_paths:
+            resolved = src / sp
+            if resolved.is_dir():
+                target = dest / Path(sp)
+                target.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(resolved, target, dirs_exist_ok=True)
+    else:
+        for fallback in [".claude/skills", "skills"]:
+            candidate = src / fallback
+            if candidate.is_dir():
+                shutil.copytree(candidate, dest / "skills", dirs_exist_ok=True)
+                break
+
+    # agents
+    agents_paths = plugin_entry.get("agents", [])
+    if agents_paths:
+        for ap in agents_paths:
+            resolved = src / ap
+            target = dest / Path(ap)
+            if resolved.is_file():
+                target.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(resolved, target)
+            elif resolved.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(resolved, target, dirs_exist_ok=True)
+    else:
+        for fallback in [".claude/agents", "agents"]:
+            candidate = src / fallback
+            if candidate.is_dir():
+                shutil.copytree(candidate, dest / "agents", dirs_exist_ok=True)
+                break
+
+    # commands, gems — fallback only
+    for name in ["commands", "gems"]:
+        for fallback in [f".claude/{name}", name]:
+            candidate = src / fallback
+            if candidate.is_dir():
+                shutil.copytree(candidate, dest / name, dirs_exist_ok=True)
+                break
+
+
+def _update_installed_json(mkt_name, name, version, install_path, sha):
+    path = _ensure_installed_json()
+    data = _read_json(path)
+    ts = _now_iso()
+    data["plugins"][f"{name}@{mkt_name}"] = [
+        {
+            "scope": "user",
+            "installPath": str(install_path),
+            "version": version,
+            "installedAt": ts,
+            "lastUpdated": ts,
+            "gitCommitSha": sha,
+        }
+    ]
+    _write_json(path, data)
+
+
+def _update_enabled_plugins(mkt_name, name):
+    path = _ensure_settings()
+    data = _read_json(path)
+    ep = data.setdefault("enabledPlugins", {})
+    key = f"{name}@{mkt_name}"
+    if key not in ep:
+        ep[key] = True
+    _write_json(path, data)
+
+
+def install_plugin(mkt_name, plugin_entry, enable=True):
+    name = plugin_entry["name"]
+    version = plugin_entry.get("version", "0.0.0")
+    source = plugin_entry["source"]
+    src_repo = source["repo"]
+    src_ref = source.get("ref", "main")
+
+    print(f"==> Installing {name}@{version} from {src_repo} ({src_ref})")
+
+    cache_dir = _plugins_dir() / "cache" / mkt_name / name / version
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "src"
+        _clone_source(src_repo, src_ref, clone_dir)
+
+        result = _git("-C", str(clone_dir), "rev-parse", "HEAD")
+        commit_sha = result.stdout.strip()
+
+        _copy_content(clone_dir, cache_dir, plugin_entry)
+
+    (cache_dir / ".in_use").write_text("installed\n")
+    _update_installed_json(mkt_name, name, version, cache_dir, commit_sha)
+    if enable:
+        _update_enabled_plugins(mkt_name, name)
+
+    print(f"==> Installed {name}@{version} -> {cache_dir}")
+
+
+# ── install modes ───────────────────────────────────────────────────────
+
+
+def install_all(enable=True):
+    mkt_base = _plugins_dir() / "marketplaces"
+    if not mkt_base.exists():
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+    found = False
+    for mkt_json in sorted(mkt_base.glob("*/marketplace.json")):
+        found = True
+        mkt_name = mkt_json.parent.name
+        data = _read_json(mkt_json)
+        plugins = data.get("plugins", [])
+        print(f"==> Marketplace '{mkt_name}': {len(plugins)} plugins")
+        for entry in plugins:
+            install_plugin(mkt_name, entry, enable=enable)
+
+    if not found:
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+
+def install_named(names, enable=True):
+    mkt_base = _plugins_dir() / "marketplaces"
+    if not mkt_base.exists():
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+    marketplaces = {}
+    for mkt_json in sorted(mkt_base.glob("*/marketplace.json")):
+        mkt_name = mkt_json.parent.name
+        marketplaces[mkt_name] = _read_json(mkt_json)
+
+    for target in names:
+        installed = False
+        for mkt_name, data in marketplaces.items():
+            for entry in data.get("plugins", []):
+                if entry["name"] == target:
+                    install_plugin(mkt_name, entry, enable=enable)
+                    installed = True
+                    break
+            if installed:
+                break
+        if not installed:
+            print(f"ERROR: plugin '{target}' not found", file=sys.stderr)
+            sys.exit(1)
+
+
+def install_from_repo(url, enable=True):
+    print(f"==> Installing plugin from repo {url}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "src"
+        _git("clone", "--depth", "1", "--quiet", url, str(clone_dir))
+
+        result = _git("-C", str(clone_dir), "rev-parse", "HEAD")
+        commit_sha = result.stdout.strip()
+        repo_name = os.path.basename(url).removesuffix(".git")
+
+        cache_dir = _plugins_dir() / "cache" / "local" / repo_name / "0.0.0"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+
+        _copy_content(clone_dir, cache_dir, {"skills": [], "agents": []})
+
+    (cache_dir / ".in_use").write_text("installed\n")
+    _update_installed_json("local", repo_name, "0.0.0", cache_dir, commit_sha)
+    if enable:
+        _update_enabled_plugins("local", repo_name)
+
+    print(f"==> Installed {repo_name} from {url} -> {cache_dir}")
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install Claude Code plugins from a marketplace.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--marketplace-repo", metavar="OWNER/REPO", help="Register a GitHub marketplace repo"
+    )
+    group.add_argument(
+        "--all", action="store_true", help="Install all plugins from registered marketplaces"
+    )
+    group.add_argument("--repo", metavar="URL", help="Install plugin from a git URL")
+    group.add_argument("names", nargs="*", default=[], help="Plugin names to install")
+    parser.add_argument(
+        "--no-enable", action="store_true", help="Cache plugins without enabling in settings.json"
+    )
+
+    args = parser.parse_args()
+    enable = not args.no_enable
+
+    if args.marketplace_repo:
+        register_marketplace(args.marketplace_repo)
+    elif args.all:
+        install_all(enable=enable)
+    elif args.repo:
+        install_from_repo(args.repo, enable=enable)
+    elif args.names:
+        install_named(args.names, enable=enable)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/runner/opencode/Containerfile
+++ b/images/runner/opencode/Containerfile
@@ -1,0 +1,34 @@
+FROM localhost/base:latest
+
+ARG OPENCODE_VERSION=1.15.13
+ARG OPENCODE_SHA256=51785a07c009f27c5125a5235c5a0ff78433dace07f73fbc44eb672ead4b3d79
+
+USER root
+
+RUN curl -fsSL -o /tmp/opencode.tar.gz \
+        "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
+    && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/opencode \
+    && rm -f /tmp/opencode.tar.gz
+
+COPY opencode/install-skills.py /usr/local/bin/install-skills
+RUN chmod +x /usr/local/bin/install-skills
+
+COPY opencode/opencode.json /home/agent-ci/.config/opencode/opencode.json
+RUN chown -R agent-ci:agent-ci /home/agent-ci/.config
+
+USER agent-ci
+RUN install-skills --marketplace-repo opendatahub-io/skills-registry \
+    && install-skills --all
+
+USER root
+COPY shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER agent-ci
+ENV AGENT_TOOL=opencode
+ENV OPENCODE_CONFIG_DIR=/home/agent-ci/.config/opencode
+WORKDIR /home/agent-ci
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["opencode"]

--- a/images/runner/opencode/Containerfile.openshell
+++ b/images/runner/opencode/Containerfile.openshell
@@ -1,0 +1,38 @@
+# OpenCode sandbox image for OpenShell.
+#
+# Use with: agentic-ci run --backend openshell --image <this-image> ...
+# Or:       openshell sandbox create --from <this-image> --provider ...
+#
+# Build:
+#   podman build -t openshell-base -f images/runner/shared/Containerfile.openshell-base images/runner/
+#   podman build -t openshell-opencode -f images/runner/opencode/Containerfile.openshell images/runner/
+
+FROM localhost/openshell-base:latest
+
+ARG OPENCODE_VERSION=1.15.11
+ARG OPENCODE_SHA256=49317253722c698394980e1921ff28e919d79bb29d5c3f4cf314a4adaf7037cd
+
+USER root
+
+RUN curl -fsSL -o /tmp/opencode.tar.gz \
+        "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
+    && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/opencode \
+    && rm -f /tmp/opencode.tar.gz
+
+COPY opencode/install-skills.py /usr/local/bin/install-skills
+RUN chmod +x /usr/local/bin/install-skills
+
+COPY opencode/opencode.json /sandbox/.config/opencode/opencode.json
+RUN chown -R sandbox:sandbox /sandbox/.config
+
+COPY shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+USER sandbox
+RUN install-skills --marketplace-repo opendatahub-io/skills-registry \
+    && install-skills --all
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["opencode"]

--- a/images/runner/opencode/install-skills.py
+++ b/images/runner/opencode/install-skills.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Install skills from a marketplace registry for OpenCode.
+
+Clones plugin repos from a marketplace and copies their skill directories
+into OpenCode's global skills path (~/.config/opencode/skills/).
+
+Usage:
+    install-skills.py --marketplace-repo opendatahub-io/skills-registry
+    install-skills.py --all
+    install-skills.py plugin-a plugin-b
+
+Environment:
+    OPENCODE_CONFIG_DIR     Override ~/.config/opencode
+                            (default: $HOME/.config/opencode)
+    MARKETPLACE_CACHE_DIR   Override marketplace cache location
+                            (default: $OPENCODE_CONFIG_DIR)
+"""
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def _config_dir():
+    return Path(
+        os.environ.get(
+            "OPENCODE_CONFIG_DIR",
+            Path.home() / ".config" / "opencode",
+        )
+    )
+
+
+def _skills_dir():
+    return _config_dir() / "skills"
+
+
+def _marketplace_base():
+    return Path(os.environ.get("MARKETPLACE_CACHE_DIR", str(_config_dir()))) / "marketplaces"
+
+
+def _git(*args, **kwargs):
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        **kwargs,
+    )
+
+
+def _read_json(path):
+    with open(path) as f:
+        return json.load(f)
+
+
+# ── marketplace registration ────────────────────────────────────────────
+
+
+def register_marketplace(repo):
+    url = f"https://github.com/{repo}.git"
+    print(f"==> Registering marketplace from {repo}")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "registry"
+        _git("clone", "--depth", "1", "--quiet", url, str(clone_dir))
+
+        mkt_json_path = clone_dir / ".claude-plugin" / "marketplace.json"
+        if not mkt_json_path.exists():
+            print(f"ERROR: {repo} has no .claude-plugin/marketplace.json", file=sys.stderr)
+            sys.exit(1)
+
+        mkt_data = _read_json(mkt_json_path)
+        mkt_name = mkt_data.get("name") or os.path.basename(repo)
+
+        mkt_dir = _marketplace_base() / mkt_name
+        mkt_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(mkt_json_path, mkt_dir / "marketplace.json")
+
+    print(f"==> Marketplace '{mkt_name}' registered")
+
+
+# ── skill installation ─────────────────────────────────────────────────
+
+
+def _clone_source(repo, ref, dest):
+    url = f"https://github.com/{repo}.git"
+    if len(ref) == 40 and all(c in "0123456789abcdef" for c in ref):
+        _git("clone", "--quiet", url, str(dest))
+        _git("-C", str(dest), "checkout", "--quiet", ref)
+    else:
+        _git("clone", "--depth", "1", "--branch", ref, "--quiet", url, str(dest))
+
+
+def _copy_skills(src, dest):
+    """Copy skills from cloned source into OpenCode skills directory."""
+    src = Path(src)
+    dest = Path(dest)
+    dest.mkdir(parents=True, exist_ok=True)
+
+    for search_path in [".claude/skills", ".opencode/skills", "skills"]:
+        candidate = src / search_path
+        if candidate.is_dir():
+            shutil.copytree(candidate, dest, dirs_exist_ok=True)
+            return True
+    return False
+
+
+def install_plugin(mkt_name, plugin_entry):
+    name = plugin_entry["name"]
+    version = plugin_entry.get("version", "0.0.0")
+    source = plugin_entry["source"]
+    src_repo = source["repo"]
+    src_ref = source.get("ref", "main")
+
+    print(f"==> Installing skills from {name}@{version} ({src_repo} @ {src_ref})")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        clone_dir = Path(tmp) / "src"
+        _clone_source(src_repo, src_ref, clone_dir)
+
+        skills_dest = _skills_dir()
+        found = _copy_skills(clone_dir, skills_dest)
+
+    if found:
+        print(f"==> Installed skills from {name}@{version} -> {skills_dest}")
+    else:
+        print(f"==> No skills found in {name}@{version}")
+
+
+# ── install modes ───────────────────────────────────────────────────────
+
+
+def install_all():
+    mkt_base = _marketplace_base()
+    if not mkt_base.exists():
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+    found = False
+    for mkt_json in sorted(mkt_base.glob("*/marketplace.json")):
+        found = True
+        mkt_name = mkt_json.parent.name
+        data = _read_json(mkt_json)
+        plugins = data.get("plugins", [])
+        print(f"==> Marketplace '{mkt_name}': {len(plugins)} plugins")
+        for entry in plugins:
+            install_plugin(mkt_name, entry)
+
+    if not found:
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+
+def install_named(names):
+    mkt_base = _marketplace_base()
+    if not mkt_base.exists():
+        print("ERROR: no marketplaces registered", file=sys.stderr)
+        sys.exit(1)
+
+    marketplaces = {}
+    for mkt_json in sorted(mkt_base.glob("*/marketplace.json")):
+        mkt_name = mkt_json.parent.name
+        marketplaces[mkt_name] = _read_json(mkt_json)
+
+    for target in names:
+        installed = False
+        for mkt_name, data in marketplaces.items():
+            for entry in data.get("plugins", []):
+                if entry["name"] == target:
+                    install_plugin(mkt_name, entry)
+                    installed = True
+                    break
+            if installed:
+                break
+        if not installed:
+            print(f"ERROR: plugin '{target}' not found", file=sys.stderr)
+            sys.exit(1)
+
+
+# ── CLI ─────────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Install skills from a marketplace for OpenCode.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--marketplace-repo", metavar="OWNER/REPO", help="Register a GitHub marketplace repo"
+    )
+    group.add_argument(
+        "--all", action="store_true", help="Install all skills from registered marketplaces"
+    )
+    group.add_argument("names", nargs="*", default=[], help="Plugin names to install skills from")
+
+    args = parser.parse_args()
+
+    if args.marketplace_repo:
+        register_marketplace(args.marketplace_repo)
+    elif args.all:
+        install_all()
+    elif args.names:
+        install_named(args.names)
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/images/runner/opencode/opencode.json
+++ b/images/runner/opencode/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "permission": { "*": "allow" }
+}

--- a/images/runner/shared/Containerfile.base
+++ b/images/runner/shared/Containerfile.base
@@ -1,0 +1,64 @@
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
+
+ARG UV_VERSION=0.11.18
+ARG UV_SHA256=a095a969fc8357f42e35652e0554525a47a29010ddb814bd82650c2ffa7d6d62
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+
+ARG GH_VERSION=2.93.0
+ARG GH_SHA256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+
+ARG GLAB_VERSION=1.101.0
+ARG GLAB_SHA256=f8f40309a622416b769a455a85509bae7800070cd023466f2d33d8ee82f3fc61
+
+RUN microdnf install -y --nodocs \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        jq \
+        make \
+        which \
+        tar \
+        xz \
+        shadow-utils \
+    && microdnf clean all
+
+RUN useradd -u 1000 -m agent-ci
+
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+RUN curl -fsSL -o /tmp/shellcheck.tar.xz \
+        "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    && echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/shellcheck.tar.xz -C /tmp \
+    && mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck \
+    && chmod +x /usr/local/bin/shellcheck \
+    && rm -rf /tmp/shellcheck.tar.xz /tmp/shellcheck-v${SHELLCHECK_VERSION}
+
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+RUN uv pip install --system --no-cache \
+        agentic-ci==0.2.22 \
+        ruff==0.15.15

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -1,0 +1,94 @@
+# OpenShell sandbox base image.
+#
+# Equivalent of the NVIDIA ghcr.io/nvidia/openshell-community/sandboxes/base
+# image but UBI-based. Agent CLIs are added by per-agent Containerfiles
+# (Containerfile.openshell in each agent directory).
+#
+# Conventions from the OpenShell sandbox contract:
+#   - sandbox user with writable /sandbox home
+#   - iproute2 for network namespace management
+#   - /sandbox as the working directory
+#
+# x86_64 only.
+
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
+
+ARG UV_VERSION=0.11.16
+ARG UV_SHA256=1bc4be1be0a000f893b0d1db97906cf392b63fa22fda9a0ecf33d0d4bbb4bc9a
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+
+ARG GH_VERSION=2.93.0
+ARG GH_SHA256=02d1290eba130e0b896f3709ffff22e1c75a51475ddb70476a85abc6b5807af0
+
+ARG GLAB_VERSION=1.100.0
+ARG GLAB_SHA256=d2a8ccffe924d3ad22feb2d1338840e9a610041c6ea6fd76e9aeda3744f210c2
+
+# System packages. iproute is required by the OpenShell supervisor for
+# network namespace setup.
+RUN microdnf install -y --nodocs \
+        python3 \
+        python3-pip \
+        git \
+        curl \
+        jq \
+        make \
+        which \
+        tar \
+        xz \
+        shadow-utils \
+        iproute \
+    && microdnf clean all
+
+# sandbox user — matches the OpenShell convention
+RUN groupadd -g 998 sandbox \
+    && useradd -u 998 -g sandbox -m -d /sandbox -s /bin/bash sandbox
+
+# uv (pinned)
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+# GitHub CLI (pinned)
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+# GitLab CLI (pinned)
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# ShellCheck (pinned)
+RUN curl -fsSL -o /tmp/shellcheck.tar.xz \
+        "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    && echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/shellcheck.tar.xz -C /tmp \
+    && mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck \
+    && chmod +x /usr/local/bin/shellcheck \
+    && rm -rf /tmp/shellcheck.tar.xz /tmp/shellcheck-v${SHELLCHECK_VERSION}
+
+# Python packages (agentic-ci for skill use inside the sandbox)
+RUN uv pip install --system --no-cache \
+        agentic-ci==0.2.22 \
+        ruff==0.15.14
+
+# Sandbox home directories
+USER sandbox
+RUN mkdir -p /sandbox/.local/bin /sandbox/.config /sandbox/.claude /sandbox/.agents
+ENV PATH="/sandbox/.local/bin:${PATH}"
+
+WORKDIR /sandbox

--- a/images/runner/shared/entrypoint.sh
+++ b/images/runner/shared/entrypoint.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# Container entrypoint for AI coding agent runner images.
+#
+# Handles GCP/Vertex AI credential setup from environment variables
+# so standalone callers only need to pass env vars. When used with
+# agentic-ci, this entrypoint is overridden (--entrypoint sleep).
+#
+# Auth methods:
+#   Vertex AI:  GCP_SERVICE_ACCOUNT_KEY (raw JSON or base64)
+#               AIPCC_CICD_GCP_SERVICE_ACCOUNT_KEY / AIPCC_CICD_GCP_PROJECT_ID
+#               take precedence over GCP_* if defined.
+#   Direct:     ANTHROPIC_API_KEY (no setup needed)
+
+set -euo pipefail
+
+_is_json() {
+    printf '%s\n' "$1" | python3 -m json.tool >/dev/null 2>&1
+}
+
+_setup_vertex() {
+    local creds=""
+
+    if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]]; then
+        if _is_json "$GCP_SERVICE_ACCOUNT_KEY"; then
+            creds="$GCP_SERVICE_ACCOUNT_KEY"
+        else
+            local decoded
+            decoded=$(printf '%s\n' "$GCP_SERVICE_ACCOUNT_KEY" | base64 -d 2>/dev/null) || true
+            if [[ -n "$decoded" ]] && _is_json "$decoded"; then
+                creds="$decoded"
+            else
+                echo "ERROR: GCP_SERVICE_ACCOUNT_KEY is not valid JSON or base64-encoded JSON" >&2
+                exit 1
+            fi
+        fi
+    fi
+
+    [[ -z "$creds" ]] && return 1
+
+    if [[ -n "${GCP_PROJECT_ID:-}" && -z "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]]; then
+        export ANTHROPIC_VERTEX_PROJECT_ID="$GCP_PROJECT_ID"
+    fi
+
+    local gcloud_dir="$HOME/.config/gcloud"
+    mkdir -p "$gcloud_dir/configurations"
+
+    cat > "$gcloud_dir/configurations/config_default" << EOF
+[core]
+project = ${ANTHROPIC_VERTEX_PROJECT_ID:-}
+disable_prompts = true
+EOF
+
+    printf '%s\n' "$creds" > "$gcloud_dir/application_default_credentials.json"
+    chmod 600 "$gcloud_dir/application_default_credentials.json"
+
+    export CLOUD_ML_REGION="${CLOUD_ML_REGION:-global}"
+    _VERTEX_CONFIGURED=1
+}
+
+_enable_plugins() {
+    local plugins_var="${AGENT_ENABLED_PLUGINS:-}"
+
+    local claude_home="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+    local settings_path="$claude_home/settings.json"
+    local installed_path="$claude_home/plugins/installed_plugins.json"
+
+    if [[ ! -f "$installed_path" ]]; then
+        if [[ -n "$plugins_var" ]]; then
+            echo "WARNING: AGENT_ENABLED_PLUGINS is set but $installed_path not found" >&2
+        fi
+        return 0
+    fi
+    [[ ! -f "$settings_path" ]] && printf '{}\n' > "$settings_path"
+
+    # Matching uses the name prefix before '@' (e.g. 'foo' from 'foo@mkt'),
+    # so AGENT_ENABLED_PLUGINS=foo enables foo from all marketplaces.
+    python3 -c "
+import json, sys
+
+plugins_csv = sys.argv[1]
+settings_path = sys.argv[2]
+installed_path = sys.argv[3]
+
+with open(installed_path) as f:
+    installed = json.load(f)
+installed_keys = list(installed.get('plugins', {}).keys())
+
+try:
+    with open(settings_path) as f:
+        settings = json.load(f)
+except (json.JSONDecodeError, ValueError):
+    print(f'WARNING: {settings_path} contains invalid JSON, resetting to empty', file=sys.stderr)
+    settings = {}
+enabled = settings.setdefault('enabledPlugins', {})
+
+requested = set(p.strip() for p in plugins_csv.split(',') if p.strip()) if plugins_csv else set()
+
+if not requested:
+    for key in installed_keys:
+        enabled[key] = True
+else:
+    enabled.clear()
+    matched = set()
+    for key in installed_keys:
+        name = key.split('@')[0]
+        if name in requested:
+            enabled[key] = True
+            matched.add(name)
+
+    unmatched = sorted(requested - matched)
+    if unmatched:
+        if matched:
+            safe_matched = ', '.join(sorted(matched))
+            if len(safe_matched) > 200:
+                safe_matched = safe_matched[:200] + '...'
+            print(f'Matched: {safe_matched}', file=sys.stderr)
+        safe_names = ', '.join(unmatched)
+        if len(safe_names) > 200:
+            safe_names = safe_names[:200] + '...'
+        print(f'ERROR: unknown plugin(s) in AGENT_ENABLED_PLUGINS: {safe_names}', file=sys.stderr)
+        sys.exit(1)
+
+with open(settings_path, 'w') as f:
+    json.dump(settings, f, indent=2)
+    f.write('\n')
+" "$plugins_var" "$settings_path" "$installed_path"
+}
+
+_detect_tool() {
+    local cmd="${1:-}"
+    case "$cmd" in
+        claude|claude-code)
+            export DISABLE_AUTOUPDATER=1
+            if [[ "${_VERTEX_CONFIGURED:-}" == "1" ]]; then
+                export CLAUDE_CODE_USE_VERTEX=1
+            fi
+            ;;
+        opencode)
+            export OPENCODE_DISABLE_AUTOUPDATE=1
+            ;;
+        *)
+            if [[ "${AGENT_TOOL:-}" == "claude" ]]; then
+                export DISABLE_AUTOUPDATER=1
+                if [[ "${_VERTEX_CONFIGURED:-}" == "1" ]]; then
+                    export CLAUDE_CODE_USE_VERTEX=1
+                fi
+            elif [[ "${AGENT_TOOL:-}" == "opencode" ]]; then
+                export OPENCODE_DISABLE_AUTOUPDATE=1
+            fi
+            ;;
+    esac
+}
+
+# Allow sourcing for tests without executing main logic
+if [[ "${1:-}" == "--source-only" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# AIPCC_CICD_GCP_* variants take precedence over GCP_* if defined.
+if [[ -n "${AIPCC_CICD_GCP_SERVICE_ACCOUNT_KEY:-}" ]]; then
+    export GCP_SERVICE_ACCOUNT_KEY="$AIPCC_CICD_GCP_SERVICE_ACCOUNT_KEY"
+fi
+if [[ -n "${AIPCC_CICD_GCP_PROJECT_ID:-}" ]]; then
+    export GCP_PROJECT_ID="$AIPCC_CICD_GCP_PROJECT_ID"
+fi
+
+_VERTEX_CONFIGURED=0
+if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]]; then
+    _setup_vertex
+fi
+
+_detect_tool "${1:-}"
+_enable_plugins
+
+# If the first argument is the tool command itself (e.g. "claude", "opencode"),
+# pass through as-is. Otherwise, the caller passed only flags/args and expects
+# the entrypoint to prepend the tool command (matching the runner image
+# behavior where the entrypoint always prepends the agent command).
+case "${1:-}" in
+    claude|claude-code|opencode|bash|sh)
+        exec "$@"
+        ;;
+    *)
+        exec "${AGENT_TOOL:-claude}" "$@"
+        ;;
+esac

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,11 @@ markdown_extensions:
 
 nav:
   - Home: index.md
+  - Container Images:
+      - Overview: image/index.md
+      - Build Pipeline: image/build.md
+      - Extending: image/extending.md
+      - Skill Loading: image/skills.md
   - Sandbox Backends:
       - Podman: backends/podman.md
       - OpenShell: backends/openshell.md

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "minimumReleaseAge": "7 days",
+  "postUpgradeTasks": {
+    "commands": ["python3 scripts/bump-versions.py --sync"],
+    "fileFilters": [
+      "images/runner/shared/Containerfile.base",
+      "images/runner/shared/Containerfile.openshell-base",
+      "images/runner/claude-code/Containerfile",
+      "images/runner/claude-code/Containerfile.openshell",
+      "images/runner/opencode/Containerfile",
+      "images/runner/opencode/Containerfile.openshell",
+      "images/ci/Containerfile.podman",
+      "images/ci/Containerfile.openshell"
+    ],
+    "executionMode": "update"
+  },
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "agentic-ci",
+        "claude-code"
+      ],
+      "minimumReleaseAge": "0 days"
+    }
+  ],
+  "customDatasources": {
+    "claude-code": {
+      "defaultRegistryUrlTemplate": "https://downloads.claude.ai/claude-code-releases/latest",
+      "format": "plain"
+    }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG UV_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$"
+      ],
+      "matchStrings": ["ARG SHELLCHECK_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "koalaman/shellcheck",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG GH_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "cli/cli",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG GLAB_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "gitlab-org/cli",
+      "datasourceTemplate": "gitlab-releases",
+      "registryUrlTemplate": "https://gitlab.com",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG GITLEAKS_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "gitleaks/gitleaks",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/claude-code/Containerfile$",
+        "^images/runner/claude-code/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG CLAUDE_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "claude-code",
+      "datasourceTemplate": "custom.claude-code",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/opencode/Containerfile$",
+        "^images/runner/opencode/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG OPENCODE_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "anomalyco/opencode",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG ACLI_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "acli",
+      "datasourceTemplate": "rpm",
+      "registryUrlTemplate": "https://acli.atlassian.com/linux/rpm/repodata/",
+      "versioningTemplate": "rpm"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$"
+      ],
+      "matchStrings": ["ruff==(?<currentValue>[^\\s]+)"],
+      "depNameTemplate": "ruff",
+      "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["agentic-ci==(?<currentValue>[^\\s]+)"],
+      "depNameTemplate": "agentic-ci",
+      "datasourceTemplate": "pypi"
+    }
+  ]
+}

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -1,0 +1,637 @@
+#!/usr/bin/env python3
+"""Bump pinned dependency versions in Containerfiles.
+
+For each tool, fetches the latest version and SHA256 checksum, then
+updates the corresponding ARG lines in the Containerfiles.
+
+Usage:
+    bump-versions.py                 # bump all tools
+    bump-versions.py --check         # check for updates without modifying files
+    bump-versions.py --tool uv gh    # bump specific tools only
+    bump-versions.py --sync          # sync SHA256s for currently pinned versions
+    bump-versions.py --renovate-json # generate Renovate custom datasource JSON
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASE_CF = REPO_ROOT / "images" / "runner" / "shared" / "Containerfile.base"
+CLAUDE_CF = REPO_ROOT / "images" / "runner" / "claude-code" / "Containerfile"
+OPENCODE_CF = REPO_ROOT / "images" / "runner" / "opencode" / "Containerfile"
+CI_CF = REPO_ROOT / "images" / "ci" / "Containerfile.podman"
+OPENSHELL_BASE_CF = REPO_ROOT / "images" / "runner" / "shared" / "Containerfile.openshell-base"
+OPENSHELL_CLAUDE_CF = REPO_ROOT / "images" / "runner" / "claude-code" / "Containerfile.openshell"
+OPENSHELL_OPENCODE_CF = REPO_ROOT / "images" / "runner" / "opencode" / "Containerfile.openshell"
+OPENSHELL_CI_CF = REPO_ROOT / "images" / "ci" / "Containerfile.openshell"
+RENOVATE_OUT_DIR = REPO_ROOT / "public" / "renovate"
+
+
+def _fetch_json(url):
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "bump-versions/1.0")
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def _fetch_text(url):
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "bump-versions/1.0")
+    with urllib.request.urlopen(req) as resp:
+        return resp.read().decode().strip()
+
+
+def _sha256_of_url(url):
+    req = urllib.request.Request(url)
+    req.add_header("User-Agent", "bump-versions/1.0")
+    h = hashlib.sha256()
+    with urllib.request.urlopen(req) as resp:
+        while chunk := resp.read(65536):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _github_latest(owner_repo):
+    data = _fetch_json(f"https://api.github.com/repos/{owner_repo}/releases/latest")
+    return data["tag_name"].lstrip("v")
+
+
+def _opencode_sha(assets, version):
+    """Return SHA256 for opencode-linux-x64.tar.gz.
+
+    Uses the ``digest`` field from the GitHub release asset when available
+    (avoids downloading the tarball). Falls back to computing SHA256 from
+    the download when the field is absent.
+    """
+    asset = next((a for a in assets if a["name"] == "opencode-linux-x64.tar.gz"), None)
+    if asset is None:
+        raise RuntimeError(f"opencode-linux-x64.tar.gz not found in release v{version}")
+    digest = asset.get("digest")
+    if digest:
+        return digest.removeprefix("sha256:")
+    url = (
+        f"https://github.com/anomalyco/opencode/releases/download/"
+        f"v{version}/opencode-linux-x64.tar.gz"
+    )
+    return _sha256_of_url(url)
+
+
+def _update_arg(path, arg_name, new_value):
+    text = path.read_text()
+    pattern = re.compile(rf"^(ARG\s+{re.escape(arg_name)}\s*=\s*)(.+)$", re.MULTILINE)
+    match = pattern.search(text)
+    if not match:
+        return None
+    old_value = match.group(2)
+    if old_value == new_value:
+        return None
+    text = pattern.sub(rf"\g<1>{new_value}", text)
+    path.write_text(text)
+    return old_value
+
+
+# ── Tool definitions ────────────────────────────────────────────────────
+
+
+def bump_uv(check_only):
+    version = _github_latest("astral-sh/uv")
+    url = (
+        f"https://github.com/astral-sh/uv/releases/download/"
+        f"{version}/uv-x86_64-unknown-linux-musl.tar.gz"
+    )
+    sha_text = _fetch_text(url + ".sha256")
+    sha = sha_text.split()[0]
+
+    result = {"tool": "uv", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "UV_VERSION", version)
+                _update_arg(cf, "UV_SHA256", sha)
+    return result
+
+
+def bump_shellcheck(check_only):
+    version = _github_latest("koalaman/shellcheck")
+    url = (
+        f"https://github.com/koalaman/shellcheck/releases/download/"
+        f"v{version}/shellcheck-v{version}.linux.x86_64.tar.xz"
+    )
+    sha = _sha256_of_url(url)
+
+    result = {"tool": "shellcheck", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+            if cf.exists():
+                _update_arg(cf, "SHELLCHECK_VERSION", version)
+                _update_arg(cf, "SHELLCHECK_SHA256", sha)
+    return result
+
+
+def bump_gh(check_only):
+    version = _github_latest("cli/cli")
+    url = f"https://github.com/cli/cli/releases/download/v{version}/gh_{version}_linux_amd64.tar.gz"
+    sha = _sha256_of_url(url)
+
+    result = {"tool": "gh", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "GH_VERSION", version)
+                _update_arg(cf, "GH_SHA256", sha)
+    return result
+
+
+def bump_glab(check_only):
+    data = _fetch_json(
+        "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest"
+    )
+    version = data["tag_name"].lstrip("v")
+    url = (
+        f"https://gitlab.com/gitlab-org/cli/-/releases/"
+        f"v{version}/downloads/glab_{version}_linux_amd64.tar.gz"
+    )
+    sha = _sha256_of_url(url)
+
+    result = {"tool": "glab", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "GLAB_VERSION", version)
+                _update_arg(cf, "GLAB_SHA256", sha)
+    return result
+
+
+def bump_claude(check_only):
+    version = _fetch_text("https://downloads.claude.ai/claude-code-releases/latest")
+    manifest = _fetch_json(
+        f"https://downloads.claude.ai/claude-code-releases/{version}/manifest.json"
+    )
+    sha = manifest["platforms"]["linux-x64"]["checksum"]
+
+    result = {"tool": "claude", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [CLAUDE_CF, OPENSHELL_CLAUDE_CF]:
+            if cf.exists():
+                _update_arg(cf, "CLAUDE_VERSION", version)
+                _update_arg(cf, "CLAUDE_SHA256", sha)
+    return result
+
+
+def bump_acli(check_only):
+    try:
+        out = subprocess.run(
+            [
+                "dnf",
+                "repoquery",
+                "--quiet",
+                "--latest-limit=1",
+                "--repo=acli",
+                "--queryformat=%{VERSION}-%{RELEASE}",
+                "acli.x86_64",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        version = out.stdout.strip()
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        version = "(requires dnf with acli repo configured)"
+
+    result = {"tool": "acli", "version": version}
+    if not check_only and "~" in version:
+        for cf in [CI_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "ACLI_VERSION", version)
+    return result
+
+
+def bump_opencode(check_only):
+    data = _fetch_json("https://api.github.com/repos/anomalyco/opencode/releases/latest")
+    version = data["tag_name"].lstrip("v")
+    sha = _opencode_sha(data["assets"], version)
+
+    result = {"tool": "opencode", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [OPENCODE_CF, OPENSHELL_OPENCODE_CF]:
+            if cf.exists():
+                _update_arg(cf, "OPENCODE_VERSION", version)
+                _update_arg(cf, "OPENCODE_SHA256", sha)
+    return result
+
+
+def bump_gitleaks(check_only):
+    version = _github_latest("gitleaks/gitleaks")
+    url = (
+        f"https://github.com/gitleaks/gitleaks/releases/download/"
+        f"v{version}/gitleaks_{version}_linux_x64.tar.gz"
+    )
+    sha = _sha256_of_url(url)
+
+    result = {"tool": "gitleaks", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [CI_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "GITLEAKS_VERSION", version)
+                _update_arg(cf, "GITLEAKS_SHA256", sha)
+    return result
+
+
+def bump_ruff(check_only):
+    data = _fetch_json("https://pypi.org/pypi/ruff/json")
+    version = data["info"]["version"]
+
+    result = {"tool": "ruff", "version": version}
+    if not check_only:
+        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+            if cf.exists():
+                text = cf.read_text()
+                text = re.sub(r"ruff==[\d.]+", f"ruff=={version}", text)
+                cf.write_text(text)
+    return result
+
+
+def bump_agentic_ci(check_only):
+    data = _fetch_json("https://pypi.org/pypi/agentic-ci/json")
+    version = data["info"]["version"]
+
+    result = {"tool": "agentic-ci", "version": version}
+    if not check_only:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+            if not cf.exists():
+                continue
+            text = cf.read_text()
+            text = re.sub(r"agentic-ci==[\d.]+", f"agentic-ci=={version}", text)
+            cf.write_text(text)
+    return result
+
+
+TOOLS = {
+    "uv": bump_uv,
+    "shellcheck": bump_shellcheck,
+    "gh": bump_gh,
+    "glab": bump_glab,
+    "gitleaks": bump_gitleaks,
+    "claude": bump_claude,
+    "opencode": bump_opencode,
+    "acli": bump_acli,
+    "ruff": bump_ruff,
+    "agentic-ci": bump_agentic_ci,
+}
+
+
+def _current_value(path, arg_name):
+    if not path.exists():
+        return None
+    match = re.search(rf"^ARG\s+{re.escape(arg_name)}\s*=\s*(.+)$", path.read_text(), re.MULTILINE)
+    return match.group(1) if match else None
+
+
+# ── Sync functions (update SHA256 for currently pinned versions) ────────
+
+
+def sync_uv():
+    versions = {}
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "UV_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "uv", "skipped": "UV_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://github.com/astral-sh/uv/releases/download/"
+            f"{version}/uv-x86_64-unknown-linux-musl.tar.gz"
+        )
+        sha_text = _fetch_text(url + ".sha256")
+        sha = sha_text.split()[0]
+        for cf in files:
+            _update_arg(cf, "UV_SHA256", sha)
+    return {"tool": "uv", "versions": list(versions)}
+
+
+def sync_shellcheck():
+    versions = {}
+    for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "SHELLCHECK_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "shellcheck", "skipped": "SHELLCHECK_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://github.com/koalaman/shellcheck/releases/download/"
+            f"v{version}/shellcheck-v{version}.linux.x86_64.tar.xz"
+        )
+        sha = _sha256_of_url(url)
+        for cf in files:
+            _update_arg(cf, "SHELLCHECK_SHA256", sha)
+    return {"tool": "shellcheck", "versions": list(versions)}
+
+
+def sync_gh():
+    versions = {}
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "GH_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "gh", "skipped": "GH_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://github.com/cli/cli/releases/download/"
+            f"v{version}/gh_{version}_linux_amd64.tar.gz"
+        )
+        sha = _sha256_of_url(url)
+        for cf in files:
+            _update_arg(cf, "GH_SHA256", sha)
+    return {"tool": "gh", "versions": list(versions)}
+
+
+def sync_glab():
+    versions = {}
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "GLAB_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "glab", "skipped": "GLAB_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://gitlab.com/gitlab-org/cli/-/releases/"
+            f"v{version}/downloads/glab_{version}_linux_amd64.tar.gz"
+        )
+        sha = _sha256_of_url(url)
+        for cf in files:
+            _update_arg(cf, "GLAB_SHA256", sha)
+    return {"tool": "glab", "versions": list(versions)}
+
+
+def sync_gitleaks():
+    versions = {}
+    for cf in [CI_CF, OPENSHELL_CI_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "GITLEAKS_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "gitleaks", "skipped": "GITLEAKS_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://github.com/gitleaks/gitleaks/releases/download/"
+            f"v{version}/gitleaks_{version}_linux_x64.tar.gz"
+        )
+        sha = _sha256_of_url(url)
+        for cf in files:
+            _update_arg(cf, "GITLEAKS_SHA256", sha)
+    return {"tool": "gitleaks", "versions": list(versions)}
+
+
+def sync_claude():
+    versions = {}
+    for cf in [CLAUDE_CF, OPENSHELL_CLAUDE_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "CLAUDE_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "claude", "skipped": "CLAUDE_VERSION not found"}
+    for version, files in versions.items():
+        manifest = _fetch_json(
+            f"https://downloads.claude.ai/claude-code-releases/{version}/manifest.json"
+        )
+        sha = manifest["platforms"]["linux-x64"]["checksum"]
+        for cf in files:
+            _update_arg(cf, "CLAUDE_SHA256", sha)
+    return {"tool": "claude", "versions": list(versions)}
+
+
+def sync_opencode():
+    versions = {}
+    for cf in [OPENCODE_CF, OPENSHELL_OPENCODE_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "OPENCODE_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "opencode", "skipped": "OPENCODE_VERSION not found"}
+    for version, files in versions.items():
+        data = _fetch_json(
+            f"https://api.github.com/repos/anomalyco/opencode/releases/tags/v{version}"
+        )
+        sha = _opencode_sha(data["assets"], version)
+        for cf in files:
+            _update_arg(cf, "OPENCODE_SHA256", sha)
+    return {"tool": "opencode", "versions": list(versions)}
+
+
+def sync_acli():
+    return {"tool": "acli", "skipped": "rpm-based, no checksum to sync"}
+
+
+def sync_ruff():
+    return {"tool": "ruff", "skipped": "pip package, no checksum arg"}
+
+
+def sync_agentic_ci():
+    return {"tool": "agentic-ci", "skipped": "pip package, no checksum arg"}
+
+
+SYNC_TOOLS = {
+    "uv": sync_uv,
+    "shellcheck": sync_shellcheck,
+    "gh": sync_gh,
+    "glab": sync_glab,
+    "gitleaks": sync_gitleaks,
+    "claude": sync_claude,
+    "opencode": sync_opencode,
+    "acli": sync_acli,
+    "ruff": sync_ruff,
+    "agentic-ci": sync_agentic_ci,
+}
+
+
+# ── Renovate custom datasource JSON generators ──────────────────────────
+
+
+def renovate_json_claude():
+    """Return Renovate releases JSON for the claude-code custom datasource."""
+    version = _fetch_text("https://downloads.claude.ai/claude-code-releases/latest")
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    return {"releases": [{"version": version, "releaseTimestamp": now}]}
+
+
+def renovate_json_opencode():
+    """Return Renovate releases JSON for the opencode custom datasource."""
+    version = _github_latest("anomalyco/opencode")
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    return {"releases": [{"version": version, "releaseTimestamp": now}]}
+
+
+def renovate_json_acli():
+    """Return Renovate releases JSON for the acli custom datasource."""
+    out = subprocess.run(
+        [
+            "dnf",
+            "repoquery",
+            "--quiet",
+            "--latest-limit=1",
+            "--repo=acli",
+            "--queryformat=%{VERSION}-%{RELEASE}",
+            "acli.x86_64",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    version = out.stdout.strip()
+    if not version:
+        raise RuntimeError("dnf repoquery returned empty output; acli repo may not be configured")
+    now = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    return {"releases": [{"version": version, "releaseTimestamp": now}]}
+
+
+RENOVATE_TOOLS = {
+    "claude-code": renovate_json_claude,
+    "opencode": renovate_json_opencode,
+    "acli": renovate_json_acli,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Bump pinned versions in Containerfiles.")
+    parser.add_argument(
+        "--check", action="store_true", help="Check for updates without modifying files"
+    )
+    parser.add_argument(
+        "--sync", action="store_true", help="Sync SHA256 checksums for currently pinned versions"
+    )
+    parser.add_argument(
+        "--renovate-json",
+        action="store_true",
+        dest="renovate_json",
+        help="Generate Renovate custom datasource JSON files",
+    )
+    parser.add_argument(
+        "--tool", nargs="+", choices=list(TOOLS), help="Operate on specific tools only"
+    )
+    args = parser.parse_args()
+
+    if args.renovate_json:
+        tools = [t for t in (args.tool or list(RENOVATE_TOOLS)) if t in RENOVATE_TOOLS]
+        RENOVATE_OUT_DIR.mkdir(parents=True, exist_ok=True)
+        for name in tools:
+            print(f"Generating renovate JSON for {name}...", end=" ", flush=True)
+            try:
+                data = RENOVATE_TOOLS[name]()
+                out_file = RENOVATE_OUT_DIR / f"{name}.json"
+                out_file.write_text(json.dumps(data, indent=2))
+                print(data["releases"][0]["version"])
+            except Exception as e:
+                print(f"WARNING: {e}")
+        return
+
+    if args.sync:
+        tools = args.tool or list(SYNC_TOOLS)
+        for name in tools:
+            fn = SYNC_TOOLS.get(name)
+            if fn is None:
+                continue
+            print(f"Syncing {name}...", end=" ", flush=True)
+            try:
+                result = fn()
+                if "skipped" in result:
+                    print(f"skipped ({result['skipped']})")
+                else:
+                    versions = result.get("versions", [])
+                    if len(versions) > 1:
+                        print(
+                            f"diverged ({', '.join(versions)}) — "
+                            "hashes synced per file, bump versions to resolve"
+                        )
+                    else:
+                        print(versions[0] if versions else "done")
+            except Exception as e:
+                print(f"ERROR: {e}")
+        return
+
+    tools = args.tool or list(TOOLS)
+    updates = []
+
+    for name in tools:
+        print(f"Checking {name}...", end=" ", flush=True)
+        try:
+            result = TOOLS[name](check_only=args.check)
+            print(result["version"])
+            updates.append(result)
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+    if args.check:
+        print("\nCurrent → Latest:")
+        version_args = {
+            "uv": "UV_VERSION",
+            "shellcheck": "SHELLCHECK_VERSION",
+            "gh": "GH_VERSION",
+            "glab": "GLAB_VERSION",
+            "gitleaks": "GITLEAKS_VERSION",
+            "claude": "CLAUDE_VERSION",
+            "opencode": "OPENCODE_VERSION",
+            "acli": "ACLI_VERSION",
+        }
+        pip_packages = {"agentic-ci", "ruff"}
+        for u in updates:
+            name = u["tool"]
+            if name in version_args:
+                current = None
+                for cf in [
+                    BASE_CF,
+                    CLAUDE_CF,
+                    OPENCODE_CF,
+                    CI_CF,
+                    OPENSHELL_BASE_CF,
+                    OPENSHELL_CLAUDE_CF,
+                    OPENSHELL_OPENCODE_CF,
+                    OPENSHELL_CI_CF,
+                ]:
+                    current = _current_value(cf, version_args[name])
+                    if current is not None:
+                        break
+                latest = u["version"]
+                changed = " ← UPDATE" if current != latest else ""
+                print(f"  {name:15s} {current or '?':20s} → {latest}{changed}")
+            elif name in pip_packages:
+                current = "?"
+                for cf in [BASE_CF, OPENSHELL_BASE_CF, CI_CF, OPENSHELL_CI_CF]:
+                    if not cf.exists():
+                        continue
+                    match = re.search(rf"{re.escape(name)}==([\d.]+)", cf.read_text())
+                    if match:
+                        current = match.group(1)
+                        break
+                latest = u["version"]
+                changed = " ← UPDATE" if current != latest else ""
+                print(f"  {name:15s} {current:20s} → {latest}{changed}")
+    else:
+        print("\nContainerfiles updated.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/e2e/e2e-claude-runner.sh
+++ b/tests/e2e/e2e-claude-runner.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+# shellcheck source=tests/images/shell-utils.sh
+# e2e-claude-runner.sh -- End-to-end tests for the claude-runner image
+# using agentic-ci.
+#
+# Builds are handled by the CI job; this script runs a test prompt via
+# agentic-ci and verifies the output.
+#
+# Requires: python3, podman, agentic-ci
+# Credentials: GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS,
+#              or ANTHROPIC_API_KEY
+#
+# Usage:
+#   ./tests/e2e/e2e-claude-runner.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/../images/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_E2E="$(mktemp -d)"
+
+cleanup() {
+    agentic-ci stop --harness claude-code 2>/dev/null || true
+    rm -rf "$TMPDIR_E2E"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc -- expected '$pattern' in output"
+        echo "  Got: ${output:0:200}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+print_header "=== Preflight checks ==="
+check_dependencies python3 podman agentic-ci
+
+print_header "=== Component versions ==="
+echo "  agentic-ci: $(agentic-ci --version 2>&1 || echo unknown)"
+echo "  podman:     $(podman --version 2>&1 || echo unknown)"
+
+IMAGE="${CLAUDE_CONTAINER_IMAGE:-localhost/claude-runner:latest}"
+
+_has_creds() {
+    [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
+    [[ -n "${GCLOUD_CREDENTIALS:-}" ]] || \
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]]
+}
+
+if ! _has_creds; then
+    echo ""
+    print_warning "Skipping e2e tests (no credentials set)"
+    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, or ANTHROPIC_API_KEY"
+    exit 0
+fi
+
+# -- Streaming test -----------------------------------------------------------
+print_header "=== agentic-ci run: streaming ==="
+
+WORKDIR="$TMPDIR_E2E/streaming"
+mkdir -p "$WORKDIR"
+
+print_step "Running Claude Code via agentic-ci (streaming)..."
+RC=0
+agentic-ci run "Reply with only the word pong" \
+    --image "$IMAGE" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    > "$TMPDIR_E2E/stream-out.txt" 2>"$TMPDIR_E2E/stream-err.txt" || RC=$?
+
+assert_ok "streaming container exited successfully" test "$RC" -eq 0
+assert_ok "streaming output file is non-empty" test -s "$TMPDIR_E2E/stream-out.txt"
+assert_contains "streaming output contains response" \
+    "$(cat "$TMPDIR_E2E/stream-out.txt")" "pong"
+
+if [[ -s "$TMPDIR_E2E/stream-out.txt" ]]; then
+    echo "--- streaming output ---"
+    head -20 "$TMPDIR_E2E/stream-out.txt"
+    echo "--- end streaming output ---"
+fi
+
+# Stop the container before the next test
+agentic-ci stop --harness claude-code 2>/dev/null || true
+
+# -- Non-streaming test -------------------------------------------------------
+print_header "=== agentic-ci run: non-streaming ==="
+
+WORKDIR="$TMPDIR_E2E/nostream"
+mkdir -p "$WORKDIR"
+
+print_step "Running Claude Code via agentic-ci (non-streaming)..."
+RC=0
+agentic-ci run "Reply with only the word pong" \
+    --image "$IMAGE" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$TMPDIR_E2E/nostream-out.txt" 2>"$TMPDIR_E2E/nostream-err.txt" || RC=$?
+
+assert_ok "non-streaming container exited successfully" test "$RC" -eq 0
+assert_ok "non-streaming output file is non-empty" test -s "$TMPDIR_E2E/nostream-out.txt"
+assert_contains "non-streaming output contains response" \
+    "$(cat "$TMPDIR_E2E/nostream-out.txt")" "pong"
+
+if [[ -s "$TMPDIR_E2E/nostream-out.txt" ]]; then
+    echo "--- non-streaming output ---"
+    head -20 "$TMPDIR_E2E/nostream-out.txt"
+    echo "--- end non-streaming output ---"
+fi
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-opencode-runner.sh
+++ b/tests/e2e/e2e-opencode-runner.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# shellcheck source=tests/images/shell-utils.sh
+# e2e-opencode-runner.sh -- End-to-end tests for the opencode-runner image
+# using agentic-ci.
+#
+# Builds are handled by the CI job; this script runs a test prompt via
+# agentic-ci and verifies the output.
+#
+# Requires: python3, podman, agentic-ci
+# Credentials: GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS,
+#              or ANTHROPIC_API_KEY
+#
+# Usage:
+#   ./tests/e2e/e2e-opencode-runner.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/../images/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_E2E="$(mktemp -d)"
+
+cleanup() {
+    agentic-ci stop --harness opencode 2>/dev/null || true
+    rm -rf "$TMPDIR_E2E"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc -- expected '$pattern' in output"
+        echo "  Got: ${output:0:200}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+print_header "=== Preflight checks ==="
+check_dependencies python3 podman agentic-ci
+
+print_header "=== Component versions ==="
+echo "  agentic-ci: $(agentic-ci --version 2>&1 || echo unknown)"
+echo "  podman:     $(podman --version 2>&1 || echo unknown)"
+
+IMAGE="${OPENCODE_CONTAINER_IMAGE:-localhost/opencode-runner:latest}"
+
+_has_creds() {
+    [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
+    [[ -n "${GCLOUD_CREDENTIALS:-}" ]] || \
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]]
+}
+
+if ! _has_creds; then
+    echo ""
+    print_warning "Skipping e2e tests (no credentials set)"
+    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, or ANTHROPIC_API_KEY"
+    exit 0
+fi
+
+# -- Run OpenCode test --------------------------------------------------------
+print_header "=== agentic-ci run: OpenCode ==="
+
+WORKDIR="$TMPDIR_E2E/run"
+mkdir -p "$WORKDIR"
+
+print_step "Running OpenCode via agentic-ci..."
+RC=0
+agentic-ci run "Reply with only the word pong" \
+    --image "$IMAGE" \
+    --harness opencode \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$TMPDIR_E2E/out.txt" 2>"$TMPDIR_E2E/err.txt" || RC=$?
+
+assert_ok "container exited successfully" test "$RC" -eq 0
+
+COMBINED_OUTPUT="$(cat "$TMPDIR_E2E/out.txt" 2>/dev/null)$(cat "$TMPDIR_E2E/err.txt" 2>/dev/null)"
+assert_ok "output captured" test -n "$COMBINED_OUTPUT"
+
+if [[ -s "$TMPDIR_E2E/out.txt" ]]; then
+    echo "--- output ---"
+    head -20 "$TMPDIR_E2E/out.txt"
+    echo "--- end output ---"
+fi
+if [[ -s "$TMPDIR_E2E/err.txt" ]]; then
+    echo "--- stderr ---"
+    head -20 "$TMPDIR_E2E/err.txt"
+    echo "--- end stderr ---"
+fi
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# e2e-openshell-sandbox.sh -- End-to-end tests for OpenShell sandbox images.
+#
+# Builds the openshell-base, claude-sandbox, and opencode-sandbox images,
+# then verifies that expected binaries, configs, and plugins/skills are
+# present in each image. If credentials are available, also runs agent
+# prompts through the OpenShell backend.
+#
+# Requires: podman, agentic-ci (for agent run tests)
+# Credentials: GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS,
+#              or ANTHROPIC_API_KEY (optional, for agent run tests)
+#
+# Usage:
+#   ./tests/e2e/e2e-openshell-sandbox.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/../images/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_E2E="$(mktemp -d)"
+
+cleanup() {
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+    agentic-ci stop --backend openshell --harness opencode 2>/dev/null || true
+    rm -rf "$TMPDIR_E2E"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc -- expected '$pattern' in output"
+        echo "  Got: ${output:0:200}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+dump_gateway_log() {
+    local log
+    log="$(ls -t ~/.local/state/openshell/gateway-*.log 2>/dev/null | head -1)"
+    if [[ -n "$log" && -s "$log" ]]; then
+        echo "--- gateway log ($log) ---"
+        cat "$log"
+        echo "--- end gateway log ---"
+    fi
+}
+
+# --- Resolve sandbox images ---
+# Use pre-built images from env vars (CI), or build locally (dev).
+if [[ -n "${CLAUDE_SANDBOX_IMAGE:-}" ]] && [[ -n "${OPENCODE_SANDBOX_IMAGE:-}" ]]; then
+    print_header "=== Using pre-built sandbox images ==="
+    CLAUDE_SANDBOX="$CLAUDE_SANDBOX_IMAGE"
+    OPENCODE_SANDBOX="$OPENCODE_SANDBOX_IMAGE"
+    print_step "claude-sandbox: $CLAUDE_SANDBOX"
+    print_step "opencode-sandbox: $OPENCODE_SANDBOX"
+else
+    print_header "=== Building OpenShell sandbox images ==="
+
+    print_step "Building openshell-base..."
+    podman build -t openshell-base:latest \
+        -f "$REPO_ROOT/images/runner/shared/Containerfile.openshell-base" \
+        "$REPO_ROOT/images/runner/shared/"
+
+    print_step "Building claude-sandbox..."
+    podman build -t localhost/claude-sandbox:latest \
+        -f "$REPO_ROOT/images/runner/claude-code/Containerfile.openshell" \
+        "$REPO_ROOT/images/runner/"
+
+    CLAUDE_SANDBOX="localhost/claude-sandbox:latest"
+
+    print_step "Building opencode-sandbox..."
+    podman build -t localhost/opencode-sandbox:latest \
+        -f "$REPO_ROOT/images/runner/opencode/Containerfile.openshell" \
+        "$REPO_ROOT/images/runner/"
+
+    OPENCODE_SANDBOX="localhost/opencode-sandbox:latest"
+fi
+
+# Pre-built supervisor from PR #1763 (google-cloud provider + GCE metadata
+# emulator). The upstream supervisor image doesn't include these changes
+# yet. Remove this override once PR #1763 merges and the openshell RPM
+# is upgraded past 0.0.55.
+# Tracking: https://github.com/NVIDIA/OpenShell/pull/1763
+export OPENSHELL_SUPERVISOR_IMAGE=quay.io/mprpic/openshell-supervisor:pr1763
+print_step "Using supervisor image: $OPENSHELL_SUPERVISOR_IMAGE"
+
+# Helper: run a command inside a sandbox image as the sandbox user
+run_in() {
+    local image="$1"; shift
+    podman run --rm --entrypoint "" "$image" "$@"
+}
+
+# --- openshell-base checks ---
+print_header "=== openshell-base: binaries ==="
+
+assert_ok "uv is installed" run_in "$CLAUDE_SANDBOX" uv --version
+assert_ok "gh is installed" run_in "$CLAUDE_SANDBOX" gh --version
+assert_ok "glab is installed" run_in "$CLAUDE_SANDBOX" glab --version
+assert_ok "shellcheck is installed" run_in "$CLAUDE_SANDBOX" shellcheck --version
+assert_ok "git is installed" run_in "$CLAUDE_SANDBOX" git --version
+assert_ok "python3 is installed" run_in "$CLAUDE_SANDBOX" python3 --version
+assert_ok "ruff is installed" run_in "$CLAUDE_SANDBOX" ruff --version
+
+print_header "=== openshell-base: user/workdir ==="
+
+assert_ok "sandbox user exists (uid 998)" \
+    run_in "$CLAUDE_SANDBOX" id -u sandbox
+assert_ok "workdir is /sandbox" \
+    run_in "$CLAUDE_SANDBOX" sh -c 'test "$(pwd)" = "/sandbox"'
+
+# --- claude-sandbox checks ---
+print_header "=== claude-sandbox: binaries ==="
+
+assert_ok "claude is installed" run_in "$CLAUDE_SANDBOX" claude --version
+assert_ok "node is installed" run_in "$CLAUDE_SANDBOX" node --version
+
+print_header "=== claude-sandbox: plugins ==="
+
+assert_ok "settings.json exists" \
+    run_in "$CLAUDE_SANDBOX" test -f /sandbox/.claude/settings.json
+assert_ok "installed_plugins.json exists" \
+    run_in "$CLAUDE_SANDBOX" test -f /sandbox/.claude/plugins/installed_plugins.json
+assert_ok "marketplace registered" \
+    run_in "$CLAUDE_SANDBOX" test -d /sandbox/.claude/plugins/marketplaces
+
+print_header "=== claude-sandbox: entrypoint ==="
+
+assert_ok "entrypoint.sh is installed" \
+    run_in "$CLAUDE_SANDBOX" test -x /usr/local/bin/entrypoint.sh
+
+# --- opencode-sandbox checks ---
+print_header "=== opencode-sandbox: binaries ==="
+assert_ok "opencode is installed" run_in "$OPENCODE_SANDBOX" opencode --version
+print_header "=== opencode-sandbox: skills ==="
+assert_ok "opencode.json config exists" \
+    run_in "$OPENCODE_SANDBOX" test -f /sandbox/.config/opencode/opencode.json
+assert_ok "skills directory exists" \
+    run_in "$OPENCODE_SANDBOX" test -d /sandbox/.config/opencode/skills
+print_header "=== opencode-sandbox: entrypoint ==="
+assert_ok "entrypoint.sh is installed" \
+    run_in "$OPENCODE_SANDBOX" test -x /usr/local/bin/entrypoint.sh
+
+# --- Agent run tests (require credentials) ---
+_has_creds() {
+    [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
+    [[ -n "${GCLOUD_CREDENTIALS:-}" ]] || \
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]]
+}
+
+if ! _has_creds; then
+    echo ""
+    print_warning "Skipping agent run tests (no credentials set)"
+    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, or ANTHROPIC_API_KEY"
+else
+    # The OpenShell provider's Vertex backend reads gcloud ADC from disk.
+    # CI provides credentials as env vars, so write them to the ADC path.
+    ADC_PATH="$HOME/.config/gcloud/application_default_credentials.json"
+    if [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] && [[ ! -f "$ADC_PATH" ]]; then
+        mkdir -p "$(dirname "$ADC_PATH")"
+        if echo "$GCP_SERVICE_ACCOUNT_KEY" | python3 -c "import json,sys; json.load(sys.stdin)" 2>/dev/null; then
+            echo "$GCP_SERVICE_ACCOUNT_KEY" > "$ADC_PATH"
+        else
+            echo "$GCP_SERVICE_ACCOUNT_KEY" | base64 -d > "$ADC_PATH"
+        fi
+        print_step "Wrote GCP credentials to gcloud ADC path"
+    elif [[ -n "${GCLOUD_CREDENTIALS:-}" ]] && [[ ! -f "$ADC_PATH" ]]; then
+        mkdir -p "$(dirname "$ADC_PATH")"
+        echo "$GCLOUD_CREDENTIALS" > "$ADC_PATH"
+        print_step "Wrote GCP credentials to gcloud ADC path"
+    fi
+
+    print_header "=== Component versions ==="
+    echo "  agentic-ci:        $(agentic-ci --version 2>&1 || echo unknown)"
+    echo "  openshell:         $(openshell --version 2>&1 || echo unknown)"
+    echo "  openshell RPM:     $(rpm -q openshell 2>&1 || echo unknown)"
+    echo "  openshell-gateway: $(openshell-gateway --version 2>&1 || echo unknown)"
+    echo "  openshell-gw RPM:  $(rpm -q openshell-gateway 2>&1 || echo unknown)"
+    echo "  podman:            $(podman --version 2>&1 || echo unknown)"
+    echo "  claude:            $(run_in "$CLAUDE_SANDBOX" claude --version 2>&1 || echo unknown)"
+    echo "  opencode:          $(run_in "$OPENCODE_SANDBOX" opencode --version 2>&1 || echo unknown)"
+
+    # --- Claude Code via OpenShell ---
+    print_header "=== agentic-ci run: Claude Code via OpenShell ==="
+
+    WORKDIR="$TMPDIR_E2E/claude"
+    mkdir -p "$WORKDIR"
+
+    print_step "Running Claude Code via agentic-ci (openshell backend)..."
+    RC=0
+    agentic-ci run "Reply with only the word pong" \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel \
+        --no-streaming || RC=$?
+
+    assert_ok "claude-code exited successfully" test "$RC" -eq 0
+    dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+
+    # --- OpenCode via OpenShell ---
+    print_header "=== agentic-ci run: OpenCode via OpenShell ==="
+
+    WORKDIR="$TMPDIR_E2E/opencode"
+    mkdir -p "$WORKDIR"
+
+    print_step "Running OpenCode via agentic-ci (openshell backend)..."
+    RC=0
+    agentic-ci run "Reply with only the word pong" \
+        --backend openshell \
+        --image "$OPENCODE_SANDBOX" \
+        --harness opencode \
+        --workdir "$WORKDIR" \
+        --no-otel \
+        --no-streaming || RC=$?
+
+    assert_ok "opencode exited successfully" test "$RC" -eq 0
+    dump_gateway_log
+fi
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/images/shell-utils.sh
+++ b/tests/images/shell-utils.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# shell-utils.sh -- Shared shell utilities for agentic CI projects.
+#
+# Source this file to get colored output functions, dependency checking,
+# and other common helpers.
+#
+# Usage:
+#   source /path/to/shell-utils.sh
+
+# Color constants
+readonly AGENTIC_RED='\033[0;31m'
+readonly AGENTIC_GREEN='\033[0;32m'
+readonly AGENTIC_YELLOW='\033[1;33m'
+readonly AGENTIC_BLUE='\033[0;34m'
+readonly AGENTIC_CYAN='\033[0;36m'
+readonly AGENTIC_NC='\033[0m'
+
+# Colored output functions
+print_step()    { echo -e "${AGENTIC_BLUE}▶ $1${AGENTIC_NC}"; }
+print_success() { echo -e "${AGENTIC_GREEN}✓ $1${AGENTIC_NC}"; }
+print_warning() { echo -e "${AGENTIC_YELLOW}⚠ $1${AGENTIC_NC}"; }
+print_error()   { echo -e "${AGENTIC_RED}✗ $1${AGENTIC_NC}"; }
+print_header()  { echo -e "${AGENTIC_CYAN}$1${AGENTIC_NC}"; }
+
+# Check that all required commands are available.
+# Usage: check_dependencies podman python3 git curl jq
+check_dependencies() {
+    local missing=()
+    for cmd in "$@"; do
+        command -v "$cmd" >/dev/null 2>&1 || missing+=("$cmd")
+    done
+    if [[ ${#missing[@]} -ne 0 ]]; then
+        print_error "Missing dependencies: ${missing[*]}"
+        return 1
+    fi
+}
+
+# URL-encode a string for use in API paths.
+urlencode() {
+    python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$1"
+}

--- a/tests/images/test_entrypoint.sh
+++ b/tests/images/test_entrypoint.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# test-entrypoint.sh -- Test the shared entrypoint env detection.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+source "$SCRIPT_DIR/shell-utils.sh"
+
+PASS=0
+FAIL=0
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -q "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc — expected '$pattern' in output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if ! echo "$output" | grep -q "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc — did not expect '$pattern' in output"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+print_results() {
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap print_results EXIT
+
+ENTRYPOINT="$REPO_ROOT/images/runner/shared/entrypoint.sh"
+
+_DETECT_SCRIPT='
+source "'"$ENTRYPOINT"'" --source-only
+_detect_tool "$1"
+for v in CLAUDE_CODE_USE_VERTEX DISABLE_AUTOUPDATER OPENCODE_DISABLE_AUTOUPDATE; do
+    if val=$(printenv "$v" 2>/dev/null); then printf "%s=%s\n" "$v" "$val"; fi
+done
+'
+
+run_detect() {
+    env -i HOME="$HOME" PATH="$PATH" bash -c "$_DETECT_SCRIPT" _ "$1" 2>/dev/null
+}
+
+run_detect_with_vertex() {
+    env -i HOME="$HOME" PATH="$PATH" bash -c "
+        _VERTEX_CONFIGURED=1; $_DETECT_SCRIPT
+    " _ "$1" 2>/dev/null
+}
+
+print_header "=== Entrypoint tool detection: claude ==="
+
+CLAUDE_ENV=$(run_detect "claude")
+assert_contains "claude: sets DISABLE_AUTOUPDATER=1" "$CLAUDE_ENV" "DISABLE_AUTOUPDATER=1"
+assert_not_contains "claude: does not set CLAUDE_CODE_USE_VERTEX" "$CLAUDE_ENV" "CLAUDE_CODE_USE_VERTEX"
+assert_not_contains "claude: does not set OPENCODE_DISABLE_AUTOUPDATE" "$CLAUDE_ENV" "OPENCODE_DISABLE_AUTOUPDATE"
+
+print_header "=== Entrypoint tool detection: opencode ==="
+
+OC_ENV=$(run_detect "opencode")
+assert_contains "opencode: sets OPENCODE_DISABLE_AUTOUPDATE=1" "$OC_ENV" "OPENCODE_DISABLE_AUTOUPDATE=1"
+assert_not_contains "opencode: does not set DISABLE_AUTOUPDATER" "$OC_ENV" "DISABLE_AUTOUPDATER"
+
+print_header "=== Entrypoint tool detection: AGENT_TOOL fallback ==="
+
+AGENT_TOOL_CLAUDE_ENV=$(env -i HOME="$HOME" PATH="$PATH" AGENT_TOOL=claude bash -c "
+    source '$ENTRYPOINT' --source-only
+    _detect_tool 'some-other-cmd'
+    printenv DISABLE_AUTOUPDATER 2>/dev/null && echo 'DISABLE_AUTOUPDATER='\$(printenv DISABLE_AUTOUPDATER) || true
+" 2>/dev/null)
+assert_contains "AGENT_TOOL=claude: sets DISABLE_AUTOUPDATER=1" "$AGENT_TOOL_CLAUDE_ENV" "DISABLE_AUTOUPDATER=1"
+
+AGENT_TOOL_OC_ENV=$(env -i HOME="$HOME" PATH="$PATH" AGENT_TOOL=opencode bash -c "
+    source '$ENTRYPOINT' --source-only
+    _detect_tool 'some-other-cmd'
+    printenv OPENCODE_DISABLE_AUTOUPDATE 2>/dev/null && echo 'OPENCODE_DISABLE_AUTOUPDATE='\$(printenv OPENCODE_DISABLE_AUTOUPDATE) || true
+" 2>/dev/null)
+assert_contains "AGENT_TOOL=opencode: sets OPENCODE_DISABLE_AUTOUPDATE=1" "$AGENT_TOOL_OC_ENV" "OPENCODE_DISABLE_AUTOUPDATE=1"
+
+print_header "=== Entrypoint tool detection: with vertex credentials ==="
+
+VERTEX_CLAUDE_ENV=$(run_detect_with_vertex "claude")
+assert_contains "claude+vertex: sets CLAUDE_CODE_USE_VERTEX=1" "$VERTEX_CLAUDE_ENV" "CLAUDE_CODE_USE_VERTEX=1"
+assert_contains "claude+vertex: sets DISABLE_AUTOUPDATER=1" "$VERTEX_CLAUDE_ENV" "DISABLE_AUTOUPDATER=1"
+
+VERTEX_OC_ENV=$(run_detect_with_vertex "opencode")
+assert_not_contains "opencode+vertex: does NOT set CLAUDE_CODE_USE_VERTEX" "$VERTEX_OC_ENV" "CLAUDE_CODE_USE_VERTEX"
+assert_contains "opencode+vertex: sets OPENCODE_DISABLE_AUTOUPDATE=1" "$VERTEX_OC_ENV" "OPENCODE_DISABLE_AUTOUPDATE=1"
+
+print_header "=== Entrypoint: AGENT_ENABLED_PLUGINS enablement ==="
+
+TMPDIR_EP="$(mktemp -d)"
+_ep_cleanup() {
+    rm -rf "$TMPDIR_EP"
+}
+trap '_ep_cleanup; print_results' EXIT
+
+EP_HOME="$TMPDIR_EP/claude-home"
+mkdir -p "$EP_HOME/plugins"
+
+python3 -c "
+import json, sys
+data = {
+    'version': 2,
+    'plugins': {
+        'alpha@mkt': [{'scope': 'user', 'installPath': '/tmp/a', 'version': '1.0.0'}],
+        'beta@mkt': [{'scope': 'user', 'installPath': '/tmp/b', 'version': '1.0.0'}]
+    }
+}
+with open(sys.argv[1], 'w') as f:
+    json.dump(data, f)
+" "$EP_HOME/plugins/installed_plugins.json"
+echo '{}' > "$EP_HOME/settings.json"
+
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="alpha" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null
+
+ALPHA_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if ep.get('alpha@mkt') else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "AGENT_ENABLED_PLUGINS=alpha: alpha@mkt enabled" \
+    test "$ALPHA_ENABLED" = "yes"
+
+BETA_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if ep.get('beta@mkt') else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "AGENT_ENABLED_PLUGINS=alpha: beta@mkt NOT enabled" \
+    test "$BETA_ENABLED" = "no"
+
+echo '{}' > "$EP_HOME/settings.json"
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="alpha,beta" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null
+
+BOTH_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+a = ep.get('alpha@mkt', False)
+b = ep.get('beta@mkt', False)
+print('yes' if (a and b) else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "AGENT_ENABLED_PLUGINS=alpha,beta: both enabled" \
+    test "$BOTH_ENABLED" = "yes"
+
+python3 -c "
+import json, sys
+s = {'enabledPlugins': {'alpha@mkt': True, 'beta@mkt': True}}
+with open(sys.argv[1], 'w') as f:
+    json.dump(s, f)
+" "$EP_HOME/settings.json"
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="alpha" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null
+
+PREENABLED_ALPHA=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if ep.get('alpha@mkt') else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "Pre-enabled + AGENT_ENABLED_PLUGINS=alpha: alpha@mkt stays enabled" \
+    test "$PREENABLED_ALPHA" = "yes"
+
+PREENABLED_BETA=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if ep.get('beta@mkt') else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "Pre-enabled + AGENT_ENABLED_PLUGINS=alpha: beta@mkt disabled" \
+    test "$PREENABLED_BETA" = "no"
+
+echo '{}' > "$EP_HOME/settings.json"
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null
+
+ALL_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+a = ep.get('alpha@mkt', False)
+b = ep.get('beta@mkt', False)
+print('yes' if (a and b) else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "No AGENT_ENABLED_PLUGINS: all plugins enabled" \
+    test "$ALL_ENABLED" = "yes"
+
+echo '{}' > "$EP_HOME/settings.json"
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS=",,," \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null
+
+DEGEN_ALL=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+a = ep.get('alpha@mkt', False)
+b = ep.get('beta@mkt', False)
+print('yes' if (a and b) else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "AGENT_ENABLED_PLUGINS=,,,: all plugins enabled (treated as unset)" \
+    test "$DEGEN_ALL" = "yes"
+
+EP_NO_CACHE="$TMPDIR_EP/claude-home-no-cache"
+mkdir -p "$EP_NO_CACHE"
+echo '{}' > "$EP_NO_CACHE/settings.json"
+MISSING_CACHE_RC=0
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_NO_CACHE" AGENT_ENABLED_PLUGINS="alpha" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null || MISSING_CACHE_RC=$?
+assert_ok "AGENT_ENABLED_PLUGINS with missing installed_plugins.json: returns 0" \
+    test "$MISSING_CACHE_RC" -eq 0
+
+MISSING_CACHE_SETTINGS=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+print('yes' if 'enabledPlugins' not in s else 'no')
+" "$EP_NO_CACHE/settings.json")
+assert_ok "AGENT_ENABLED_PLUGINS with missing installed_plugins.json: settings.json unchanged" \
+    test "$MISSING_CACHE_SETTINGS" = "yes"
+
+echo '{}' > "$EP_HOME/settings.json"
+NONEXIST_RC=0
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="nonexistent" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null || NONEXIST_RC=$?
+assert_ok "AGENT_ENABLED_PLUGINS=nonexistent: exits with error" \
+    test "$NONEXIST_RC" -ne 0
+
+echo 'NOT-JSON{{{' > "$EP_HOME/settings.json"
+MALFORMED_RC=0
+env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="alpha" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>/dev/null || MALFORMED_RC=$?
+assert_ok "Malformed settings.json: recovers and exits 0" \
+    test "$MALFORMED_RC" -eq 0
+
+MALFORMED_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if ep.get('alpha@mkt') else 'no')
+" "$EP_HOME/settings.json")
+assert_ok "Malformed settings.json: alpha@mkt enabled after recovery" \
+    test "$MALFORMED_ENABLED" = "yes"
+
+echo '{}' > "$EP_HOME/settings.json"
+MIX_RC=0
+MIX_STDERR=$(env -i HOME="$HOME" PATH="$PATH" CLAUDE_CONFIG_DIR="$EP_HOME" AGENT_ENABLED_PLUGINS="alpha,nonexistent" \
+    bash -c "source '$ENTRYPOINT' --source-only; _enable_plugins" 2>&1 >/dev/null) || MIX_RC=$?
+assert_ok "AGENT_ENABLED_PLUGINS=alpha,nonexistent: exits with error" \
+    test "$MIX_RC" -ne 0
+assert_contains "AGENT_ENABLED_PLUGINS=alpha,nonexistent: reports matched plugins" \
+    "$MIX_STDERR" "Matched: alpha"
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/images/test_install_plugin.sh
+++ b/tests/images/test_install_plugin.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+# test-install-plugin.sh -- Smoke test for image/install-plugin.py
+#
+# Creates mock git repos (plugin + marketplace), patches the install script
+# to clone from local paths instead of GitHub, and verifies the resulting
+# cache directory structure and metadata files.
+#
+# Requires: python3, git
+#
+# Usage:
+#   ./tests/test-install-plugin.sh
+
+set -euo pipefail
+
+# shellcheck source=shell-utils.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/images/runner/claude-code/install-plugin.py"
+
+source "$SCRIPT_DIR/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+        exit 0
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+
+print_header "=== Preflight checks ==="
+check_dependencies python3 git
+
+# -- Build mock plugin repo ---------------------------------------------------
+
+print_header "=== Setting up mock repos ==="
+
+MOCK_PLUGIN_REPO="$TMPDIR_TEST/mock-plugin-repo"
+mkdir -p "$MOCK_PLUGIN_REPO/.claude/skills/greet"
+cat > "$MOCK_PLUGIN_REPO/.claude/skills/greet/SKILL.md" << 'EOF'
+# Greet skill
+Say hello to the user.
+EOF
+
+git -C "$MOCK_PLUGIN_REPO" init --quiet -b main
+git -C "$MOCK_PLUGIN_REPO" add -A
+git -C "$MOCK_PLUGIN_REPO" \
+    -c user.email="test@test" -c user.name="test" \
+    commit --quiet -m "init"
+
+# -- Build mock marketplace repo ----------------------------------------------
+
+MOCK_MKT_REPO="$TMPDIR_TEST/mock-mkt-repo"
+MKT_NAME="test-marketplace"
+PLUGIN_NAME="mock-greet"
+PLUGIN_VERSION="1.0.0"
+
+mkdir -p "$MOCK_MKT_REPO/.claude-plugin"
+cat > "$MOCK_MKT_REPO/.claude-plugin/marketplace.json" << MKEOF
+{
+  "name": "$MKT_NAME",
+  "plugins": [
+    {
+      "name": "$PLUGIN_NAME",
+      "version": "$PLUGIN_VERSION",
+      "source": {
+        "repo": "fake-org/mock-greet",
+        "ref": "main"
+      }
+    }
+  ]
+}
+MKEOF
+
+git -C "$MOCK_MKT_REPO" init --quiet -b main
+git -C "$MOCK_MKT_REPO" add -A
+git -C "$MOCK_MKT_REPO" \
+    -c user.email="test@test" -c user.name="test" \
+    commit --quiet -m "init"
+
+# -- Pre-register the marketplace (bypass --marketplace-repo) -----------------
+
+CLAUDE_HOME="$TMPDIR_TEST/claude-home"
+export CLAUDE_HOME
+PLUGINS_DIR="$CLAUDE_HOME/plugins"
+
+mkdir -p "$PLUGINS_DIR/marketplaces/$MKT_NAME"
+cp "$MOCK_MKT_REPO/.claude-plugin/marketplace.json" \
+   "$PLUGINS_DIR/marketplaces/$MKT_NAME/marketplace.json"
+
+# -- Patch install-plugin.py to clone from local mock repo --------------------
+
+PATCHED_SCRIPT="$TMPDIR_TEST/install-plugin-patched.py"
+sed "s|https://github.com/{repo}.git|$MOCK_PLUGIN_REPO|g" \
+    "$INSTALL_SCRIPT" > "$PATCHED_SCRIPT"
+chmod +x "$PATCHED_SCRIPT"
+
+# -- Run the patched installer ------------------------------------------------
+
+print_header "=== Running install-plugin.py --all ==="
+
+RUN_RC=0
+python3 "$PATCHED_SCRIPT" --all >/dev/null 2>&1 || RUN_RC=$?
+
+assert_ok "T-01: install-plugin.py exits 0" test "$RUN_RC" -eq 0
+
+# -- Verify results -----------------------------------------------------------
+
+print_header "=== Verifying output structure ==="
+
+CACHE_DEST="$PLUGINS_DIR/cache/$MKT_NAME/$PLUGIN_NAME/$PLUGIN_VERSION"
+
+# Cache directory exists
+assert_ok "T-02: cache directory created" \
+    test -d "$CACHE_DEST"
+
+# Skill file copied
+assert_ok "T-03: skills/greet/SKILL.md exists in cache" \
+    test -f "$CACHE_DEST/skills/greet/SKILL.md"
+
+# .in_use marker
+assert_ok "T-04: .in_use marker exists" \
+    test -f "$CACHE_DEST/.in_use"
+
+# installed_plugins.json has the plugin entry
+INSTALLED_JSON="$PLUGINS_DIR/installed_plugins.json"
+assert_ok "T-05: installed_plugins.json exists" \
+    test -f "$INSTALLED_JSON"
+
+PLUGIN_KEY="${PLUGIN_NAME}@${MKT_NAME}"
+HAS_ENTRY=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print('yes' if sys.argv[2] in d.get('plugins', {}) else 'no')
+" "$INSTALLED_JSON" "$PLUGIN_KEY")
+assert_ok "T-06: installed_plugins.json has '$PLUGIN_KEY'" \
+    test "$HAS_ENTRY" = "yes"
+
+# settings.json has enabledPlugins entry
+SETTINGS_JSON="$CLAUDE_HOME/settings.json"
+assert_ok "T-07: settings.json exists" \
+    test -f "$SETTINGS_JSON"
+
+HAS_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if sys.argv[2] in ep else 'no')
+" "$SETTINGS_JSON" "$PLUGIN_KEY")
+assert_ok "T-08: settings.json enabledPlugins has '$PLUGIN_KEY'" \
+    test "$HAS_ENABLED" = "yes"
+
+# -- Test --no-enable flag ----------------------------------------------------
+
+print_header "=== Testing --no-enable flag ==="
+
+NOENABLE_HOME="$TMPDIR_TEST/claude-home-noenable"
+NOENABLE_PLUGINS="$NOENABLE_HOME/plugins"
+mkdir -p "$NOENABLE_PLUGINS/marketplaces/$MKT_NAME"
+cp "$MOCK_MKT_REPO/.claude-plugin/marketplace.json" \
+   "$NOENABLE_PLUGINS/marketplaces/$MKT_NAME/marketplace.json"
+
+PATCHED_NOENABLE="$TMPDIR_TEST/install-plugin-noenable.py"
+sed "s|https://github.com/{repo}.git|$MOCK_PLUGIN_REPO|g" \
+    "$INSTALL_SCRIPT" > "$PATCHED_NOENABLE"
+chmod +x "$PATCHED_NOENABLE"
+
+NOENABLE_RC=0
+CLAUDE_HOME="$NOENABLE_HOME" python3 "$PATCHED_NOENABLE" --all --no-enable \
+    >/dev/null 2>&1 || NOENABLE_RC=$?
+
+assert_ok "T-09: --no-enable exits 0" test "$NOENABLE_RC" -eq 0
+
+NOENABLE_CACHE="$NOENABLE_PLUGINS/cache/$MKT_NAME/$PLUGIN_NAME/$PLUGIN_VERSION"
+assert_ok "T-10: --no-enable cache directory created" \
+    test -d "$NOENABLE_CACHE"
+
+assert_ok "T-11: --no-enable skills cached" \
+    test -f "$NOENABLE_CACHE/skills/greet/SKILL.md"
+
+NOENABLE_INSTALLED="$NOENABLE_PLUGINS/installed_plugins.json"
+NOENABLE_HAS_ENTRY=$(python3 -c "
+import json, sys
+d = json.load(open(sys.argv[1]))
+print('yes' if sys.argv[2] in d.get('plugins', {}) else 'no')
+" "$NOENABLE_INSTALLED" "$PLUGIN_KEY")
+assert_ok "T-12: --no-enable installed_plugins.json has entry" \
+    test "$NOENABLE_HAS_ENTRY" = "yes"
+
+NOENABLE_SETTINGS="$NOENABLE_HOME/settings.json"
+if [[ -f "$NOENABLE_SETTINGS" ]]; then
+    NOENABLE_HAS_ENABLED=$(python3 -c "
+import json, sys
+s = json.load(open(sys.argv[1]))
+ep = s.get('enabledPlugins', {})
+print('yes' if sys.argv[2] in ep else 'no')
+" "$NOENABLE_SETTINGS" "$PLUGIN_KEY")
+else
+    NOENABLE_HAS_ENABLED="no"
+fi
+assert_ok "T-13: --no-enable settings.json does NOT have enabledPlugins entry" \
+    test "$NOENABLE_HAS_ENABLED" = "no"
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/images/test_install_skills.sh
+++ b/tests/images/test_install_skills.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# test-install-skills.sh -- Smoke test for images/runner/opencode/install-skills.py
+#
+# Creates mock git repos (plugin + marketplace), patches the install script
+# to clone from local paths instead of GitHub, and verifies the resulting
+# skill directory structure for OpenCode.
+#
+# Requires: python3, git
+#
+# Usage:
+#   ./tests/test-install-skills.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+INSTALL_SCRIPT="$REPO_ROOT/images/runner/opencode/install-skills.py"
+
+source "$SCRIPT_DIR/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_TEST="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_TEST"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+        exit 0
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+
+print_header "=== Preflight checks ==="
+check_dependencies python3 git
+
+# -- Build mock plugin repo ---------------------------------------------------
+
+print_header "=== Setting up mock repos ==="
+
+MOCK_PLUGIN_REPO="$TMPDIR_TEST/mock-plugin-repo"
+mkdir -p "$MOCK_PLUGIN_REPO/.claude/skills/greet"
+cat > "$MOCK_PLUGIN_REPO/.claude/skills/greet/SKILL.md" << 'EOF'
+---
+name: greet
+description: Say hello to the user
+---
+# Greet skill
+Say hello to the user.
+EOF
+
+git -C "$MOCK_PLUGIN_REPO" init --quiet -b main
+git -C "$MOCK_PLUGIN_REPO" add -A
+git -C "$MOCK_PLUGIN_REPO" \
+    -c user.email="test@test" -c user.name="test" \
+    commit --quiet -m "init"
+
+# -- Build mock marketplace repo ----------------------------------------------
+
+MOCK_MKT_REPO="$TMPDIR_TEST/mock-mkt-repo"
+MKT_NAME="test-marketplace"
+PLUGIN_NAME="mock-greet"
+PLUGIN_VERSION="1.0.0"
+
+mkdir -p "$MOCK_MKT_REPO/.claude-plugin"
+cat > "$MOCK_MKT_REPO/.claude-plugin/marketplace.json" << MKEOF
+{
+  "name": "$MKT_NAME",
+  "plugins": [
+    {
+      "name": "$PLUGIN_NAME",
+      "version": "$PLUGIN_VERSION",
+      "source": {
+        "repo": "fake-org/mock-greet",
+        "ref": "main"
+      }
+    }
+  ]
+}
+MKEOF
+
+git -C "$MOCK_MKT_REPO" init --quiet -b main
+git -C "$MOCK_MKT_REPO" add -A
+git -C "$MOCK_MKT_REPO" \
+    -c user.email="test@test" -c user.name="test" \
+    commit --quiet -m "init"
+
+# -- Pre-register the marketplace (bypass --marketplace-repo) -----------------
+
+OPENCODE_CONFIG_DIR="$TMPDIR_TEST/opencode-config"
+export OPENCODE_CONFIG_DIR
+SKILLS_DIR="$OPENCODE_CONFIG_DIR/skills"
+MKT_CACHE="$TMPDIR_TEST/mkt-cache"
+
+mkdir -p "$MKT_CACHE/marketplaces/$MKT_NAME"
+cp "$MOCK_MKT_REPO/.claude-plugin/marketplace.json" \
+   "$MKT_CACHE/marketplaces/$MKT_NAME/marketplace.json"
+
+# -- Patch install-skills.py to clone from local mock repo --------------------
+
+PATCHED_SCRIPT="$TMPDIR_TEST/install-skills-patched.py"
+sed "s|https://github.com/{repo}.git|$MOCK_PLUGIN_REPO|g" \
+    "$INSTALL_SCRIPT" > "$PATCHED_SCRIPT"
+chmod +x "$PATCHED_SCRIPT"
+
+# -- Run the patched installer ------------------------------------------------
+
+print_header "=== Running install-skills.py --all ==="
+
+export MARKETPLACE_CACHE_DIR="$MKT_CACHE"
+
+RUN_RC=0
+python3 "$PATCHED_SCRIPT" --all >/dev/null 2>&1 || RUN_RC=$?
+
+assert_ok "T-01: install-skills.py exits 0" test "$RUN_RC" -eq 0
+
+# -- Verify results -----------------------------------------------------------
+
+print_header "=== Verifying output structure ==="
+
+assert_ok "T-02: skills directory created" \
+    test -d "$SKILLS_DIR"
+
+assert_ok "T-03: greet/SKILL.md exists in skills dir" \
+    test -f "$SKILLS_DIR/greet/SKILL.md"
+
+assert_ok "T-04: SKILL.md has correct content" \
+    grep -q "Say hello to the user" "$SKILLS_DIR/greet/SKILL.md"
+
+echo ""
+print_header "=== All test sections complete ==="


### PR DESCRIPTION
## Summary

- Migrate all container image build infrastructure from the GitLab-hosted
  `ai-agentic-lib` repository into this GitHub repo, consolidating the
  agentic-ci tooling in one place.
- Convert GitLab CI build/push/lint/test jobs to GitHub Actions workflows.
- Port e2e tests for claude-runner, opencode-runner, and openshell-sandbox
  images with a manual-dispatch GHA workflow (`e2e.yml`).
- Add PR triggers that build all images without pushing (verifying they
  compile), plus `image-lint` and `image-test` jobs for PRs.
- Guard registry login and push steps to only run on main/schedule/dispatch events.
- Image tags use epoch timestamps only (`latest` + epoch). Version tags
  from agentic-ci releases do not trigger image rebuilds to keep image
  and CLI versioning decoupled.
- Remove ENV lines from OpenShell Containerfiles since OpenShell discards
  image env vars when creating sandboxes (the harness injects them at runtime).
- Bring over Renovate config for automated dependency bumping in Containerfiles.
- Includes OpenShell sandbox images from ai-agentic-lib MR !61.

### What moved

| Component | Files |
|-----------|-------|
| Runner images (podman path) | `Containerfile.base`, `claude-code/Containerfile`, `opencode/Containerfile` |
| Sandbox images (OpenShell path) | `Containerfile.openshell-base`, `claude-code/Containerfile.openshell`, `opencode/Containerfile.openshell` |
| CI images | `Containerfile.podman`, `Containerfile.openshell` |
| OpenShell supervisor | `openshell-supervisor/Containerfile` (temporary, pending upstream PR #1763) |
| Supporting scripts | `entrypoint.sh`, `install-plugin.py`, `install-skills.py`, `claude-settings.json`, `opencode.json` |
| Version management | `scripts/bump-versions.py` (tracks 8 Containerfiles) |
| Build + push CI | `.github/workflows/images.yml` (6 image jobs via podman) |
| PR checks CI | `.github/workflows/images-pr.yml` (lint + build + test) |
| E2E tests CI | `.github/workflows/e2e.yml` (manual dispatch, 3 jobs) |
| Renovate config | `renovate.json` (custom managers for 10 tools) |
| Image unit tests (42 assertions) | `tests/images/` (entrypoint, install-plugin, install-skills) |
| E2E tests | `tests/e2e/` (claude-runner, opencode-runner, openshell-sandbox) |
| Image docs | `docs/image/` (overview, build pipeline, extending, skill loading) |
| Local build targets | `Makefile` (8 image build + lint + test + 3 e2e targets) |

### CI workflow behavior

| Event | Login | Build | Push | Lint/Test |
|-------|-------|-------|------|-----------|
| Push to main (images/** changed) | Yes | Yes | Yes | No |
| Daily schedule (6am UTC) | Yes | Yes | Yes | No |
| Pull request | No | Yes | No | Yes |
| Manual dispatch | Optional | Yes | Optional | No |

### E2E tests (`e2e.yml`, manual dispatch only)

| Job | Runner | What it tests |
|-----|--------|---------------|
| `e2e-claude-runner` | ubuntu-latest | Streaming + non-streaming `agentic-ci run` with Claude Code harness |
| `e2e-opencode-runner` | ubuntu-latest | `agentic-ci run` with OpenCode harness |
| `e2e-openshell-sandbox` | openshell CI container | Image content verification + agent runs via OpenShell backend |

Secrets: `GCP_PROJECT_ID`, `GCP_SERVICE_ACCOUNT_KEY`

### GitHub secrets required

| Secret | Description |
|--------|-------------|
| `QUAY_USERNAME` | quay.io robot account username |
| `QUAY_PASSWORD` | quay.io robot account password |
| `GCP_PROJECT_ID` | GCP project for Vertex AI (e2e tests) |
| `GCP_SERVICE_ACCOUNT_KEY` | Base64-encoded service account key (e2e tests) |

### Post-merge

- Point Renovate instance to this repo instead of ai-agentic-lib
- Create `QUAY_USERNAME` and `QUAY_PASSWORD` secrets in GitHub repo settings
- Create `GCP_PROJECT_ID` and `GCP_SERVICE_ACCOUNT_KEY` secrets for e2e tests
- Verify the daily schedule triggers correctly (`.github/workflows/images.yml`)

### Follow-up work

- Switch CI build jobs from ubuntu runners with podman to `quay.io/buildah/stable:latest` container

## Test plan

- [x] All 42 image unit tests pass locally (entrypoint, install-plugin, install-skills)
- [x] shellcheck passes on all shell scripts (including e2e tests)
- [x] ruff passes on all Python scripts (format + lint)
- [x] All existing Python tests still pass
- [ ] Verify GitHub Actions workflows trigger correctly after merge
- [ ] Verify images build and push to quay.io successfully
- [ ] Run e2e tests via manual dispatch with GCP credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published runner and sandbox container images with local build targets, hardened entrypoint behavior, and non-interactive plugin/skill installers.

* **Documentation**
  * New Container Images docs, README section, site navigation, and guidance for extending images and loading skills.

* **CI / Chores**
  * Workflows for image linting, building, testing, daily rebuilds, e2e dispatch, Renovate config, and a version-bump utility; Makefile targets and helper scripts added.

* **Tests**
  * Image-focused unit/smoke and end-to-end test scripts for entrypoints, installers, and runner images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->