### PR TITLE
Start OTEL collector in run_skill() default container runner

### DIFF
--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -30,7 +30,7 @@ from typing import Callable
 
 from agentic_ci.backends.podman import PodmanBackend
 from agentic_ci.harness import ClaudeCodeHarness
-from agentic_ci.otel import parse_metrics
+from agentic_ci.otel import parse_metrics, start_collector, stop_collector
 
 log = logging.getLogger(__name__)
 
@@ -121,10 +121,23 @@ def _default_run_container(
     )
     if verdict_path is not None:
         backend.verdict_path = verdict_path
+
+    otel_proc = None
+    otel_port = None
+    if harness.supports_otel:
+        run_dir = Path(work_dir) / "_run"
+        run_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            otel_proc, otel_port, _, _ = start_collector(str(run_dir))
+        except Exception:
+            log.warning("Failed to start OTEL collector, continuing without telemetry")
+
     try:
         backend.setup()
-        return backend.run(prompt, model=model)
+        return backend.run(prompt, model=model, otel_port=otel_port)
     finally:
+        if otel_proc:
+            stop_collector(otel_proc)
         backend.stop()
 
 


### PR DESCRIPTION
## Summary

- Start the OTEL collector subprocess in `_default_run_container()` before running the agent container, and stop it in the `finally` block
- Pass the collector port to `PodmanBackend.run()` so Claude Code exports telemetry metrics
- The JSONL file lands at `work_dir/_run/claude-otel.jsonl` where `_load_otel_cost()` already looks, so cost data now flows into verdict `_cost_summary` fields automatically
- Collector startup failure is handled gracefully (log warning, continue without telemetry)

## Context

The OTEL plumbing was fully wired in the `agentic-ci run` CLI path but not in the `run_skill()` path used by autofix and triage runners. All the infrastructure existed (collector, env vars, metric parsing, cost formatting) but the collector was never started, so `otel_port=None` was passed to the backend and no metrics were collected.

## Test plan

- [x] `tox -e lint` passes
- [x] `tox -e py313` passes (501 tests)
- [ ] Run an autofix ticket end-to-end and verify `claude-otel.jsonl` is produced in `work_dir/_run/`
- [ ] Verify Jira comment includes cost summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)