### PR TITLE
fix: pass max_results in MLflow experiment search

### DIFF
--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -13,7 +13,7 @@ def _resolve_experiment_id(endpoint, name, headers):
     try:
         resp = requests.post(
             url,
-            json={"filter": f"name = '{escaped_name}'"},
+            json={"filter": f"name = '{escaped_name}'", "max_results": 1},
             headers=headers,
             timeout=30,
         )


### PR DESCRIPTION
## Summary
- MLflow 3.x defaults `max_results` to 0 in the experiments search API, which the server rejects with `INVALID_PARAMETER_VALUE`
- The `_resolve_experiment_id` function catches the `RequestException` silently and returns `None`, causing `mlflow-push` to print "experiment not found — skipping trace push" even when the experiment exists
- Fix: pass `"max_results": 1` in the search request

## Test plan
- [x] Reproduced locally with MLflow 3.13.0 — experiment lookup returned `None` without the fix
- [x] Verified `agentic-ci mlflow-push` successfully pushes traces after the fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MLflow experiment search to return only the most relevant result when querying by name, improving search efficiency and preventing unnecessary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->