### PR TITLE
Bump agentic-ci from 0.2.22 to 0.2.25 in container images

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -101,7 +101,7 @@ RUN curl -fsSL -o /tmp/uv.tar.gz \
 
 # Python packages
 RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.22
+        agentic-ci==0.2.25
 
 # Rootless podman config: storage driver and subordinate UID/GID
 # mappings so nested podman can pull images with mixed file ownership.

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -78,7 +78,7 @@ RUN curl -fsSL -o /tmp/uv.tar.gz \
 
 # Python packages
 RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.22
+        agentic-ci==0.2.25
 
 # Rootless podman storage config
 RUN mkdir -p /etc/containers && \

--- a/images/runner/shared/Containerfile.base
+++ b/images/runner/shared/Containerfile.base
@@ -60,5 +60,5 @@ RUN curl -fsSL -o /tmp/glab.tar.gz \
     && rm -rf /tmp/glab.tar.gz /tmp/bin
 
 RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.22 \
+        agentic-ci==0.2.25 \
         ruff==0.15.15

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -83,7 +83,7 @@ RUN curl -fsSL -o /tmp/shellcheck.tar.xz \
 
 # Python packages (agentic-ci for skill use inside the sandbox)
 RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.22 \
+        agentic-ci==0.2.25 \
         ruff==0.15.14
 
 # Sandbox home directories


### PR DESCRIPTION
## Summary
- Bump pinned `agentic-ci` package version from 0.2.22 to 0.2.25 in all four Containerfiles:
  - `images/ci/Containerfile.podman`
  - `images/ci/Containerfile.openshell`
  - `images/runner/shared/Containerfile.base`
  - `images/runner/shared/Containerfile.openshell-base`

## Test plan
- [ ] Verify CI image builds succeed
- [ ] Verify runner base image builds succeed
- [ ] Verify OpenShell base image builds succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)