### PR TITLE
Fix claude config sandbox startup

### DIFF
--- a/.claude/skills/test-e2e-openshell/SKILL.md
+++ b/.claude/skills/test-e2e-openshell/SKILL.md
@@ -29,10 +29,10 @@ Also ask for:
   `$API_KEY_FILE`.
 
 Per-section requirements:
-- **Vertex AI auth** (Sections A, C, E, F): GCP ADC credentials at
+- **Vertex AI auth** (Sections A, C, E, F, G): GCP ADC credentials at
   `~/.config/gcloud/application_default_credentials.json` and
   `ANTHROPIC_VERTEX_PROJECT_ID` + `CLOUD_ML_REGION` set in the environment.
-- **API key auth** (Sections B, D): The API key file above.
+- **API key auth** (Sections B, D, H): The API key file above.
 
 ## Container setup
 
@@ -390,6 +390,79 @@ Verify:
 
 ---
 
+## Section G: Skill execution — Vertex AI
+
+Verifies that a plugin skill loads and executes correctly inside the
+sandbox. Uses the `git-shallow-clone` skill from the `odh-ai-helpers`
+plugin to clone a repo into `/tmp` and confirm the result.
+
+Requires GCP ADC credentials and `ANTHROPIC_VERTEX_PROJECT_ID`.
+
+Run cleanup first.
+
+### G1. Run
+
+```bash
+podman exec \
+  -e ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id> \
+  -e CLOUD_ML_REGION=global \
+  -e SANDBOX_IMAGE="$CLAUDE_SANDBOX_IMAGE" \
+  openshell-e2e bash -c '
+    mkdir -p /tmp/e2e-workdir && cd /tmp/e2e-workdir && \
+    agentic-ci run \
+      --backend openshell \
+      --harness claude-code \
+      --image "$SANDBOX_IMAGE" \
+      --model claude-haiku-4-5 \
+      --no-otel \
+      "Use the /odh-ai-helpers:git-shallow-clone skill to shallow-clone https://github.com/opendatahub-io/agentic-ci.git into /tmp/agentic-ci. After the clone completes, run: ls /tmp/agentic-ci and print the output, then respond with exactly: SKILL_OK"
+  '
+```
+
+Verify:
+- `Plugins:` line includes `odh-ai-helpers`
+- Output shows `Skill` tool invocation for `odh-ai-helpers:git-shallow-clone`
+- Output shows a `Bash` tool call running `git clone`
+- Output shows `ls /tmp/agentic-ci` with repo contents (e.g. `src`, `pyproject.toml`, `Makefile`)
+- Agent response contains `SKILL_OK`
+- `Agent exit code: 0`
+
+---
+
+## Section H: Skill execution — API Key
+
+Same test as Section G but with API key auth.
+
+Run cleanup first.
+
+### H1. Run
+
+```bash
+podman exec \
+  -e "ANTHROPIC_API_KEY=$(cat "$API_KEY_FILE")" \
+  -e SANDBOX_IMAGE="$CLAUDE_SANDBOX_IMAGE" \
+  openshell-e2e bash -c '
+    mkdir -p /tmp/e2e-workdir && cd /tmp/e2e-workdir && \
+    agentic-ci run \
+      --backend openshell \
+      --harness claude-code \
+      --image "$SANDBOX_IMAGE" \
+      --model claude-haiku-4-5 \
+      --no-otel \
+      "Use the /odh-ai-helpers:git-shallow-clone skill to shallow-clone https://github.com/opendatahub-io/agentic-ci.git into /tmp/agentic-ci. After the clone completes, run: ls /tmp/agentic-ci and print the output, then respond with exactly: SKILL_OK"
+  '
+```
+
+Verify:
+- Output shows `Auth: API key`
+- `Plugins:` line includes `odh-ai-helpers`
+- Output shows `Skill` tool invocation for `odh-ai-helpers:git-shallow-clone`
+- Output shows `ls /tmp/agentic-ci` with repo contents (e.g. `src`, `pyproject.toml`, `Makefile`)
+- Agent response contains `SKILL_OK`
+- `Agent exit code: 0`
+
+---
+
 ## Final cleanup
 
 ```bash
@@ -398,7 +471,7 @@ podman rm -f openshell-e2e
 
 ## Running the full suite
 
-Execute sections in order (A through F), running the cleanup step before each
+Execute sections in order (A through H), running the cleanup step before each
 section. Skip sections whose prerequisites are not met. If any step fails,
 check the gateway log inside the container:
 

--- a/.claude/skills/test-e2e-podman/SKILL.md
+++ b/.claude/skills/test-e2e-podman/SKILL.md
@@ -28,10 +28,10 @@ Also ask for:
   `$API_KEY_FILE`.
 
 Per-section requirements:
-- **Vertex AI auth** (Sections A): GCP ADC credentials at
+- **Vertex AI auth** (Sections A, E): GCP ADC credentials at
   `~/.config/gcloud/application_default_credentials.json` and
   `ANTHROPIC_VERTEX_PROJECT_ID` + `CLOUD_ML_REGION` set in the environment.
-- **API key auth** (Sections B, D): The API key file above.
+- **API key auth** (Sections B, D, F): The API key file above.
 
 ## Container setup
 
@@ -367,6 +367,92 @@ Verify:
 
 ---
 
+## Section E: Skill execution — Vertex AI
+
+Verifies that a plugin skill loads and executes correctly inside the
+runner container. Uses the `git-shallow-clone` skill from the
+`odh-ai-helpers` plugin to clone a repo into `/tmp` and confirm the
+result.
+
+Requires GCP ADC credentials and `ANTHROPIC_VERTEX_PROJECT_ID`.
+
+Run cleanup first.
+
+### E1. Run
+
+```bash
+podman exec \
+  -e ANTHROPIC_VERTEX_PROJECT_ID=<your-project-id> \
+  -e CLOUD_ML_REGION=global \
+  -e CLAUDE_IMAGE="$CLAUDE_IMAGE" \
+  podman-e2e bash -c '
+    agentic-ci run \
+      --image "$CLAUDE_IMAGE" \
+      --model claude-haiku-4-5 --no-otel \
+      "Use the /odh-ai-helpers:git-shallow-clone skill to shallow-clone https://github.com/opendatahub-io/agentic-ci.git into /tmp/agentic-ci. After the clone completes, run: ls /tmp/agentic-ci and print the output, then respond with exactly: SKILL_OK"
+  '
+```
+
+Verify:
+- `Plugins:` line includes `odh-ai-helpers`
+- Output shows `Skill` tool invocation for `odh-ai-helpers:git-shallow-clone`
+- Output shows a `Bash` tool call running `git clone`
+- Output shows `ls /tmp/agentic-ci` with repo contents (e.g. `src`, `pyproject.toml`, `Makefile`)
+- Agent response contains `SKILL_OK`
+- `Agent exit code: 0`
+
+### E2. Stop
+
+```bash
+podman exec \
+  -e CLAUDE_IMAGE="$CLAUDE_IMAGE" \
+  podman-e2e bash -c '
+    agentic-ci stop --image "$CLAUDE_IMAGE"
+  '
+```
+
+---
+
+## Section F: Skill execution — API Key
+
+Same test as Section E but with API key auth.
+
+Run cleanup first.
+
+### F1. Run
+
+```bash
+podman exec \
+  -e "ANTHROPIC_API_KEY=$(cat "$API_KEY_FILE")" \
+  -e CLAUDE_IMAGE="$CLAUDE_IMAGE" \
+  podman-e2e bash -c '
+    agentic-ci run \
+      --image "$CLAUDE_IMAGE" \
+      --model claude-haiku-4-5 --no-otel \
+      "Use the /odh-ai-helpers:git-shallow-clone skill to shallow-clone https://github.com/opendatahub-io/agentic-ci.git into /tmp/agentic-ci. After the clone completes, run: ls /tmp/agentic-ci and print the output, then respond with exactly: SKILL_OK"
+  '
+```
+
+Verify:
+- Output shows `Auth: API key`
+- `Plugins:` line includes `odh-ai-helpers`
+- Output shows `Skill` tool invocation for `odh-ai-helpers:git-shallow-clone`
+- Output shows `ls /tmp/agentic-ci` with repo contents (e.g. `src`, `pyproject.toml`, `Makefile`)
+- Agent response contains `SKILL_OK`
+- `Agent exit code: 0`
+
+### F2. Stop
+
+```bash
+podman exec \
+  -e CLAUDE_IMAGE="$CLAUDE_IMAGE" \
+  podman-e2e bash -c '
+    agentic-ci stop --image "$CLAUDE_IMAGE"
+  '
+```
+
+---
+
 ## Final cleanup
 
 ```bash
