### PR TITLE
RHAIFIRST-100: Add debugging section to AGENTS.md

### DIFF
--- a/.claude/skills/debug-agentic-ci/SKILL.md
+++ b/.claude/skills/debug-agentic-ci/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: debug-agentic-ci
+description: Investigate infrastructure-level failures in the agentic-ci framework. Covers container backend issues, skill engine errors, forge MR/PR failures, and gate problems. Use when the container failed, MR operations broke, or the skill engine returned errors.
+allowed-tools: Bash Read Grep Glob
+---
+
+# Debug Agentic-CI
+
+Investigate failures in the CI infrastructure layer: container backends, skill engine, forge operations, gates, and telemetry.
+
+## Key entry points
+
+| Area | Entry point |
+|------|-------------|
+| CLI + orchestration | `src/agentic_ci/cli.py` |
+| Skill engine | `src/agentic_ci/skill.py` (`run_skill()`, `SkillConfig`) |
+| Podman backend | `src/agentic_ci/backends/podman.py` |
+| OpenShell backend | `src/agentic_ci/backends/openshell/` |
+| Forge (MR/PR) | `src/agentic_ci/forge.py` |
+| Git operations | `src/agentic_ci/git.py` |
+| Gates | `src/agentic_ci/gates.py` |
+| Jira client | `src/agentic_ci/jira.py` |
+| Stream parsing | `src/agentic_ci/stream.py` |
+| OTEL telemetry | `src/agentic_ci/otel.py` |
+| Container images | `images/` |
+
+## Protocol
+
+1. **Read** this repo's `AGENTS.md` for architecture context.
+2. **Check** [references/symptoms.md](references/symptoms.md) for known patterns matching the failure.
+3. **Investigate** the relevant module following the entry points above.
+4. **Write RCA** using [assets/rca-template.md](assets/rca-template.md).

--- a/.claude/skills/debug-agentic-ci/assets/rca-template.md
+++ b/.claude/skills/debug-agentic-ci/assets/rca-template.md
@@ -1,0 +1,23 @@
+# RCA: [Brief description]
+
+## Symptom
+
+- **Category**: [from symptoms.md]
+- **Summary**: [what happened vs what was expected]
+
+## Evidence
+
+- [key evidence: error messages, log excerpts, file state]
+
+## Root cause
+
+[Name the function, condition, and data that triggered the failure.]
+
+## Fix
+
+- **Files**: [list with line references]
+- **Change**: [concrete description of what to fix]
+
+## Verification
+
+- [ ] [how to confirm the fix works]

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -1,0 +1,71 @@
+# Agentic-CI Symptom Catalog
+
+Known failure patterns from this repo's history. Update this file when fixing bugs or adding features that change failure modes.
+
+## Container backend
+
+### Container exits with code 137 (OOM or SIGKILL)
+- **Likely cause**: Entrypoint sleep passthrough caused the container to receive SIGKILL on timeout instead of graceful shutdown. Fixed by removing sleep passthrough.
+- **Where to look**: `images/runner/shared/entrypoint.sh`, `backends/podman.py` timeout handling
+
+### Container entrypoint bypassed
+- **Likely cause**: PodmanBackend was using `--entrypoint` override. Fixed by stopping the bypass so credential setup in entrypoint.sh runs.
+- **Where to look**: `backends/podman.py` container launch args
+
+### Container config dirs overwritten with /sandbox paths
+- **Likely cause**: Podman backend was injecting OpenShell-style `/sandbox` paths into config dirs. Fixed to use container-appropriate paths.
+- **Where to look**: `backends/podman.py` config dir setup, `harness.py` path resolution
+
+### AGENT_ENABLED_PLUGINS not working in OpenShell
+- **Likely cause**: Plugin env var wasn't being passed through to the sandbox environment. Fixed by explicitly forwarding it.
+- **Where to look**: `backends/openshell/sandbox.py` env var injection, `harness.py`
+
+## Skill engine
+
+### Verdict file missing but agent exited 0
+- **Likely cause**: Agent was SIGKILL'd (timeout) after producing output but before writing verdict. The completion validator now checks verdict file existence before promoting SIGKILL exit to success.
+- **Where to look**: `skill.py:run_skill()` verdict loading, completion validator logic
+
+### Verdict rejected: string where array expected
+- **Likely cause**: LLM returns single values instead of arrays. Fixed by coercing string verdict list fields to arrays.
+- **Where to look**: `verdict.py` coercion logic, `skill.py` verdict validation
+
+## Forge (MR/PR operations)
+
+### GitHub comment filtering returns wrong comments
+- **Likely cause**: GitHub API pagination or comment type filtering was incorrect. Fixed to properly filter by comment type.
+- **Where to look**: `forge.py` GitHub comment methods, API pagination
+
+### GitHub CI status detection wrong
+- **Likely cause**: Check runs vs commit statuses weren't both queried. Fixed to check both GitHub status APIs.
+- **Where to look**: `forge.py` CI status detection methods
+
+### Artifact files left in commits
+- **Likely cause**: `strip_committed_files()` didn't exist. Added to remove skill artifacts from git commits before push.
+- **Where to look**: `gates.py:strip_committed_files()`, post-gate execution in `skill.py`
+
+## Credentials and auth
+
+### GCP project ID not resolved
+- **Likely cause**: Harness project resolution didn't fall back to `GCP_PROJECT_ID` env var when gcloud config was empty.
+- **Where to look**: `harness.py` project resolution, `cli.py` credential setup
+
+### OTEL collector not receiving data
+- **Likely cause**: For OpenShell backend, OTEL host networking wasn't configured. Fixed to set up OTEL endpoint forwarding.
+- **Where to look**: `otel.py` collector setup, `backends/openshell/` network config
+
+## Jira client
+
+### Markdown formatting lost in ADF roundtrip
+- **Likely cause**: `adf_to_text()` was stripping markdown formatting. Fixed to preserve it during conversion.
+- **Where to look**: `jira.py:adf_to_text()`
+
+## Container images
+
+### AGENTS.md not found in container
+- **Likely cause**: COPY paths in Containerfiles didn't match the repo layout after restructuring.
+- **Where to look**: `images/runner/shared/Containerfile.base`, COPY directives
+
+### OpenShell sandbox auto-attaches provider
+- **Likely cause**: Default provider attachment behavior interfered with custom credential injection. Fixed by preventing auto-attachment.
+- **Where to look**: `backends/openshell/sandbox.py` provider config

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,16 @@ Fix any failures before moving on. Do not skip any of these checks.
 - Fix lint errors at the source. Don't suppress with `# noqa` or exclude files from linting.
 - All tests live under `tests/`.
 - `pytest` for tests.
