### PR TITLE
Package hooks and remove gems from plugin installer

### DIFF
--- a/images/runner/claude-code/install-plugin.py
+++ b/images/runner/claude-code/install-plugin.py
@@ -2,7 +2,7 @@
 """Install Claude Code plugins from a marketplace non-interactively.
 
 Populates ~/.claude/plugins/ cache and metadata files so the container
-image ships with pre-cached skills, agents, commands, and gems.
+image ships with pre-cached skills, agents, commands, and hooks.
 
 Usage:
     install-plugin.py --marketplace-repo opendatahub-io/skills-registry
@@ -127,7 +127,7 @@ def _clone_source(repo, ref, dest):
 
 
 def _copy_content(src, dest, plugin_entry):
-    """Copy skills, agents, commands, gems from cloned source into cache.
+    """Copy skills, agents, commands, hooks from cloned source into cache.
 
     When explicit paths are declared in the marketplace entry, preserve
     the original relative path so Claude Code finds them where it expects.
@@ -170,8 +170,8 @@ def _copy_content(src, dest, plugin_entry):
                 shutil.copytree(candidate, dest / "agents", dirs_exist_ok=True)
                 break
 
-    # commands, gems — fallback only
-    for name in ["commands", "gems"]:
+    # commands, hooks — fallback only
+    for name in ["commands", "hooks"]:
         for fallback in [f".claude/{name}", name]:
             candidate = src / fallback
             if candidate.is_dir():


### PR DESCRIPTION
## Summary

- Add `hooks/` to the fallback copy loop in `install-plugin.py` so Claude Code event hooks from plugins are included in the container image
- Remove `gems/` from the loop (unused)

## Context

The `hooks/hooks.json` in [autofix-skills](https://github.com/opendatahub-io/autofix-skills) defines a `SessionStart` hook for context-compression recovery. This hook was not being packaged into the container image because `install-plugin.py` only copied `skills/`, `agents/`, `commands/`, and `gems/`.

Hooks are Claude Code specific (OpenCode uses a different plugin-based system), but since the runner image targets Claude Code, they should be bundled.

`gems/` was included in the original copy loop but no plugin uses it. Removed to keep the list accurate.

Note: `schemas/` is intentionally not added to this loop. The companion PR (opendatahub-io/autofix-skills#27) relocates schemas into per-skill directories so they're copied automatically as part of `skills/`.

## Change

One-line change in `_copy_content()`:

```python
# Before
for name in ["commands", "gems"]:

# After
for name in ["commands", "hooks"]:
```

## Companion PR

opendatahub-io/autofix-skills#27 removes `autofix-research` and moves schemas into per-skill directories.

## Test plan

- [ ] Run `install-plugin --repo` against autofix-skills and verify `hooks/hooks.json` appears in the cache
- [ ] Verify no `gems/` directory is created (none of our plugins have one)
- [ ] Rebuild container image and run E2E