### PR TITLE
Upload and download workdir in OpenShell backend

### DIFF
--- a/.claude/skills/test-e2e-openshell/SKILL.md
+++ b/.claude/skills/test-e2e-openshell/SKILL.md
@@ -21,7 +21,7 @@ Ask the user for three things:
 3. **API key file** — path to a local file containing an Anthropic API key (one line, no whitespace). Needed for Sections B and D. Store as `$API_KEY_FILE`.
 
 Per-section requirements:
-- **Vertex AI auth** (Sections A, C): GCP ADC credentials at `~/.config/gcloud/application_default_credentials.json` and `ANTHROPIC_VERTEX_PROJECT_ID` + `CLOUD_ML_REGION` set in the environment.
+- **Vertex AI auth** (Sections A, C, E): GCP ADC credentials at `~/.config/gcloud/application_default_credentials.json` and `ANTHROPIC_VERTEX_PROJECT_ID` + `CLOUD_ML_REGION` set in the environment. Also requires `OPENSHELL_SUPERVISOR_IMAGE` pointing to a supervisor with the GCE metadata emulator (e.g. `quay.io/mprpic/openshell-supervisor:pr1763`); see `docs/backends/openshell.md` for details.
 - **API key auth** (Sections B, D): The API key file above.
 
 ## Container setup
@@ -238,6 +238,79 @@ Verify:
 
 ---
 
+## Section E: Workdir round-trip
+
+Verifies that the OpenShell backend uploads the workdir into the sandbox,
+the agent can modify files inside it, and changes are downloaded back to
+the host after the run completes. Uses Vertex AI auth and Claude Code.
+
+Requires `OPENSHELL_SUPERVISOR_IMAGE` set to a supervisor with the GCE
+metadata emulator (see "Before you start").
+
+Run cleanup first.
+
+### E1. Prepare workdir
+
+Create a temporary directory with a seed file:
+
+```bash
+podman exec openshell-e2e bash -c '
+  mkdir -p /tmp/workdir-test
+  echo red > /tmp/workdir-test/color.txt
+'
+```
+
+Verify:
+
+```bash
+podman exec openshell-e2e cat /tmp/workdir-test/color.txt
+```
+
+Should print `red`.
+
+### E2. Run agent to modify the file
+
+```bash
+podman exec \
+  -e ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id> \
+  -e CLOUD_ML_REGION=global \
+  -e OPENSHELL_SUPERVISOR_IMAGE=quay.io/mprpic/openshell-supervisor:pr1763 \
+  -e SANDBOX_IMAGE="$CLAUDE_SANDBOX_IMAGE" \
+  openshell-e2e bash -c '
+    agentic-ci run \
+      --backend openshell \
+      --harness claude-code \
+      --image "$SANDBOX_IMAGE" \
+      --model claude-haiku-4-5 \
+      --workdir /tmp/workdir-test \
+      --no-otel \
+      "Overwrite the file color.txt with exactly the word blue (no newline, no quotes). Do not create any other files."
+  '
+```
+
+Verify:
+- Output shows `Uploading workdir`
+- Output shows `Downloading workdir`
+- `Agent exit code: 0`
+
+### E3. Verify workdir was updated on the host
+
+```bash
+podman exec openshell-e2e cat /tmp/workdir-test/color.txt
+```
+
+The file should now contain `blue`, not `red`. This confirms the full
+round-trip: the workdir was uploaded into the sandbox, the agent modified
+it, and the changes were downloaded back to the host.
+
+### E4. Clean up workdir
+
+```bash
+podman exec openshell-e2e rm -rf /tmp/workdir-test
+```
+
+---
+
 ## Final cleanup
 
 ```bash
@@ -246,7 +319,7 @@ podman rm -f openshell-e2e
 
 ## Running the full suite
 
-Execute sections in order (A through D), running the cleanup step before each
+Execute sections in order (A through E), running the cleanup step before each
 section. Skip sections whose prerequisites are not met. If any step fails,
 check the gateway log inside the container:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,9 +35,9 @@ src/agentic_ci/
 
 - **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`.
 
