### PR TITLE
Support repo-level network policy endpoints

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,13 @@
+.git/
+.tox/
+.mypy_cache/
+.ruff_cache/
+.pytest_cache/
+.claude/
+__pycache__/
+*.egg-info/
+dist/
+build/
+public/
+docs/_build/
+htmlcov/

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -220,7 +220,7 @@ jobs:
             -t "${IMAGE_NAME}:latest" \
             -t "${IMAGE_NAME}:${EPOCH}" \
             -f images/ci/Containerfile.podman \
-            images/ci/
+            .
 
           echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
 
@@ -406,7 +406,7 @@ jobs:
             -t "${IMAGE_NAME}:latest" \
             -t "${IMAGE_NAME}:${EPOCH}" \
             -f images/ci/Containerfile.openshell \
-            images/ci/
+            .
 
           echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ opencode-build: base-build ## Build the OpenCode runner image locally
 
 .PHONY: ci-build
 ci-build: ## Build the CI podman image locally
-	podman build -t ci-podman:latest -f images/ci/Containerfile.podman images/ci/
+	podman build -t ci-podman:latest -f images/ci/Containerfile.podman .
 
 .PHONY: openshell-base-build
 openshell-base-build: ## Build the OpenShell sandbox base image locally
@@ -34,7 +34,7 @@ openshell-opencode-build: openshell-base-build ## Build the OpenShell OpenCode s
 
 .PHONY: openshell-ci-build
 openshell-ci-build: ## Build the OpenShell CI image locally
-	podman build -t openshell:latest -f images/ci/Containerfile.openshell images/ci/
+	podman build -t openshell:latest -f images/ci/Containerfile.openshell .
 
 .PHONY: bump-versions
 bump-versions: ## Bump pinned dependency versions in Containerfiles

--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -139,7 +139,9 @@ openshell sandbox create \
   --from <SANDBOX_IMAGE> \
   -- true
 
-# Apply network policy and wait for the supervisor to compile and load it
+# Apply network policy and wait for the supervisor to compile and load it.
+# Built-in defaults are always included. If .agentic-ci/openshell-policy.yml
+# exists in the workdir, its endpoints are merged in automatically.
 openshell policy update --wait \
   --binary /usr/local/bin/claude \
   --binary /usr/bin/opencode \
@@ -200,6 +202,22 @@ The default endpoints cover:
 | `*.aiplatform.googleapis.com:443` | read-write | Vertex AI (regional endpoints) |
 | `oauth2.googleapis.com:443` | read-write | GCP token exchange |
 | `api.anthropic.com:443` | read-write | Anthropic API (API key auth) |
+
+### Project-specific endpoints
+
+Projects can declare additional endpoints in
+`.agentic-ci/openshell-policy.yml` at the repository root. These are
+merged with the built-in defaults (duplicates are ignored).
+
+```yaml
+# .agentic-ci/openshell-policy.yml
+endpoints:
+  - "redhat.atlassian.net:443:read-only"
+  - "*.example.com:443:full"
+```
+
+The `--policy` CLI flag takes precedence: if a flag path is provided
+and the file exists, the repo-level file is ignored.
 
 ## Supervisor Image
 

--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -99,9 +99,11 @@ RUN curl -fsSL -o /tmp/uv.tar.gz \
     && chmod +x /usr/local/bin/uv \
     && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
 
-# Python packages
-RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.25
+# agentic-ci from local source
+COPY pyproject.toml README.md /tmp/agentic-ci/
+COPY src/ /tmp/agentic-ci/src/
+RUN uv pip install --system --no-cache /tmp/agentic-ci \
+    && rm -rf /tmp/agentic-ci
 
 # Rootless podman config: storage driver and subordinate UID/GID
 # mappings so nested podman can pull images with mixed file ownership.

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -76,9 +76,11 @@ RUN curl -fsSL -o /tmp/uv.tar.gz \
     && chmod +x /usr/local/bin/uv \
     && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
 
-# Python packages
-RUN uv pip install --system --no-cache \
-        agentic-ci==0.2.25
+# agentic-ci from local source
+COPY pyproject.toml README.md /tmp/agentic-ci/
+COPY src/ /tmp/agentic-ci/src/
+RUN uv pip install --system --no-cache /tmp/agentic-ci \
+    && rm -rf /tmp/agentic-ci
 
 # Rootless podman storage config
 RUN mkdir -p /etc/containers && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
 ]
 keywords = ["ci", "cd", "ai", "agents", "claude", "llm", "telemetry"]
 dependencies = [
+    "PyYAML>=6.0",
     "requests>=2.28",
     "tenacity>=8.0",
 ]

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -263,7 +263,8 @@ def bump_agentic_ci(check_only):
 
     result = {"tool": "agentic-ci", "version": version}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        # CI images install from local source; only bump runner base images.
+        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
             if not cf.exists():
                 continue
             text = cf.read_text()

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -57,7 +57,12 @@ class OpenShellBackend(Backend):
         image_info = f", image: {self.image}" if self.image else ""
         log.section(f"Creating sandbox ({image_info.lstrip(', ') or 'default image'})")
 
