### PR TITLE
feat: enable trace export and MLflow trace push

### DIFF
--- a/docs/mlflow-traces.md
+++ b/docs/mlflow-traces.md
@@ -1,0 +1,180 @@
+# MLflow Trace Export
+
+Push OTel traces from agent runs to an MLflow instance for observability, cost tracking, and debugging.
+
+## How it works
+
+1. **During the agent run**, the local OTLP collector captures all telemetry (metrics, logs, and traces) to a JSONL file
+2. **After the run**, a separate CI job reads that JSONL file and forwards the `/v1/traces` records to MLflow's OTLP endpoint
+
+The trace push is intentionally decoupled from the agent run — it runs as a follow-up job with `allow_failure: true` so trace push failures never block the pipeline.
+
+**Security note:** Traces include user prompts and tool content (`OTEL_LOG_USER_PROMPTS=1`, `OTEL_LOG_TOOL_CONTENT=1`). Avoid including API keys, passwords, or PII in prompts when trace export is enabled — they will be logged to the JSONL file and forwarded to MLflow.
+
+## Prerequisites
+
+- An MLflow instance with OTLP ingestion enabled (`/v1/traces` endpoint)
+- An MLflow experiment created for the agent (e.g., `rfe-autofixer`)
+- A Bearer token for authentication (e.g., from a Kubernetes ServiceAccount)
+
+### CI variables
+
+Set these at the project or group level:
+
+| Variable | Description |
+|----------|-------------|
+| `MLFLOW_TRACKING_URI` | MLflow endpoint URL (e.g., `https://mlflow.example.com`) |
+| `MLFLOW_EXPERIMENT_NAME` | MLflow experiment name |
+| `MLFLOW_TRACKING_TOKEN` | Bearer token for authentication |
+
+## GitLab CI
+
+```yaml
+stages:
+  - agent
+  - observe
+
+agent-run:
+  stage: agent
+  script:
+    - agentic-ci run --harness claude-code "$PROMPT"
+  after_script:
+    - cp /tmp/agentic-ci-run.*/claude-otel.jsonl . 2>/dev/null || true
+  artifacts:
+    paths:
+      - claude-otel.jsonl
+    when: always
+    expire_in: 30 days
+
+trace-push:
+  stage: observe
+  needs: [agent-run]
+  allow_failure: true
+  rules:
+    - if: $MLFLOW_TRACKING_URI && $MLFLOW_EXPERIMENT_NAME
+  script:
+    - agentic-ci mlflow-push claude-otel.jsonl
+        --endpoint "$MLFLOW_TRACKING_URI"
+        --experiment "$MLFLOW_EXPERIMENT_NAME"
+        --token "$MLFLOW_TRACKING_TOKEN"
+```
+
+### With multiple agents
+
+If you run several agents in parallel, each can push to its own experiment:
+
+```yaml
+.agent-template:
+  stage: agent
+  after_script:
+    - cp /tmp/agentic-ci-run.*/claude-otel.jsonl . 2>/dev/null || true
+  artifacts:
+    paths:
+      - claude-otel.jsonl
+    when: always
+
+rfe-autofixer:
+  extends: .agent-template
+  variables:
+    MLFLOW_EXPERIMENT_NAME: rfe-autofixer
+  script:
+    - agentic-ci run --harness claude-code "$RFE_PROMPT"
+
+rfe-assessor:
+  extends: .agent-template
+  variables:
+    MLFLOW_EXPERIMENT_NAME: rfe-assessor
+  script:
+    - agentic-ci run --harness claude-code "$ASSESSOR_PROMPT"
+
+trace-push:
+  stage: observe
+  needs:
+    - job: rfe-autofixer
+      artifacts: true
+    - job: rfe-assessor
+      artifacts: true
+  allow_failure: true
+  parallel:
+    matrix:
+      - EXPERIMENT: [rfe-autofixer, rfe-assessor]
+  script:
+    - agentic-ci mlflow-push claude-otel.jsonl
+        --endpoint "$MLFLOW_TRACKING_URI"
+        --experiment "$EXPERIMENT"
+```
+
+## GitHub Actions
+
+```yaml
+name: Agent Run
+
+on: [push, workflow_dispatch]
+
+jobs:
+  agent-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install agentic-ci
+        run: pip install agentic-ci
+
+      - name: Run agent
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: agentic-ci run --harness claude-code "$PROMPT"
+
+      - name: Collect OTEL log
+        if: always()
+        run: cp /tmp/agentic-ci-run.*/claude-otel.jsonl . 2>/dev/null || true
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: otel-log
+          path: claude-otel.jsonl
+
+  trace-push:
+    runs-on: ubuntu-latest
+    needs: agent-run
+    if: always() && needs.agent-run.result != 'cancelled'
+    continue-on-error: true
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: otel-log
+
+      - name: Install agentic-ci
+        run: pip install agentic-ci
+
+      - name: Push traces to MLflow
+        env:
+          MLFLOW_TRACKING_URI: ${{ vars.MLFLOW_TRACKING_URI }}
+          MLFLOW_TRACKING_TOKEN: ${{ secrets.MLFLOW_TRACKING_TOKEN }}
+        run: |
+          agentic-ci mlflow-push claude-otel.jsonl \
+            --endpoint "$MLFLOW_TRACKING_URI" \
+            --experiment "${{ vars.MLFLOW_EXPERIMENT_NAME }}" \
+            --token "$MLFLOW_TRACKING_TOKEN"
+```
+
+## CLI reference
+
+```
+agentic-ci mlflow-push [-h] --endpoint URL --experiment NAME [--token TOKEN] jsonl
+
+positional arguments:
+  jsonl              Path to claude-otel.jsonl file
+
+options:
+  --endpoint URL     MLflow tracking URI (env: MLFLOW_TRACKING_URI)
+  --experiment NAME  MLflow experiment name (env: MLFLOW_EXPERIMENT_NAME)
+  --token TOKEN      MLflow Bearer token (env: MLFLOW_TRACKING_TOKEN)
+```
+
+All options can be set via environment variables, so the CI job can be as simple as:
+
+```bash
+agentic-ci mlflow-push claude-otel.jsonl
+```

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -29,6 +29,24 @@ def cmd_stop(args, backend):
     backend.stop()
 
 