-- **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Mounts workdir and gcloud credentials as volumes. Uses `--network host` when OTEL is enabled.
+- **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Bind-mounts the workdir into the container at `/workspace`, so changes are visible on the host immediately. Mounts gcloud credentials as read-only volumes. Uses `--network host` when OTEL is enabled.
 
-- **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Manages gateway lifecycle, sandbox creation with network policy, and credential upload. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
+- **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Uploads the workdir into the sandbox on `setup()` and downloads it back after `run()` completes. Only changes inside the workdir are reflected back to the host; files written elsewhere in the sandbox are not retrieved. Manages gateway lifecycle, sandbox creation with network policy, and credential injection. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
 
 - **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. Both produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
 

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -23,6 +23,12 @@ class OpenShellBackend(Backend):
     Authentication is handled through the OpenShell google-cloud provider,
     which injects GCP credentials via the supervisor proxy. The agent
     uses its native Vertex AI integration directly.
+
+    Unlike PodmanBackend, which bind-mounts the workdir so changes are
+    visible immediately on the host, OpenShellBackend copies the workdir
+    into the sandbox on setup() and copies it back after run() completes.
+    Only changes inside the workdir are reflected back to the host; files
+    written elsewhere in the sandbox (e.g. /tmp) are not retrieved.
     """
 
     _ENV_SCRIPT = "/tmp/.agentic-ci-env.sh"
@@ -51,6 +57,9 @@ class OpenShellBackend(Backend):
 
         sandbox.create(image=self.image, policy_path=self.policy_path)
 
+        log.section("Uploading workdir")
+        sandbox.upload(self.workdir)
+
     def stop(self):
         try:
             if sandbox.exists():
@@ -74,11 +83,23 @@ class OpenShellBackend(Backend):
         self._write_env_script(model, otel_port, otel_rate_file)
         agent_args = self.harness.build_args(prompt, model, extra_args)
 
-        cmd = ["bash", "-c", f'. {self._ENV_SCRIPT} && exec "$@"', "--", *agent_args]
+        workdir_name = os.path.basename(self.workdir)
+        sandbox_workdir = f"/sandbox/{workdir_name}"
+        cmd = [
+            "bash",
+            "-c",
+            f'cd {shlex.quote(sandbox_workdir)} && . {self._ENV_SCRIPT} && exec "$@"',
+            "--",
+            *agent_args,
+        ]
         proc = sandbox.exec_cmd_streaming(cmd)
 
         rc = self._process_stream(proc, streaming)
         self._wait_for_otel_flush(otel_port)
+
+        log.section("Downloading workdir")
+        sandbox.download(sandbox_workdir, self.workdir)
+
         return rc
 
     def _write_env_script(self, model, otel_port=None, otel_rate_file=None):

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -84,6 +84,14 @@ def upload(local_path):
     )
 
 
+def download(sandbox_path, local_dest):
+    """Download a path from the sandbox to a local destination."""
+    _run(
+        ["openshell", "sandbox", "download", SANDBOX_NAME, sandbox_path, local_dest],
+        check=True,
+    )
+
+
 def exec_cmd(cmd):
     """Run a command inside the sandbox. Returns the CompletedProcess."""
     return _run(


### PR DESCRIPTION
The OpenShell backend accepted a workdir parameter but never made it available inside the sandbox. This adds workdir upload on setup() and download after run() completes, so agents can read and modify the source code they operate on and changes are reflected back to the host.

- sandbox.upload(workdir) after sandbox creation
- sandbox.download(sandbox_workdir, local_workdir) after agent run
- Add sandbox.download() wrapping openshell sandbox download
- Use absolute /sandbox/ paths for cd and download
- Document workdir handling contrast between Podman and OpenShell
- Remove mock-only unit tests in favor of e2e coverage
- Add Section E to e2e openshell skill: workdir round-trip test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workdir synchronization behavior between host and sandbox environments in backend documentation

* **New Features**
  * Enhanced workdir handling: OpenShell backend now copies workdir to sandbox during setup and back to host after execution

* **Tests**
  * Added new E2E test section for workdir round-trip verification to ensure file changes persist between host and sandbox

<!-- end of auto-generated comment: release notes by coderabbit.ai -->