-        sandbox.create(image=self.image, policy_path=self.policy_path, otel_port=otel_port)
+        sandbox.create(
+            image=self.image,
+            policy_path=self.policy_path,
+            otel_port=otel_port,
+            workdir=self.workdir,
+        )
 
         log.section("Uploading workdir")
         sandbox.upload(self.workdir)

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -69,7 +69,7 @@ class OpenShellBackend(Backend):
 
     def stop(self):
         try:
-            if sandbox.exists():
+            if gateway.is_running() and sandbox.exists():
                 sandbox.delete()
                 log.section("Sandbox deleted")
             else:

--- a/src/agentic_ci/backends/openshell/gateway.py
+++ b/src/agentic_ci/backends/openshell/gateway.py
@@ -57,6 +57,8 @@ def start():
 
     subprocess.Popen(
         ["podman", "system", "service", "--time=0", f"unix://{sock}"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
     )
 
     try:

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -2,6 +2,8 @@
 
 import os
 
+import yaml
+
 REPO_POLICY_PATH = ".agentic-ci/openshell-policy.yml"
 
 # Default network endpoints in openshell policy update format:
@@ -22,19 +24,47 @@ DEFAULT_ENDPOINTS = [
 ]
 
 
-def resolve_endpoints(flag_path=None):
+def _load_endpoints_from_file(path):
+    """Parse endpoint list from a YAML policy file."""
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict):
+        return []
+    endpoints = data.get("endpoints", [])
+    if not isinstance(endpoints, list):
+        return []
+    return [str(ep) for ep in endpoints]
+
+
+def resolve_endpoints(flag_path=None, workdir="."):
     """Resolve the endpoint list to use for policy update.
 
-    1. Explicit --policy flag path (parsed for endpoints — not yet supported,
-       returns default endpoints)
-    2. .agentic-ci/openshell-policy.yml in the workdir (same)
-    3. Built-in default endpoints
+    Merges the built-in defaults with extra endpoints from, in priority
+    order:
+
+    1. Explicit ``--policy`` flag path
+    2. ``.agentic-ci/openshell-policy.yml`` in *workdir*
 
     Returns a list of endpoint strings for ``openshell policy update --add-endpoint``.
     """
-    if flag_path and os.path.isfile(flag_path):
-        print(f"  Policy source: --policy flag ({os.path.abspath(flag_path)})", flush=True)
-    else:
-        print("  Policy source: built-in default", flush=True)
+    extra = []
+    source = "built-in default"
 
-    return list(DEFAULT_ENDPOINTS)
+    if flag_path and os.path.isfile(flag_path):
+        extra = _load_endpoints_from_file(flag_path)
+        source = f"--policy flag ({os.path.abspath(flag_path)})"
+    else:
+        repo_path = os.path.join(workdir, REPO_POLICY_PATH)
+        if os.path.isfile(repo_path):
+            extra = _load_endpoints_from_file(repo_path)
+            source = f"repo ({os.path.abspath(repo_path)})"
+
+    print(f"  Policy source: {source}", flush=True)
+
+    endpoints = list(DEFAULT_ENDPOINTS)
+    seen = set(endpoints)
+    for ep in extra:
+        if ep not in seen:
+            endpoints.append(ep)
+            seen.add(ep)
+    return endpoints

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -24,7 +24,7 @@ def exists():
     return result.returncode == 0
 
 
