### PR TITLE
Run podman e2e tests inside the CI podman container

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -188,11 +188,17 @@ jobs:
   build-ci-podman:
     name: Build ci-podman
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/podman:${CI_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
@@ -462,19 +468,27 @@ jobs:
   # --------------------------------------------------------------------------
   e2e-claude-runner:
     name: E2E claude-runner
-    needs: build-claude-runner
+    needs: [build-claude-runner, build-ci-podman]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-ci-podman.outputs.image }}
+      options: --privileged
+      credentials:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Configure podman for container environment
+        run: |
+          printf '[storage]\ndriver = "overlay"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' \
+            > /etc/containers/storage.conf
 
-      - name: Install agentic-ci
+      - name: Install agentic-ci from repo
         run: uv tool install .
 
       - name: Run e2e tests
@@ -486,19 +500,27 @@ jobs:
 
   e2e-opencode-runner:
     name: E2E opencode-runner
-    needs: build-opencode-runner
+    needs: [build-opencode-runner, build-ci-podman]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-ci-podman.outputs.image }}
+      options: --privileged
+      credentials:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      - name: Configure podman for container environment
+        run: |
+          printf '[storage]\ndriver = "overlay"\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\n' \
+            > /etc/containers/storage.conf
 
-      - name: Install agentic-ci
+      - name: Install agentic-ci from repo
         run: uv tool install .
 
       - name: Run e2e tests


### PR DESCRIPTION
## Summary

- E2e-claude-runner and e2e-opencode-runner jobs now run inside the `quay.io/aipcc/agentic-ci/podman` container image built in the same workflow, matching the environment used by production CI runners.
- Follows the same pattern already established by the e2e-openshell-sandbox job.
- Addresses review feedback from #77: https://github.com/opendatahub-io/agentic-ci/pull/77#discussion_r3404046387

## Test plan

- [ ] CI workflow parses without errors
- [ ] E2E jobs pull the ci-<sha> podman image and run inside it
- [ ] Podman-in-container works with `--privileged`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to improve testing infrastructure and job dependency management. Testing jobs now run in containerized environments for consistency and better isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->