### PR TITLE
Fix AGENT_ENABLED_PLUGINS for OpenShell backend

### DIFF
--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -149,6 +149,16 @@ class OpenShellBackend(Backend):
             lines.append(f"export {key}={shlex.quote(val)}")
 
         lines.append(f"export AGENT_MODEL={shlex.quote(model)}")
+
+        lines.extend(
+            [
+                "if [ -f /usr/local/bin/entrypoint.sh ]; then",
+                "    . /usr/local/bin/entrypoint.sh --source-only",
+                "    _enable_plugins",
+                "fi",
+            ]
+        )
+
         script = "\n".join(lines) + "\n"
 
         with tempfile.NamedTemporaryFile(

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -150,6 +150,9 @@ class ClaudeCodeHarness(Harness):
             "export CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1",
             "export DISABLE_AUTOUPDATER=1",
         ]
+        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            common.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
         if self.auth_mode == "api-key":
             lines = [
                 f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -156,6 +156,29 @@ print_header "=== claude-sandbox: entrypoint ==="
 assert_ok "entrypoint.sh is installed" \
     run_in "$CLAUDE_SANDBOX" test -x /usr/local/bin/entrypoint.sh
 
+print_header "=== claude-sandbox: AGENT_ENABLED_PLUGINS ==="
+
+# Verify _enable_plugins filters settings.json inside the image.
+# Pick the first installed plugin and check that only it is enabled.
+PLUGIN_FILTER_COUNT="$(run_in "$CLAUDE_SANDBOX" bash -c '
+    export CLAUDE_CONFIG_DIR=/sandbox/.claude
+    PLUGIN=$(python3 -c "
+import json, pathlib
+d = json.loads(pathlib.Path(\"$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json\").read_text())
+print(list(d.get(\"plugins\", {}).keys())[0].split(\"@\")[0])
+")
+    export AGENT_ENABLED_PLUGINS="$PLUGIN"
+    source /usr/local/bin/entrypoint.sh --source-only
+    _enable_plugins
+    python3 -c "
+import json, pathlib
+d = json.loads(pathlib.Path(\"$CLAUDE_CONFIG_DIR/settings.json\").read_text())
+print(len(d.get(\"enabledPlugins\", {})))
+"
+')"
+assert_ok "_enable_plugins filters to single plugin (got $PLUGIN_FILTER_COUNT)" \
+    test "$PLUGIN_FILTER_COUNT" -eq 1
+
 # --- opencode-sandbox checks ---
 print_header "=== opencode-sandbox: binaries ==="
 assert_ok "opencode is installed" run_in "$OPENCODE_SANDBOX" opencode --version
@@ -278,6 +301,50 @@ POLICY
     assert_ok "repo-policy run exited successfully" test "$RC" -eq 0
     assert_contains "repo policy: agent reached packages.redhat.com" "$OUTPUT" "pong"
     assert_contains "repo policy: source logged" "$OUTPUT" "Policy source: repo"
+    dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+
+    # --- AGENT_ENABLED_PLUGINS via OpenShell ---
+    # Verifies that the env script sources entrypoint.sh and calls
+    # _enable_plugins so only the requested plugins are loaded.
+    print_header "=== agentic-ci run: AGENT_ENABLED_PLUGINS via OpenShell ==="
+
+    WORKDIR="$TMPDIR_E2E/plugins"
+    mkdir -p "$WORKDIR"
+
+    # Pick the first installed plugin from the image
+    FIRST_PLUGIN="$(run_in "$CLAUDE_SANDBOX" python3 -c "
+import json, pathlib
+d = json.loads(pathlib.Path('/sandbox/.claude/plugins/installed_plugins.json').read_text())
+print(list(d.get('plugins', {}).keys())[0].split('@')[0])
+")"
+    print_step "Testing with AGENT_ENABLED_PLUGINS=$FIRST_PLUGIN"
+
+    PLUGINS_LOG="$TMPDIR_E2E/plugins.log"
+    RC=0
+    AGENT_ENABLED_PLUGINS="$FIRST_PLUGIN" \
+    agentic-ci run "Reply with only the word pong" \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel 2>&1 | tee "$PLUGINS_LOG" || RC=$?
+
+    OUTPUT="$(cat "$PLUGINS_LOG")"
+    assert_ok "plugin-filter run exited successfully" test "$RC" -eq 0
+
+    # The "Plugins:" line should list only the single requested plugin
+    PLUGINS_LINE="$(grep -i '^\s*Plugins:' "$PLUGINS_LOG" || true)"
+    if [[ -n "$PLUGINS_LINE" ]]; then
+        PLUGIN_COUNT="$(echo "$PLUGINS_LINE" | tr ',' '\n' | grep -c '[a-z]')"
+        assert_ok "plugin-filter: only 1 plugin loaded (got $PLUGIN_COUNT)" \
+            test "$PLUGIN_COUNT" -eq 1
+        assert_contains "plugin-filter: correct plugin loaded" "$PLUGINS_LINE" "$FIRST_PLUGIN"
+    else
+        print_error "FAIL: plugin-filter: no Plugins line found in output"
+        FAIL=$((FAIL + 1))
+    fi
     dump_gateway_log
 fi
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,11 +1,13 @@
 """Tests for backend factory."""
 
+from unittest import mock
+
 import pytest
 
 from agentic_ci.backends import create_backend
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import create_harness
+from agentic_ci.harness import ClaudeCodeHarness, create_harness
 
 
 @pytest.fixture()
@@ -67,3 +69,49 @@ def test_backends_have_stop_method(harness):
     openshell = create_backend("openshell", harness=harness, workdir="/tmp")
     assert callable(getattr(podman, "stop", None))
     assert callable(getattr(openshell, "stop", None))
+
+
+class TestOpenShellEnvScript:
+    """Tests for OpenShellBackend._write_env_script()."""
+
+    def _capture_script(self, monkeypatch, tmp_path, **env_overrides):
+        """Run _write_env_script with mocked sandbox ops and return the script content."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.delenv("AGENT_ENABLED_PLUGINS", raising=False)
+        for key, val in env_overrides.items():
+            if val is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, val)
+
+        harness = ClaudeCodeHarness()
+        backend = OpenShellBackend(workdir=str(tmp_path), harness=harness)
+
+        captured = []
+
+        def mock_upload(path):
+            with open(path) as f:
+                captured.append(f.read())
+
+        with (
+            mock.patch("agentic_ci.backends.openshell.sandbox.upload", side_effect=mock_upload),
+            mock.patch("agentic_ci.backends.openshell.sandbox.exec_cmd"),
+        ):
+            backend._write_env_script("claude-opus-4-6")
+
+        assert len(captured) == 1
+        return captured[0]
+
+    def test_env_script_calls_enable_plugins(self, monkeypatch, tmp_path):
+        script = self._capture_script(monkeypatch, tmp_path)
+        assert "_enable_plugins" in script
+        assert "entrypoint.sh --source-only" in script
+
+    def test_env_script_includes_enabled_plugins_var(self, monkeypatch, tmp_path):
+        script = self._capture_script(monkeypatch, tmp_path, AGENT_ENABLED_PLUGINS="alpha,beta")
+        assert "AGENT_ENABLED_PLUGINS" in script
+        assert "alpha,beta" in script
+
+    def test_env_script_omits_enabled_plugins_when_unset(self, monkeypatch, tmp_path):
+        script = self._capture_script(monkeypatch, tmp_path)
+        assert "AGENT_ENABLED_PLUGINS" not in script

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -127,6 +127,21 @@ class TestClaudeCodeHarness:
         assert not any("CLAUDE_CODE_USE_VERTEX" in line for line in lines)
         assert not any("GOOGLE_APPLICATION_CREDENTIALS" in line for line in lines)
 
+    def test_build_env_script_lines_forwards_enabled_plugins(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "alpha,beta")
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert any("AGENT_ENABLED_PLUGINS" in line for line in lines)
+        assert any("alpha,beta" in line for line in lines)
+
+    def test_build_env_script_lines_no_enabled_plugins_when_unset(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        monkeypatch.delenv("AGENT_ENABLED_PLUGINS", raising=False)
+        harness = ClaudeCodeHarness()
+        lines = harness.build_env_script_lines()
+        assert not any("AGENT_ENABLED_PLUGINS" in line for line in lines)
+
     def test_build_env_script_lines_with_otel(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
         harness = ClaudeCodeHarness()


### PR DESCRIPTION
## Summary

`AGENT_ENABLED_PLUGINS` controls which Claude Code plugins are active at runtime.
The env var is processed by `_enable_plugins()` in `entrypoint.sh`, which modifies
`settings.json` to enable only the requested plugins.

On the **Podman backend** this works correctly: the container entrypoint runs during
`podman run`, picks up the env var, and calls `_enable_plugins()`.

On the **OpenShell backend** the entrypoint never runs. The sandbox uses
`openshell sandbox exec` with `bash -c` directly, bypassing the OCI ENTRYPOINT.
Result: all plugins baked into the image stay enabled regardless of `AGENT_ENABLED_PLUGINS`.

Evidence:
- Podman (working): [autofix job](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14836656912) shows `Plugins: autofix-skills` (single plugin, correctly filtered)
- OpenShell (broken): [rfe-assessor job](https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-assessor/-/jobs/14837713525) shows all 13 plugins enabled

### Fix (two parts)

1. **`harness.py`** — `ClaudeCodeHarness.build_env_script_lines()` now exports
   `AGENT_ENABLED_PLUGINS` into the OpenShell env script when the env var is set
   in the host environment.

2. **`openshell/__init__.py`** — `_write_env_script()` now sources
   `entrypoint.sh --source-only` and calls `_enable_plugins` at the end of the
   env script. This reuses the existing function via the `--source-only` guard,
   with a file-existence check for robustness with custom images.

## Test plan

- [x] New tests in `test_harness.py`: env script lines forward/omit `AGENT_ENABLED_PLUGINS`
- [x] New tests in `test_backend.py`: OpenShell env script includes `_enable_plugins` call, includes/omits the env var
- [x] `tox -e py313` (511 passed)
- [x] `tox -e lint` (clean)
- [x] `tox -e check-format` (clean)
- [x] `tox -e typecheck` (clean)
- [ ] Deploy and verify on an OpenShell CI job with `AGENT_ENABLED_PLUGINS` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for plugin configuration through environment variables
  * Enabled automatic entrypoint script sourcing in sandbox environments

* **Tests**
  * Added test coverage for plugin configuration and entrypoint script handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->