### PR TITLE
Add AGENTS.md system prompt for sandbox environments

### DIFF
--- a/images/runner/claude-code/Containerfile
+++ b/images/runner/claude-code/Containerfile
@@ -17,7 +17,8 @@ COPY claude-code/install-plugin.py /usr/local/bin/install-plugin
 RUN chmod +x /usr/local/bin/install-plugin
 
 COPY claude-code/claude-settings.json /home/agent-ci/.claude/settings.json
-RUN chown -R agent-ci:agent-ci /home/agent-ci/.claude
+RUN ln -s ../AGENTS.md /home/agent-ci/.claude/CLAUDE.md \
+    && chown -R agent-ci:agent-ci /home/agent-ci/.claude
 
 USER agent-ci
 RUN install-plugin --marketplace-repo opendatahub-io/skills-registry \

--- a/images/runner/shared/AGENTS.openshell.md
+++ b/images/runner/shared/AGENTS.openshell.md
@@ -1,0 +1,46 @@
+# CI Sandbox Environment
+
+You are running inside a sandboxed CI environment with strict network, filesystem, and process restrictions.
+Actions that violate these constraints will be blocked.
+Do not retry blocked actions -- stop early to save tokens.
+
+## Network Restrictions
+
+Outbound network access is restricted by policy.
+Only connections to explicitly allowed domains will succeed.
+If a network request is blocked, do not retry it -- the policy will not change during your session.
+If the blocked request is required to complete the task, stop and report the failure instead of searching for workarounds.
+
+## Filesystem Restrictions
+
+Filesystem access is enforced by Landlock. Writes to paths not listed below will fail silently.
+
+- **Read-only:** `/usr`, `/lib`, `/etc`, `/proc`, `/dev/urandom`, `/app`, `/var/log`
+- **Read-write:** `/sandbox` (home), `/tmp`, working directory
+
+You **cannot** install system packages -- the package manager paths are
+read-only and you have no root access. Files written outside the working
+directory are **not preserved** after the session ends.
+
+## Process Restrictions
+
+- **No root access.** `sudo`, `su`, `dnf`, `microdnf` will not work.
+- **No mount operations.** `mount`, `umount`, and filesystem namespace operations are blocked by seccomp.
+- **No process debugging.** `ptrace`, `strace`, and cross-process memory access are blocked.
+- **No raw sockets.** Only standard TCP/UDP connections through the sandbox proxy are allowed.
+
+## Available Tools
+
+These tools are pre-installed.
+Do not attempt to install replacements or download binaries from the internet.
+
+`python3`, `uv`, `ruff`, `git`, `gh`, `glab`, `make`, `curl`, `jq`, `shellcheck`
+
+## Guidelines
+
+- Use `uv` for Python package management, not `pip`.
+- Use `gh` for GitHub operations and `glab` for GitLab operations.
+- Write files only to the working directory or `/tmp`.
+- If a network request is blocked, do not retry it. If it was required to complete the task, stop and report the failure.
+- If a required tool is missing, stop and report it rather than trying to install it.
+- Do not attempt to escalate privileges or bypass security controls.

--- a/images/runner/shared/AGENTS.podman.md
+++ b/images/runner/shared/AGENTS.podman.md
@@ -1,0 +1,22 @@
+# CI Sandbox Environment
+
+You are running inside a CI container. Adjust your behavior to work within these constraints.
+
+## Constraints
+
+- **No root access.** You cannot use `sudo`, `dnf`, `microdnf`, or install system packages.
+- **Workspace.** Your project files are mounted at `/workspace`. Only modify files in this directory.
+- **Network is unrestricted.** You can reach any external host.
+
+## Available Tools
+
+These tools are pre-installed. Do not attempt to install replacements or alternatives.
+
+`python3`, `uv`, `ruff`, `git`, `gh`, `glab`, `make`, `curl`, `jq`, `shellcheck`
+
+## Guidelines
+
+- Use `uv` for Python package management, not `pip`.
+- Use `gh` for GitHub operations and `glab` for GitLab operations.
+- Write files only to `/workspace` or `/tmp`. Changes elsewhere may not persist.
+- If a required tool is missing, work with what is available rather than trying to install it.

--- a/images/runner/shared/Containerfile.base
+++ b/images/runner/shared/Containerfile.base
@@ -62,3 +62,6 @@ RUN curl -fsSL -o /tmp/glab.tar.gz \
 RUN uv pip install --system --no-cache \
         agentic-ci==0.2.25 \
         ruff==0.15.15
+
+COPY shared/AGENTS.podman.md /home/agent-ci/AGENTS.md
+RUN ln -s AGENTS.md /home/agent-ci/CLAUDE.md

--- a/images/runner/shared/Containerfile.base
+++ b/images/runner/shared/Containerfile.base
@@ -63,5 +63,5 @@ RUN uv pip install --system --no-cache \
         agentic-ci==0.2.25 \
         ruff==0.15.15
 
-COPY shared/AGENTS.podman.md /home/agent-ci/AGENTS.md
+COPY AGENTS.podman.md /home/agent-ci/AGENTS.md
 RUN ln -s AGENTS.md /home/agent-ci/CLAUDE.md

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -89,6 +89,9 @@ RUN uv pip install --system --no-cache \
 # Sandbox home directories
 USER sandbox
 RUN mkdir -p /sandbox/.local/bin /sandbox/.config /sandbox/.claude /sandbox/.agents
+COPY --chown=sandbox:sandbox shared/AGENTS.openshell.md /sandbox/AGENTS.md
+RUN ln -s AGENTS.md /sandbox/CLAUDE.md \
+    && ln -s ../AGENTS.md /sandbox/.claude/CLAUDE.md
 ENV PATH="/sandbox/.local/bin:${PATH}"
 
 WORKDIR /sandbox

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -89,7 +89,7 @@ RUN uv pip install --system --no-cache \
 # Sandbox home directories
 USER sandbox
 RUN mkdir -p /sandbox/.local/bin /sandbox/.config /sandbox/.claude /sandbox/.agents
-COPY --chown=sandbox:sandbox shared/AGENTS.openshell.md /sandbox/AGENTS.md
+COPY --chown=sandbox:sandbox AGENTS.openshell.md /sandbox/AGENTS.md
 RUN ln -s AGENTS.md /sandbox/CLAUDE.md \
     && ln -s ../AGENTS.md /sandbox/.claude/CLAUDE.md
 ENV PATH="/sandbox/.local/bin:${PATH}"


### PR DESCRIPTION
Pre-install AGENTS.md (with CLAUDE.md symlink) into runner and sandbox base images so AI agents are aware of environment constraints. Podman images get a lightweight version noting container limits; OpenShell images get a stricter version covering network policy, Landlock filesystem enforcement, and seccomp restrictions. Agents are instructed to stop early on blocked actions rather than wasting tokens on retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CI sandbox environment documentation detailing network constraints, filesystem access restrictions, available tools, and usage guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->