### PR TITLE
fix: serialize OTLP traces to protobuf before pushing to MLflow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ authors = [
 keywords = ["ci", "cd", "ai", "agents", "claude", "llm", "telemetry"]
 dependencies = [
     "PyYAML>=6.0",
+    "opentelemetry-proto>=1.0.0",
     "requests>=2.28",
     "tenacity>=8.0",
 ]

--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -1,9 +1,46 @@
 """Push OTel trace payloads from a JSONL log to an MLflow OTLP endpoint."""
 
+import base64
+import copy
 import json
 import sys
 
 import requests
+from google.protobuf import json_format
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+
+_ID_KEYS = ("traceId", "spanId", "parentSpanId")
+
+
+def _hex_to_base64(value):
+    """Convert a hex string to base64 for protobuf bytes fields."""
+    if not isinstance(value, str) or len(value) not in (16, 32):
+        return value
+    try:
+        return base64.b64encode(bytes.fromhex(value)).decode()
+    except ValueError:
+        return value
+
+
+def _fixup_ids(payload):
+    """Convert hex-encoded traceId/spanId/parentSpanId to base64.
+
+    OTLP JSON spec uses lowercase hex for bytes fields, but protobuf's
+    ParseDict expects base64 encoding.
+    """
+    for rs in payload.get("resourceSpans", []):
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                for key in _ID_KEYS:
+                    if key in span:
+                        span[key] = _hex_to_base64(span[key])
+                for link in span.get("links", []):
+                    for key in _ID_KEYS:
+                        if key in link:
+                            link[key] = _hex_to_base64(link[key])
+    return payload
 
 
 def _resolve_experiment_id(endpoint, name, headers):
@@ -24,6 +61,14 @@ def _resolve_experiment_id(endpoint, name, headers):
     except requests.RequestException:
         pass
     return None
+
+
+def _serialize_traces(payload):
+    """Convert an OTLP JSON trace payload dict to protobuf bytes."""
+    payload = _fixup_ids(copy.deepcopy(payload))
+    request = ExportTraceServiceRequest()
+    json_format.ParseDict(payload, request)
+    return request.SerializeToString()
 
 
 def push_traces(log_file, endpoint, experiment, token=None):
@@ -71,11 +116,13 @@ def push_traces(log_file, endpoint, experiment, token=None):
         if not payload:
             continue
         try:
+            data = _serialize_traces(payload)
             resp = requests.post(
                 traces_url,
-                json=payload,
+                data=data,
                 headers={
                     **headers,
+                    "Content-Type": "application/x-protobuf",
                     "x-mlflow-experiment-id": experiment_id,
                 },
                 timeout=30,

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -1,0 +1,184 @@
+"""Tests for agentic_ci.mlflow — protobuf serialization and trace push."""
+
+import base64
+import copy
+import json
+import os
+import tempfile
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
+    ExportTraceServiceRequest,
+)
+
+from agentic_ci.mlflow import _fixup_ids, _hex_to_base64, _serialize_traces, push_traces
+
+# Hex-encoded IDs (what Claude Code / OTLP JSON exporters produce)
+HEX_TRACE_PAYLOAD = {
+    "resourceSpans": [
+        {
+            "resource": {
+                "attributes": [
+                    {"key": "service.name", "value": {"stringValue": "test-agent"}}
+                ]
+            },
+            "scopeSpans": [
+                {
+                    "scope": {"name": "test"},
+                    "spans": [
+                        {
+                            "traceId": "0af7651916cd43dd8448eb211c80319c",
+                            "spanId": "b7ad6b7169203331",
+                            "parentSpanId": "00f067aa0ba902b7",
+                            "name": "test-span",
+                            "kind": 1,
+                            "startTimeUnixNano": "1000000000",
+                            "endTimeUnixNano": "2000000000",
+                            "attributes": [
+                                {
+                                    "key": "test.key",
+                                    "value": {"stringValue": "test-value"},
+                                }
+                            ],
+                            "status": {},
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+}
+
+
+class TestHexToBase64:
+    def test_converts_32char_trace_id(self):
+        result = _hex_to_base64("0af7651916cd43dd8448eb211c80319c")
+        assert result != "0af7651916cd43dd8448eb211c80319c"
+        assert bytes.fromhex("0af7651916cd43dd8448eb211c80319c") == base64.b64decode(result)
+
+    def test_converts_16char_span_id(self):
+        result = _hex_to_base64("b7ad6b7169203331")
+        assert result != "b7ad6b7169203331"
+
+    def test_passes_through_base64(self):
+        b64 = "CvdlGRbNQ92ESOshHIAxnA=="
+        assert _hex_to_base64(b64) == b64
+
+    def test_passes_through_non_hex(self):
+        assert _hex_to_base64("not-hex-string") == "not-hex-string"
+        assert _hex_to_base64("") == ""
+        assert _hex_to_base64(123) == 123
+
+
+class TestFixupIds:
+    def test_converts_all_id_fields(self):
+        payload = copy.deepcopy(HEX_TRACE_PAYLOAD)
+        fixed = _fixup_ids(payload)
+        span = fixed["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+        assert span["traceId"] != "0af7651916cd43dd8448eb211c80319c"
+        assert span["spanId"] != "b7ad6b7169203331"
+        assert span["parentSpanId"] != "00f067aa0ba902b7"
+
+
+class TestSerializeTraces:
+    def test_round_trip_with_hex_ids(self):
+        serialized = _serialize_traces(copy.deepcopy(HEX_TRACE_PAYLOAD))
+        assert isinstance(serialized, bytes)
+        assert len(serialized) > 0
+
+        deserialized = ExportTraceServiceRequest()
+        deserialized.ParseFromString(serialized)
+        assert len(deserialized.resource_spans) == 1
+        span = deserialized.resource_spans[0].scope_spans[0].spans[0]
+        assert span.name == "test-span"
+        assert span.trace_id == bytes.fromhex("0af7651916cd43dd8448eb211c80319c")
+        assert span.span_id == bytes.fromhex("b7ad6b7169203331")
+
+    def test_does_not_mutate_input(self):
+        payload = copy.deepcopy(HEX_TRACE_PAYLOAD)
+        original_id = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["traceId"]
+        _serialize_traces(payload)
+        assert payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["traceId"] == original_id
+
+    def test_empty_payload(self):
+        serialized = _serialize_traces({})
+        assert isinstance(serialized, bytes)
+        deserialized = ExportTraceServiceRequest()
+        deserialized.ParseFromString(serialized)
+        assert len(deserialized.resource_spans) == 0
+
+    def test_preserves_attributes(self):
+        serialized = _serialize_traces(copy.deepcopy(HEX_TRACE_PAYLOAD))
+        deserialized = ExportTraceServiceRequest()
+        deserialized.ParseFromString(serialized)
+        resource_attrs = deserialized.resource_spans[0].resource.attributes
+        assert any(a.key == "service.name" for a in resource_attrs)
+
+
+class TestPushTraces:
+    def _write_jsonl(self, records):
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False)
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+        f.close()
+        return f.name
+
+    def test_missing_file_returns_zero(self):
+        ok, err = push_traces("/nonexistent.jsonl", "http://mlflow:5000", "exp")
+        assert (ok, err) == (0, 0)
+
+    def test_no_trace_records_returns_zero(self):
+        path = self._write_jsonl([{"path": "/v1/metrics", "payload": {}}])
+        try:
+            ok, err = push_traces(path, "http://mlflow:5000", "exp")
+            assert (ok, err) == (0, 0)
+        finally:
+            os.unlink(path)
+
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_sends_protobuf_content_type(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"experiments": [{"experiment_id": "123"}]}
+        mock_post.return_value = mock_resp
+
+        path = self._write_jsonl(
+            [{"path": "/v1/traces", "payload": copy.deepcopy(HEX_TRACE_PAYLOAD)}]
+        )
+        try:
+            ok, err = push_traces(path, "http://mlflow:5000", "exp")
+        finally:
+            os.unlink(path)
+
+        assert ok == 1
+        assert err == 0
+
+        trace_call = mock_post.call_args_list[1]
+        assert trace_call.kwargs["headers"]["Content-Type"] == "application/x-protobuf"
+        assert trace_call.kwargs["headers"]["x-mlflow-experiment-id"] == "123"
+        assert isinstance(trace_call.kwargs["data"], bytes)
+        assert "json" not in trace_call.kwargs
+
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_sends_valid_protobuf_body(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"experiments": [{"experiment_id": "42"}]}
+        mock_post.return_value = mock_resp
+
+        path = self._write_jsonl(
+            [{"path": "/v1/traces", "payload": copy.deepcopy(HEX_TRACE_PAYLOAD)}]
+        )
+        try:
+            push_traces(path, "http://mlflow:5000", "exp")
+        finally:
+            os.unlink(path)
+
+        trace_call = mock_post.call_args_list[1]
+        body = trace_call.kwargs["data"]
+        parsed = ExportTraceServiceRequest()
+        parsed.ParseFromString(body)
+        assert parsed.resource_spans[0].scope_spans[0].spans[0].name == "test-span"
+        assert parsed.resource_spans[0].scope_spans[0].spans[0].trace_id == bytes.fromhex(
+            "0af7651916cd43dd8448eb211c80319c"
+        )

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -18,9 +18,7 @@ HEX_TRACE_PAYLOAD = {
     "resourceSpans": [
         {
             "resource": {
-                "attributes": [
-                    {"key": "service.name", "value": {"stringValue": "test-agent"}}
-                ]
+                "attributes": [{"key": "service.name", "value": {"stringValue": "test-agent"}}]
             },
             "scopeSpans": [
                 {

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ commands = ruff format --check --diff .
 description = Run type checker
 deps =
     mypy
+    types-protobuf
     types-PyYAML
 commands = mypy src/
 


### PR DESCRIPTION
`push_traces()` sends trace payloads as JSON, but MLflow's `/v1/traces` endpoint uses the [`http/protobuf` protocol](https://mlflow.org/docs/latest/genai/tracing/opentelemetry/export/#opentelemetry-configuration) (see also [mlflow/mlflow#18929](https://github.com/mlflow/mlflow/pull/18929)). Traces are now serialized to protobuf via `opentelemetry-proto` before posting.

Also handles the OTLP JSON-to-protobuf encoding mismatch: the [OTLP spec](https://opentelemetry.io/docs/specs/otlp/#json-protobuf-encoding) uses hex for `traceId`/`spanId`, but protobuf's `ParseDict` expects base64 for `bytes` fields.

Validated against a live MLflow 3.10.1 instance (RHOAI 3.4 GA).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated MLflow trace integration to submit OTLP traces using protobuf-serialized payloads (instead of JSON) to better match OTLP/protobuf expectations.

* **Chores**
  * Added `opentelemetry-proto` as a runtime dependency to enable protobuf trace handling.

* **Tests**
  * Added unit tests covering protobuf trace serialization, trace ID transformations, and verifying MLflow OTLP requests (content type, headers, and payload validation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->