@@ -375,7 +461,7 @@ podman rm -f podman-e2e
 
 ## Running the full suite
 
-Execute sections in order (A through D), running the cleanup step before
+Execute sections in order (A through F), running the cleanup step before
 each section. Skip sections whose prerequisites are not met. If any step
 fails, stop and investigate. Check inner container logs with:
 

--- a/images/runner/claude-code/Containerfile
+++ b/images/runner/claude-code/Containerfile
@@ -24,6 +24,7 @@ USER agent-ci
 # is removed at the end of the same RUN so the final layer has clean
 # git config.
 RUN git config --global url."https://github.com/".insteadOf "git@github.com:" \
+    && export CLAUDE_CONFIG_DIR=/home/agent-ci/.claude \
     && export CLAUDE_CODE_PLUGIN_CACHE_DIR=/home/agent-ci/.claude-seed \
     && export DISABLE_AUTOUPDATER=1 \
     && claude plugin marketplace add opendatahub-io/skills-registry \

--- a/images/runner/claude-code/Containerfile.openshell
+++ b/images/runner/claude-code/Containerfile.openshell
@@ -26,6 +26,7 @@ USER sandbox
 
 # Build plugin seed using native Claude Code CLI.
 RUN git config --global url."https://github.com/".insteadOf "git@github.com:" \
