### PR TITLE
RHAIFIRST-121: Narrow extra_skills type to object-only format

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,11 +316,13 @@ config = SkillConfig(
     skill_name="autofix-resolve",
     extra_skills=[
         {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
-        "lint-check",  # plain string = all hooks, no args
+        {"name": "lint-check"},
     ],
     context_dir=".autofix-context",  # where config.json is written (default: ".context")
 )
 ```
+
+Each entry is an object with `name` (required), `args` (optional), and `hooks` (optional).
 
 When `extra_skills` is non-empty, `run_skill()` writes
 `{context_dir}/config.json` before launching the container:
@@ -329,7 +331,7 @@ When `extra_skills` is non-empty, `run_skill()` writes
 {
   "extra_skills": [
     {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
-    "lint-check"
+    {"name": "lint-check"}
   ]
 }
 ```

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -26,7 +26,7 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
+from typing import Callable, TypedDict
 
 from agentic_ci.backends.podman import PodmanBackend
 from agentic_ci.harness import ClaudeCodeHarness
@@ -43,6 +43,17 @@ def _noop(**_kw):
 
 def _noop_verdict(_work_dir):
     return {}
+
+
+class _SkillHookRequired(TypedDict):
+    name: str
+
+
+class SkillHook(_SkillHookRequired, total=False):
+    """Structured definition of an extra skill to run at a pipeline hook point."""
+
+    args: str
+    hooks: list[str]
 
 
 @dataclass
@@ -64,7 +75,7 @@ class SkillConfig:
     pre_gates: list[Callable[..., str | None]] = field(default_factory=list)
     post_gates: list[Callable[..., tuple[dict | None, list[str]]]] = field(default_factory=list)
 
-    extra_skills: list[str | dict] = field(default_factory=list)
+    extra_skills: list[SkillHook] = field(default_factory=list)
     context_dir: str = ".context"
     artifacts: list[str] = field(default_factory=list)
 

--- a/tests/test_skill_extra_skills.py
+++ b/tests/test_skill_extra_skills.py
@@ -25,46 +25,41 @@ def _dry_run_skill(tmp_path, extra_skills, context_dir=".context"):
 
 
 class TestExtraSkillsConfigWriting:
-    def test_plain_strings_written(self, tmp_path):
-        _dry_run_skill(tmp_path, ["skill-a", "skill-b"])
-        config_file = tmp_path / ".context" / "config.json"
-        assert config_file.exists()
-        data = json.loads(config_file.read_text())
-        assert data == {"extra_skills": ["skill-a", "skill-b"]}
-
     def test_structured_dicts_written(self, tmp_path):
         hooks = [
             {"name": "preflight", "args": "--local --fix", "hooks": ["post_implement"]},
         ]
         _dry_run_skill(tmp_path, hooks)
-        data = json.loads((tmp_path / ".context" / "config.json").read_text())
+        config_file = tmp_path / ".context" / "config.json"
+        assert config_file.exists()
+        data = json.loads(config_file.read_text())
         assert data["extra_skills"] == hooks
 
-    def test_mixed_str_and_dict(self, tmp_path):
-        mixed = [
-            "simple-skill",
-            {"name": "preflight", "args": "--fix", "hooks": ["post_implement"]},
+    def test_multiple_skills_written(self, tmp_path):
+        skills = [
+            {"name": "skill-a"},
+            {"name": "skill-b", "args": "--fix", "hooks": ["post_implement"]},
         ]
-        _dry_run_skill(tmp_path, mixed)
+        _dry_run_skill(tmp_path, skills)
         data = json.loads((tmp_path / ".context" / "config.json").read_text())
-        assert data["extra_skills"] == mixed
+        assert data["extra_skills"] == skills
 
     def test_empty_extra_skills_no_file(self, tmp_path):
         _dry_run_skill(tmp_path, [])
         assert not (tmp_path / ".context" / "config.json").exists()
 
     def test_custom_context_dir(self, tmp_path):
-        _dry_run_skill(tmp_path, ["s"], context_dir=".autofix-context")
+        _dry_run_skill(tmp_path, [{"name": "s"}], context_dir=".autofix-context")
         assert (tmp_path / ".autofix-context" / "config.json").exists()
         assert not (tmp_path / ".context" / "config.json").exists()
 
     def test_path_traversal_rejected(self, tmp_path):
         with pytest.raises(ValueError, match="escapes work_dir"):
-            _dry_run_skill(tmp_path, ["s"], context_dir="../escape")
+            _dry_run_skill(tmp_path, [{"name": "s"}], context_dir="../escape")
 
     def test_absolute_path_rejected(self, tmp_path):
         with pytest.raises(ValueError, match="escapes work_dir"):
-            _dry_run_skill(tmp_path, ["s"], context_dir="/tmp/evil")
+            _dry_run_skill(tmp_path, [{"name": "s"}], context_dir="/tmp/evil")
 
     def test_symlinked_context_dir_rejected(self, tmp_path):
         target = tmp_path / "real-dir"
@@ -72,7 +67,7 @@ class TestExtraSkillsConfigWriting:
         link = tmp_path / ".context"
         link.symlink_to(target)
         with pytest.raises(ValueError, match="symlink"):
-            _dry_run_skill(tmp_path, ["s"])
+            _dry_run_skill(tmp_path, [{"name": "s"}])
 
     def test_symlinked_config_json_rejected(self, tmp_path):
         ctx_dir = tmp_path / ".context"
@@ -81,4 +76,4 @@ class TestExtraSkillsConfigWriting:
         target.write_text("{}")
         (ctx_dir / "config.json").symlink_to(target)
         with pytest.raises(ValueError, match="symlink"):
-            _dry_run_skill(tmp_path, ["s"])
+            _dry_run_skill(tmp_path, [{"name": "s"}])


### PR DESCRIPTION
## Summary

- Changes `SkillConfig.extra_skills` from `list[str | dict]` to `list[dict[str, Any]]`
- Drops plain string support — all entries must be objects with at least a `name` key
- Updates tests and README examples to use object format

## Context

Companion to [autofix MR !757](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/757) which registers preflight for AI Core Dashboard using the object format. No existing consumers use the string format, so this is a clean cut.

## Test plan

- [x] 531 tests pass
- [x] ruff lint clean
- [x] ruff format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Changes**
  * `extra_skills` now expects an object-based format for each entry, with a required `name` field (e.g., `{"name": "skill-name"}`), replacing plain string entries.
  * Optional `args` and `hooks` are supported per entry.

* **Documentation**
  * Updated README examples and wording to reflect the object-based `extra_skills` structure.

* **Tests**
  * Adjusted and extended test coverage to validate writing `extra_skills` using the new structured format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->