+
+## Debugging
+
+Use the `/debug-agentic-ci` skill when investigating infrastructure-level failures. It provides a symptom catalog and structured RCA template.
+
+When fixing a bug or adding a feature that changes failure modes, update `.claude/skills/debug-agentic-ci/references/symptoms.md` with the new pattern so future investigations have it in context.
+
+When investigating this repo specifically, focus on these areas by symptom:
+
+- **Container failed**: Check `backends/podman.py` or `backends/openshell/` for container launch logic. Check `harness.py` for agent CLI argument construction. Check `cli.py` for credential and OTEL setup. Check `stream.py` if output parsing failed.
+- **Skill engine failure**: Check `skill.py` for the `run_skill()` flow: pre-gates, container launch, post-gates, verdict loading. Check which phase returned an error.
+- **MR/PR operations failed**: Check `forge.py` and the `forge` CLI subcommands. Check `git.py` for clone/push/branch operations. Check error handling in `ForgeError`.
+- **Gate framework issues**: Check `gates.py` for the gate registry and execution order. Check if a gate was added or changed that altered behavior. Gates run as pre/post hooks around the agent; the wiring is in the calling repo (autofix), but the gate implementations may be here.


### PR DESCRIPTION
## Summary
- Adds a `debug-agentic-ci` skill (`.claude/skills/debug-agentic-ci/`) with symptom catalog and RCA template
- Adds a "Debugging" section to AGENTS.md with skill callout and instruction to update symptoms on every bug fix
- Symptom catalog mined from git history covers: container exit codes, entrypoint bypass, verdict coercion, forge comment filtering, credential resolution, OTEL collection, ADF roundtrip, container image paths

Companion PRs:
- autofix: https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/714
- autofix-skills: https://github.com/opendatahub-io/autofix-skills/pull/30

## Test plan
- [ ] Verify skillsaw passes (`uvx skillsaw check .claude/skills/debug-agentic-ci`)
- [ ] Confirm symptom entries match actual git history
- [ ] Verify AGENTS.md renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)