+    && export CLAUDE_CONFIG_DIR=/sandbox/.claude \
     && export CLAUDE_CODE_PLUGIN_CACHE_DIR=/sandbox/.claude-seed \
     && export DISABLE_AUTOUPDATER=1 \
     && claude plugin marketplace add opendatahub-io/skills-registry \

--- a/images/runner/shared/entrypoint.sh
+++ b/images/runner/shared/entrypoint.sh
@@ -108,7 +108,7 @@ agentic-ci enable-plugins
 # the entrypoint to prepend the tool command (matching the runner image
 # behavior where the entrypoint always prepends the agent command).
 case "${1:-}" in
-    claude|claude-code|opencode|bash|sh)
+    claude|claude-code|opencode|bash|sh|true)
         exec "$@"
         ;;
     *)


### PR DESCRIPTION
The plugin install refactor (https://github.com/opendatahub-io/agentic-ci/commit/da1484ac03ab26f1415f775c08ebb80865504b85) switched to running `claude plugin
marketplace add` at build time, which creates .claude.json on startup.
Claude Code then backs up and deletes the file — but only when
CLAUDE_CONFIG_DIR is not explicitly set. At runtime, Claude Code sees the
orphaned backup, prints a config-not-found error, and exits 1.

Fix by exporting CLAUDE_CONFIG_DIR during the build step. When the env
var is explicitly set (even to the default ~/.claude path), Claude Code
preserves .claude.json instead of deleting it.

Also add `true` to the entrypoint passthrough list. The OpenShell
sandbox creation passes `-- true` as the startup command, which the
entrypoint was transforming into `exec claude true` — an invalid Claude
Code invocation that fails with "Not logged in".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new end-to-end test documentation sections for skill execution using both Vertex AI and API Key authentication methods.
  * Updated test suite running instructions to include new test sections and prerequisites.

* **Improvements**
  * Enhanced container build configuration for plugin setup initialization.
  * Improved command execution routing for greater flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->