+def cmd_mlflow_push(args):
+    from agentic_ci import mlflow
+
+    log.section("Pushing traces to MLflow")
+    log.detail("JSONL", args.jsonl)
+    log.detail("Endpoint", args.endpoint)
+    log.detail("Experiment", args.experiment)
+
+    ok, err = mlflow.push_traces(args.jsonl, args.endpoint, args.experiment, args.token)
+    if ok:
+        log.info(f"Pushed {ok} trace(s) to MLflow ({err} failed)")
+    elif err:
+        log.info(f"Failed to push traces to MLflow ({err} errors)")
+        sys.exit(1)
+    else:
+        log.info("No /v1/traces records found in JSONL")
+
+
 def cmd_run(args, backend, harness):
     pre_gate_names = _parse_gate_list(getattr(args, "pre_gates", None))
     post_gate_names = _parse_gate_list(getattr(args, "post_gates", None))
@@ -221,6 +239,31 @@ def main():
         metavar="GATES",
         help="Comma-separated list of post-agent gates to run after the agent",
     )
+    p_push = sub.add_parser(
+        "mlflow-push",
+        help="Push OTel traces from a JSONL log to an MLflow OTLP endpoint",
+    )
+    p_push.add_argument("jsonl", help="Path to claude-otel.jsonl file")
+    p_push.add_argument(
+        "--endpoint",
+        default=os.environ.get("MLFLOW_TRACKING_URI"),
+        required=not os.environ.get("MLFLOW_TRACKING_URI"),
+        metavar="URL",
+        help="MLflow tracking URI (env: MLFLOW_TRACKING_URI)",
+    )
+    p_push.add_argument(
+        "--experiment",
+        default=os.environ.get("MLFLOW_EXPERIMENT_NAME"),
+        required=not os.environ.get("MLFLOW_EXPERIMENT_NAME"),
+        metavar="NAME",
+        help="MLflow experiment name (env: MLFLOW_EXPERIMENT_NAME)",
+    )
+    p_push.add_argument(
+        "--token",
+        default=os.environ.get("MLFLOW_TRACKING_TOKEN"),
+        metavar="TOKEN",
+        help="MLflow Bearer token (env: MLFLOW_TRACKING_TOKEN)",
+    )
 
     args, extra = parser.parse_known_args()
     if hasattr(args, "prompt"):
@@ -230,6 +273,10 @@ def main():
 
     if args.command == "forge":
         args.func(args)
+        return
+
+    if args.command == "mlflow-push":
+        cmd_mlflow_push(args)
         return
 
     if args.command not in ("setup", "run", "stop"):

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -163,9 +163,14 @@ class ClaudeCodeHarness(Harness):
                     "export CLAUDE_CODE_ENABLE_TELEMETRY=1",
                     "export OTEL_METRICS_EXPORTER=otlp",
                     "export OTEL_LOGS_EXPORTER=otlp",
+                    "export OTEL_TRACES_EXPORTER=otlp",
                     "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
                     f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://{_OPENSHELL_GATEWAY_HOST}:{otel_port}",
                     "export OTEL_METRIC_EXPORT_INTERVAL=10000",
+                    "export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1",
+                    "export OTEL_LOG_USER_PROMPTS=1",
+                    "export OTEL_LOG_TOOL_DETAILS=1",
+                    "export OTEL_LOG_TOOL_CONTENT=1",
                 ]
             )
         return lines
@@ -181,11 +186,21 @@ class ClaudeCodeHarness(Harness):
             "--env",
             "OTEL_LOGS_EXPORTER=otlp",
             "--env",
