### PR TITLE
Support policy advisor approval mode for OpenShell sandboxes

### DIFF
--- a/src/agentic_ci/backends/__init__.py
+++ b/src/agentic_ci/backends/__init__.py
@@ -37,6 +37,7 @@ def create_backend(name: str, *, harness: Harness, **kwargs: Any) -> Backend:
             image=kwargs.get("image"),
             policy=kwargs.get("policy"),
             extra_env=kwargs.get("extra_env"),
+            approval_mode=kwargs.get("approval_mode"),
             harness=harness,
         )
     else:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -35,10 +35,20 @@ class OpenShellBackend(Backend):
 
     _ENV_SCRIPT = "/tmp/.agentic-ci-env.sh"
 
-    def __init__(self, workdir=".", image=None, policy=None, extra_env=None, *, harness: Harness):
+    def __init__(
+        self,
+        workdir=".",
+        image=None,
+        policy=None,
+        extra_env=None,
+        approval_mode=None,
+        *,
+        harness: Harness,
+    ):
         super().__init__(workdir=workdir, image=image, harness=harness)
         self.policy_path = policy
         self._extra_env = extra_env or {}
+        self.approval_mode = approval_mode
 
     def setup(self, otel_port=None):
         if not gateway.is_running():
@@ -62,6 +72,7 @@ class OpenShellBackend(Backend):
             policy_path=self.policy_path,
             otel_port=otel_port,
             workdir=self.workdir,
+            approval_mode=self.approval_mode,
         )
 
         log.section("Uploading workdir")

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -24,7 +24,7 @@ def exists():
     return result.returncode == 0
 
 
-def create(image=None, policy_path=None, otel_port=None, workdir="."):
+def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_mode=None):
     """Create a persistent sandbox with the CI provider attached.
 
     The sandbox is created first, then the network policy is applied
@@ -42,10 +42,27 @@ def create(image=None, policy_path=None, otel_port=None, workdir="."):
         "--provider",
         PROVIDER_NAME,
     ]
+    if approval_mode:
+        args.extend(["--approval-mode", approval_mode])
     if image:
         args.extend(["--from", image])
     args.extend(["--", "true"])
     _run(args, check=True)
+
+    if approval_mode:
+        _run(
+            [
+                "openshell",
+                "settings",
+                "set",
+                SANDBOX_NAME,
+                "--key",
+                "agent_policy_proposals_enabled",
+                "--value",
+                "true",
+            ],
+            check=True,
+        )
 
     _apply_policy(policy_path, otel_port=otel_port, workdir=workdir)
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -52,6 +52,11 @@ def test_create_openshell_with_extra_env(harness):
     assert backend._extra_env == {"FOO": "bar"}
 
 
+def test_create_openshell_with_approval_mode(harness):
+    backend = create_backend("openshell", harness=harness, approval_mode="auto")
+    assert backend.approval_mode == "auto"
+
+
 def test_unknown_backend_raises(harness):
     with pytest.raises(ValueError, match="Unknown backend"):
         create_backend("docker", harness=harness)


### PR DESCRIPTION
Add an `approval_mode` parameter to the OpenShell backend so callers can enable the policy advisor with auto-approval.  When set, the sandbox is created with `--approval-mode <value>` and `agent_policy_proposals_enabled` is turned on so the agent can propose narrow network policy changes at runtime.

This is needed by consumers like code-review where the agent must access arbitrary documentation domains that cannot be enumerated upfront in a static endpoint list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added approval mode configuration parameter to OpenShell backend initialization.

* **Tests**
  * Added test coverage for approval mode functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->