-def create(image=None, policy_path=None, otel_port=None):
+def create(image=None, policy_path=None, otel_port=None, workdir="."):
     """Create a persistent sandbox with the CI provider attached.
 
     The sandbox is created first, then the network policy is applied
@@ -47,16 +47,16 @@ def create(image=None, policy_path=None, otel_port=None):
     args.extend(["--", "true"])
     _run(args, check=True)
 
-    _apply_policy(policy_path, otel_port=otel_port)
+    _apply_policy(policy_path, otel_port=otel_port, workdir=workdir)
 
 
-def _apply_policy(policy_path, otel_port=None):
+def _apply_policy(policy_path, otel_port=None, workdir="."):
     """Apply network policy endpoints and wait for activation.
 
     Uses ``openshell policy update --wait`` which blocks until the
     supervisor has compiled and loaded the new policy revision.
     """
-    endpoints = resolve_endpoints(policy_path)
+    endpoints = resolve_endpoints(policy_path, workdir=workdir)
     if otel_port:
         endpoints.append(f"host.openshell.internal:{otel_port}:read-write")
     if not endpoints:

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -246,6 +246,39 @@ else
 
     assert_ok "opencode exited successfully" test "$RC" -eq 0
     dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness opencode 2>/dev/null || true
+
+    # --- Repo-level network policy test ---
+    # Verifies that .agentic-ci/openshell-policy.yml in the workdir adds
+    # extra endpoints to the sandbox policy.  packages.redhat.com is NOT in the
+    # default endpoint list, so the agent can only reach it if the repo
+    # policy file is picked up correctly.
+    print_header "=== agentic-ci run: repo-level network policy ==="
+
+    WORKDIR="$TMPDIR_E2E/repo-policy"
+    mkdir -p "$WORKDIR/.agentic-ci"
+    cat > "$WORKDIR/.agentic-ci/openshell-policy.yml" <<'POLICY'
+endpoints:
+  - "packages.redhat.com:443:read-write"
+POLICY
+
+    print_step "Running Claude Code with repo-level policy (packages.redhat.com allowed)..."
+    POLICY_LOG="$TMPDIR_E2E/repo-policy.log"
+    RC=0
+    agentic-ci run \
+        "Use curl to fetch https://packages.redhat.com. If you get a response, reply with only the word pong. If you cannot reach it, reply with only the word fail." \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel 2>&1 | tee "$POLICY_LOG" || RC=$?
+
+    OUTPUT="$(cat "$POLICY_LOG")"
+    assert_ok "repo-policy run exited successfully" test "$RC" -eq 0
+    assert_contains "repo policy: agent reached packages.redhat.com" "$OUTPUT" "pong"
+    assert_contains "repo policy: source logged" "$OUTPUT" "Policy source: repo"
+    dump_gateway_log
 fi
 
 echo ""

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -4,15 +4,51 @@ from agentic_ci.backends.openshell.policy import DEFAULT_ENDPOINTS, resolve_endp
 
 
 def test_default_endpoints_returned_when_no_flag(tmp_path):
-    result = resolve_endpoints(flag_path=None)
+    result = resolve_endpoints(flag_path=None, workdir=str(tmp_path))
     assert result == list(DEFAULT_ENDPOINTS)
 
 
-def test_default_endpoints_returned_with_flag(tmp_path):
+def test_flag_file_endpoints_merged(tmp_path):
     flag_file = tmp_path / "custom.yml"
-    flag_file.write_text("custom: true")
+    flag_file.write_text("endpoints:\n  - 'jira.example.com:443:read-only'\n")
+    result = resolve_endpoints(flag_path=str(flag_file))
+    assert result == list(DEFAULT_ENDPOINTS) + ["jira.example.com:443:read-only"]
+
+
+def test_flag_file_without_endpoints_key(tmp_path):
+    flag_file = tmp_path / "custom.yml"
+    flag_file.write_text("custom: true\n")
     result = resolve_endpoints(flag_path=str(flag_file))
     assert result == list(DEFAULT_ENDPOINTS)
+
+
+def test_repo_policy_file_merged(tmp_path):
+    policy_dir = tmp_path / ".agentic-ci"
+    policy_dir.mkdir()
+    policy_file = policy_dir / "openshell-policy.yml"
+    policy_file.write_text("endpoints:\n  - 'internal.example.com:443:full'\n")
+    result = resolve_endpoints(workdir=str(tmp_path))
+    assert result == list(DEFAULT_ENDPOINTS) + ["internal.example.com:443:full"]
+
+
+def test_flag_takes_precedence_over_repo(tmp_path):
+    policy_dir = tmp_path / ".agentic-ci"
+    policy_dir.mkdir()
+    (policy_dir / "openshell-policy.yml").write_text(
+        "endpoints:\n  - 'repo.example.com:443:full'\n"
+    )
+    flag_file = tmp_path / "flag.yml"
+    flag_file.write_text("endpoints:\n  - 'flag.example.com:443:full'\n")
+    result = resolve_endpoints(flag_path=str(flag_file), workdir=str(tmp_path))
+    assert "flag.example.com:443:full" in result
+    assert "repo.example.com:443:full" not in result
+
+
+def test_duplicate_endpoints_deduplicated(tmp_path):
+    flag_file = tmp_path / "custom.yml"
+    flag_file.write_text("endpoints:\n  - 'github.com:443:full'\n")
+    result = resolve_endpoints(flag_path=str(flag_file))
+    assert result.count("github.com:443:full") == 1
 
 
 def test_endpoints_include_vertex_ai():

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,9 @@ commands = ruff format --check --diff .
 
 [testenv:typecheck]
 description = Run type checker
-deps = mypy
+deps =
+    mypy
+    types-PyYAML
 commands = mypy src/
 
 [testenv:format]


### PR DESCRIPTION
## Summary

- Allow projects to declare extra OpenShell network endpoints in `.agentic-ci/openshell-policy.yml`
- Endpoints from the file are merged with the built-in defaults (deduped)
- `--policy` flag takes precedence over the repo-level file
- Uses PyYAML for parsing (new dependency)
- CI images now install agentic-ci from local source so e2e tests run with the PR's code
- Fix `stop()` hanging when gateway is already dead: redirect `podman system service` stdout/stderr to devnull so it can't hold pipe fds open, and skip sandbox check if gateway is not running

## Context

The rfe-assessor sandbox can't reach Jira because `redhat.atlassian.net` isn't in the default endpoint list. Rather than adding every project's endpoints to the defaults, this lets each repo declare its own needs.

## Test plan

- [x] Unit tests for repo file parsing, flag precedence, dedup, missing keys
- [x] E2E: sandbox with `.agentic-ci/openshell-policy.yml` adding `packages.redhat.com` can reach it (verifies full policy plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)