+            "OTEL_TRACES_EXPORTER=otlp",
+            "--env",
             "OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
             "--env",
             f"OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:{otel_port}",
             "--env",
             "OTEL_METRIC_EXPORT_INTERVAL=10000",
+            "--env",
+            "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1",
+            "--env",
+            "OTEL_LOG_USER_PROMPTS=1",
+            "--env",
+            "OTEL_LOG_TOOL_DETAILS=1",
+            "--env",
+            "OTEL_LOG_TOOL_CONTENT=1",
         ]
 
     def credential_mount_target(self):

--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -1,0 +1,97 @@
+"""Push OTel trace payloads from a JSONL log to an MLflow OTLP endpoint."""
+
+import json
+import ssl
+import sys
+import urllib.error
+import urllib.request
+
+
+def _resolve_experiment_id(endpoint, name, headers):
+    """Look up an MLflow experiment by name. Returns ID or None."""
+    url = f"{endpoint}/api/2.0/mlflow/experiments/search"
+    escaped_name = name.replace("'", "''")
+    body = json.dumps({"filter": f"name = '{escaped_name}'"}).encode()
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={**headers, "Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, context=ssl.create_default_context()) as resp:
+            data = json.loads(resp.read())
+            experiments = data.get("experiments", [])
+            if experiments:
+                return experiments[0]["experiment_id"]
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        pass
+    return None
+
+
+def push_traces(log_file, endpoint, experiment, token=None):
+    """Push /v1/traces records from a JSONL log to an MLflow OTLP endpoint.
+
+    Returns (ok_count, error_count).
+    """
+    endpoint = endpoint.rstrip("/")
+    headers = {}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    records = []
+    try:
+        with open(log_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                    if "/v1/traces" in rec.get("path", ""):
+                        records.append(rec)
+                except json.JSONDecodeError:
+                    pass
+    except FileNotFoundError:
+        return 0, 0
+
+    if not records:
+        return 0, 0
+
+    experiment_id = _resolve_experiment_id(endpoint, experiment, headers)
+    if not experiment_id:
+        print(
+            f"MLflow experiment '{experiment}' not found — skipping trace push.",
+            file=sys.stderr,
+        )
+        return 0, 0
+
+    ctx = ssl.create_default_context()
+    traces_url = f"{endpoint}/v1/traces"
+    ok, err = 0, 0
+
+    for rec in records:
+        payload = rec.get("payload")
+        if not payload:
+            continue
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            traces_url,
+            data=body,
+            headers={
+                **headers,
+                "Content-Type": "application/json",
+                "x-mlflow-experiment-id": experiment_id,
+            },
+        )
+        try:
+            with urllib.request.urlopen(req, context=ctx) as resp:
+                resp.read()
+                ok += 1
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            detail = ""
+            if isinstance(e, urllib.error.HTTPError):
+                detail = f" ({e.code})"
+            print(f"Trace push failed{detail}: {e}", file=sys.stderr)
+            err += 1
+
+    return ok, err


### PR DESCRIPTION
## Summary

- Enable full OTel span export from Claude Code by adding trace env vars to the harness
- Add `mlflow.py` module with `push_traces()` to forward `/v1/traces` records from a JSONL log to an MLflow OTLP endpoint
- Add `agentic-ci mlflow-push` CLI subcommand for use as a separate CI job
- Add documentation with GitLab CI and GitHub Actions examples

## Design

The trace push is a **separate CLI subcommand** (`agentic-ci mlflow-push`), not inline in `agentic-ci run`. This way it runs as a follow-up CI job with `allow_failure: true`, so trace push failures never block the pipeline.

## Env vars added to Claude Code harness

| Variable | Purpose |
|----------|---------|
| `OTEL_TRACES_EXPORTER=otlp` | Enable span export |
| `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` | Rich span hierarchy |
| `OTEL_LOG_USER_PROMPTS=1` | Include prompt text in spans |
| `OTEL_LOG_TOOL_DETAILS=1` | Include tool inputs in spans |
| `OTEL_LOG_TOOL_CONTENT=1` | Include tool outputs in spans |

No collector changes needed — it already accepts all OTLP paths including `/v1/traces`.

## Usage

```bash
# Agent run (produces claude-otel.jsonl)
agentic-ci run --harness claude-code "Fix the bug"

# Separate job: push traces to MLflow
agentic-ci mlflow-push claude-otel.jsonl \
    --endpoint $MLFLOW_TRACKING_URI \
    --experiment rfe-autofixer \
    --token $MLFLOW_TRACKING_TOKEN
```

See `docs/mlflow-traces.md` for full GitLab CI and GitHub Actions examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an mlflow-push CLI command to forward captured OpenTelemetry traces to MLflow, with options and environment-variable defaults for endpoint, experiment, and token.
  * Expanded OpenTelemetry configuration to emit trace-related flags and enhanced telemetry controls.

* **Documentation**
  * Added a how-to guide with GitLab/GitHub CI examples, artifact collection patterns, non-blocking push behavior, multi-agent examples, and a security note about sensitive trace contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->