### PR TITLE
Add local backend for direct agent execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 agentic-ci runs AI coding agents in sandboxed CI environments with pluggable backends and harnesses. Users run `agentic-ci run "prompt"` to execute an agent in an isolated environment with streaming output and OTEL telemetry.
 
-Two **backends** provide execution environments:
+Three **backends** provide execution environments:
+- **Local**: Runs the agent directly in the current environment. No container or sandbox — the agent binary must be on PATH. Useful inside existing CI containers (e.g. Prow step images).
 - **Podman** (default): Runs the agent in a Podman container. Simple, widely available.
 - **OpenShell**: Runs the agent in an [OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with network policy enforcement and filesystem isolation.
 
@@ -19,6 +20,7 @@ src/agentic_ci/
     harness.py          # Harness ABC + ClaudeCode/OpenCode implementations
     backends/
         __init__.py     # Backend factory (create_backend)
+        local.py        # LocalBackend — direct execution (no container)
         podman.py       # PodmanBackend — container execution
         openshell/
             __init__.py # OpenShellBackend — sandbox execution

--- a/README.md
+++ b/README.md
@@ -130,9 +130,11 @@ Extra arguments after the prompt are passed through to the Claude CLI.
 
 ```bash
 # Local backend with extra Claude args (everything after -- is passed through)
+# Note: build_args() sets --permission-mode bypassPermissions by default;
+# pass --permission-mode default to restrict tools via --allowedTools
 agentic-ci run --backend local \
     "Fix the flaky test" \
-    -- --allowedTools "Bash Read Edit" --max-turns 10 --verbose
+    -- --permission-mode default --allowedTools "Bash Read Edit" --max-turns 10 --verbose
 
 # Local backend with --continue for multi-stage flows
 agentic-ci run --backend local "Summarize your findings" \

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ simplicity and security.
 
 ## Backends
 
+### Local
+
+Runs the agent directly in the current environment with no container
+or sandbox layer. The agent binary must already be installed and on
+PATH. Environment variables (auth, OTEL, model) are set automatically
+by the harness.
+
+Good for: running inside an existing CI container (e.g. a Prow step
+image) where the agent CLI is pre-installed and an extra isolation
+layer is unnecessary.
+
+Requires: the agent CLI on PATH (e.g. `claude`).
+
 ### Podman (default)
 
 Runs the agent inside a Podman container. Each `run` creates a fresh
@@ -60,6 +73,9 @@ pip install agentic-ci
 ### Run a prompt
 
 ```bash
+# Local (direct execution, no container)
+agentic-ci run --backend local "Fix the flaky test in test_auth.py"
+
 # Podman (default backend)
 agentic-ci run "Fix the flaky test in test_auth.py" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest
@@ -113,6 +129,15 @@ Extra arguments after the prompt are passed through to the Claude CLI.
 ### Examples
 
 ```bash
+# Local backend with extra Claude args (everything after -- is passed through)
+agentic-ci run --backend local \
+    "Fix the flaky test" \
+    -- --allowedTools "Bash Read Edit" --max-turns 10 --verbose
+
+# Local backend with --continue for multi-stage flows
+agentic-ci run --backend local "Summarize your findings" \
+    -- --continue --max-turns 5
+
 # Use a specific model
 agentic-ci run "Update the changelog" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest \
@@ -237,9 +262,17 @@ from agentic_ci.backends import create_backend
 from agentic_ci.harness import create_harness
 
 harness = create_harness("claude-code")
+
+# Podman backend
 backend = create_backend("podman", harness=harness, workdir="/path/to/repo", image="my-image:latest")
 backend.setup()
 rc = backend.run(prompt="Fix the bug", model="claude-sonnet-4-6")
+backend.stop()
+
+# Local backend (no container)
+backend = create_backend("local", harness=harness, workdir="/path/to/repo")
+backend.setup()
+rc = backend.run(prompt="Fix the bug", model="claude-sonnet-4-6", extra_args=["--max-turns", "10"])
 backend.stop()
 ```
 

--- a/docs/api/backends.md
+++ b/docs/api/backends.md
@@ -1,8 +1,12 @@
-# Factory & Podman
+# Factory & Backends
 
 ## Backend Factory
 
 ::: agentic_ci.backends
+
+## Local Backend
+
+::: agentic_ci.backends.local
 
 ## Podman Backend
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ simplicity and security.
 
 ## Features
 
-- **Multiple backends**: Podman containers or OpenShell sandboxes with network policy enforcement
+- **Multiple backends**: Local (direct execution), Podman containers, or OpenShell sandboxes with network policy enforcement
 - **Multiple harnesses**: Claude Code and OpenCode agent CLIs
 - **Streaming output**: Colored, parsed CI logs with tool call summaries and token tracking
 - **OTEL telemetry**: Token usage, cost tracking, and metrics collection
@@ -25,6 +25,9 @@ pip install agentic-ci
 ## Quick start
 
 ```bash
+# Run locally (no container needed)
+agentic-ci run --backend local "Fix the flaky test in test_auth.py"
+
 # Run with Podman (default)
 agentic-ci run "Fix the flaky test in test_auth.py" \
     --image ghcr.io/opendatahub-io/ai-helpers:latest

--- a/src/agentic_ci/backends/__init__.py
+++ b/src/agentic_ci/backends/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from agentic_ci.backends.local import LocalBackend
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
 
@@ -23,7 +24,13 @@ def create_backend(name: str, *, harness: Harness, **kwargs: Any) -> Backend:
     Returns:
         A Backend instance.
     """
-    if name == "podman":
+    if name == "local":
+        return LocalBackend(
+            workdir=kwargs.get("workdir", "."),
+            extra_env=kwargs.get("extra_env"),
+            harness=harness,
+        )
+    elif name == "podman":
         return PodmanBackend(
             workdir=kwargs.get("workdir", "."),
             image=kwargs.get("image"),
@@ -41,4 +48,4 @@ def create_backend(name: str, *, harness: Harness, **kwargs: Any) -> Backend:
             harness=harness,
         )
     else:
-        raise ValueError(f"Unknown backend: {name!r}. Choose 'podman' or 'openshell'.")
+        raise ValueError(f"Unknown backend: {name!r}. Choose 'local', 'podman', or 'openshell'.")

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -1,0 +1,65 @@
+"""Local (direct execution) backend for agentic-ci."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+from agentic_ci import log
+from agentic_ci.backend import Backend
+
+if TYPE_CHECKING:
+    from agentic_ci.harness import Harness
+
+
+class LocalBackend(Backend):
+    """Runs an AI agent directly in the local environment.
+
+    No container or sandbox — the agent binary must already be installed
+    and accessible on PATH. Useful when agentic-ci is running inside an
+    existing CI container (e.g. Prow) where an extra isolation layer is
+    unnecessary.
+    """
+
+    def __init__(self, workdir=".", extra_env=None, *, harness: Harness):
+        super().__init__(workdir=workdir, image=None, harness=harness)
+        self._extra_env = extra_env or {}
+
+    def setup(self, otel_port=None):
+        log.section("Local backend (direct execution)")
+
+    def stop(self):
+        pass
+
+    def run(
+        self,
+        prompt,
+        model,
+        streaming=True,
+        otel_port=None,
+        otel_rate_file=None,
+        extra_args=None,
+    ):
+        log.section(f"Executing {self.harness.name} locally")
+
+        env = {
+            **os.environ,
+            **self.harness.build_local_env(otel_port, otel_rate_file),
+            "AGENT_MODEL": model,
+            **self._extra_env,
+        }
+
+        agent_args = self.harness.build_args(prompt, model, extra_args)
+
+        proc = subprocess.Popen(
+            agent_args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            cwd=self.workdir,
+            env=env,
+        )
+
+        rc = self._process_stream(proc, streaming)
+        self._wait_for_otel_flush(otel_port)
+        return rc

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -194,9 +194,9 @@ def main():
     common = argparse.ArgumentParser(add_help=False)
     common.add_argument(
         "--backend",
-        choices=["podman", "openshell"],
+        choices=["local", "podman", "openshell"],
         default="podman",
-        help="Sandbox backend (default: podman)",
+        help="Execution backend (default: podman)",
     )
     common.add_argument("--workdir", default=".", metavar="PATH", help="Working directory")
     common.add_argument("--image", default=None, metavar="IMAGE", help="Container/sandbox image")

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -233,7 +233,7 @@ class ClaudeCodeHarness(Harness):
         env = {
             "AGENT_TOOL": "claude",
             "DISABLE_AUTOUPDATER": "1",
-            # Workaround: -p sets sessionKind which breaks --continue lookup (anthropics/claude-code#43013)
+            # -p sets sessionKind, breaking --continue lookup (claude-code#43013)
             "CLAUDE_CODE_ENTRYPOINT": "sdk-cli",
         }
         if self.auth_mode == "api-key":

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -233,6 +233,8 @@ class ClaudeCodeHarness(Harness):
         env = {
             "AGENT_TOOL": "claude",
             "DISABLE_AUTOUPDATER": "1",
+            # Workaround: -p sets sessionKind which breaks --continue lookup (anthropics/claude-code#43013)
+            "CLAUDE_CODE_ENTRYPOINT": "sdk-cli",
         }
         if self.auth_mode == "api-key":
             env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -79,6 +79,19 @@ class Harness(ABC):
     def default_model(self) -> str:
         """Default model when no --model flag or env var is set."""
 
+    @abstractmethod
+    def build_local_env(
+        self,
+        otel_port: int | None = None,
+        otel_rate_file: str | None = None,
+    ) -> dict[str, str]:
+        """Return env vars as a plain dict for direct (local) execution.
+
+        Unlike build_env_args (podman --env format) or build_env_script_lines
+        (OpenShell export format), this returns a dict suitable for merging
+        into os.environ and passing to subprocess.Popen(env=...).
+        """
+
     @property
     def supports_otel(self) -> bool:
         """Whether the agent CLI supports OTEL telemetry export."""
@@ -216,6 +229,37 @@ class ClaudeCodeHarness(Harness):
             "OTEL_LOG_TOOL_CONTENT=1",
         ]
 
+    def build_local_env(self, otel_port=None, otel_rate_file=None):
+        env = {
+            "AGENT_TOOL": "claude",
+            "DISABLE_AUTOUPDATER": "1",
+        }
+        if self.auth_mode == "api-key":
+            env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]
+        else:
+            env["CLAUDE_CODE_USE_VERTEX"] = "1"
+            env["CLOUD_ML_REGION"] = os.environ.get("CLOUD_ML_REGION", "global")
+            env["ANTHROPIC_VERTEX_PROJECT_ID"] = os.environ.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+            )
+        if otel_port:
+            env.update(
+                {
+                    "CLAUDE_CODE_ENABLE_TELEMETRY": "1",
+                    "CLAUDE_CODE_ENHANCED_TELEMETRY_BETA": "1",
+                    "OTEL_METRICS_EXPORTER": "otlp",
+                    "OTEL_LOGS_EXPORTER": "otlp",
+                    "OTEL_TRACES_EXPORTER": "otlp",
+                    "OTEL_EXPORTER_OTLP_PROTOCOL": "http/json",
+                    "OTEL_EXPORTER_OTLP_ENDPOINT": f"http://127.0.0.1:{otel_port}",
+                    "OTEL_METRIC_EXPORT_INTERVAL": "10000",
+                    "OTEL_LOG_USER_PROMPTS": "1",
+                    "OTEL_LOG_TOOL_DETAILS": "1",
+                    "OTEL_LOG_TOOL_CONTENT": "1",
+                }
+            )
+        return env
+
     def credential_mount_target(self):
         return os.environ.get("CLAUDE_CONTAINER_HOME", "/home/agent-ci")
 
@@ -320,6 +364,23 @@ class OpenCodeHarness(Harness):
 
     def build_otel_exec_env(self, otel_port=None):
         return []
+
+    def build_local_env(self, otel_port=None, otel_rate_file=None):
+        env = {
+            "AGENT_TOOL": "opencode",
+            "OPENCODE_DISABLE_AUTOUPDATE": "1",
+        }
+        if self.auth_mode == "api-key":
+            env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]
+        else:
+            env["GOOGLE_CLOUD_PROJECT"] = os.environ.get(
+                "GOOGLE_CLOUD_PROJECT",
+                os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+            )
+            env["VERTEX_LOCATION"] = os.environ.get(
+                "VERTEX_LOCATION", os.environ.get("CLOUD_ML_REGION", "global")
+            )
+        return env
 
     def credential_mount_target(self):
         return os.environ.get("OPENCODE_CONTAINER_HOME", "/home/agent-ci")

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+# shellcheck source=tests/images/shell-utils.sh
+# e2e-local-runner.sh -- End-to-end tests for the local backend
+# using agentic-ci.
+#
+# The local backend runs the agent binary directly without a container.
+# This test verifies streaming, non-streaming, and extra args passthrough.
+#
+# Requires: python3, claude, agentic-ci
+# Credentials: ANTHROPIC_API_KEY or Vertex AI (GCP_SERVICE_ACCOUNT_KEY, etc.)
+#
+# Usage:
+#   ./tests/e2e/e2e-local-runner.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/../images/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_E2E="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMPDIR_E2E"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc -- expected '$pattern' in output"
+        echo "  Got: ${output:0:200}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+print_header "=== Preflight checks ==="
+check_dependencies python3 claude agentic-ci
+
+print_header "=== Component versions ==="
+echo "  agentic-ci: $(agentic-ci --version 2>&1 || echo unknown)"
+echo "  claude:     $(claude --version 2>&1 || echo unknown)"
+
+_has_creds() {
+    [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
+    [[ -n "${GCLOUD_CREDENTIALS:-}" ]] || \
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]]
+}
+
+if ! _has_creds; then
+    echo ""
+    print_warning "Skipping e2e tests (no credentials set)"
+    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, or ANTHROPIC_API_KEY"
+    exit 0
+fi
+
+# -- Streaming test -----------------------------------------------------------
+print_header "=== agentic-ci run --backend local: streaming ==="
+
+WORKDIR="$TMPDIR_E2E/streaming"
+mkdir -p "$WORKDIR"
+
+print_step "Running Claude Code via local backend (streaming)..."
+RC=0
+agentic-ci run --backend local \
+    "Reply with only the word pong" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    > "$TMPDIR_E2E/stream-out.txt" 2>"$TMPDIR_E2E/stream-err.txt" || RC=$?
+
+assert_ok "streaming local run exited successfully" test "$RC" -eq 0
+assert_ok "streaming output file is non-empty" test -s "$TMPDIR_E2E/stream-out.txt"
+assert_contains "streaming output contains response" \
+    "$(cat "$TMPDIR_E2E/stream-out.txt")" "pong"
+
+if [[ -s "$TMPDIR_E2E/stream-out.txt" ]]; then
+    echo "--- streaming output ---"
+    head -20 "$TMPDIR_E2E/stream-out.txt"
+    echo "--- end streaming output ---"
+fi
+
+# -- Non-streaming test -------------------------------------------------------
+print_header "=== agentic-ci run --backend local: non-streaming ==="
+
+WORKDIR="$TMPDIR_E2E/nostream"
+mkdir -p "$WORKDIR"
+
+print_step "Running Claude Code via local backend (non-streaming)..."
+RC=0
+agentic-ci run --backend local \
+    "Reply with only the word pong" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$TMPDIR_E2E/nostream-out.txt" 2>"$TMPDIR_E2E/nostream-err.txt" || RC=$?
+
+assert_ok "non-streaming local run exited successfully" test "$RC" -eq 0
+assert_ok "non-streaming output file is non-empty" test -s "$TMPDIR_E2E/nostream-out.txt"
+assert_contains "non-streaming output contains response" \
+    "$(cat "$TMPDIR_E2E/nostream-out.txt")" "pong"
+
+if [[ -s "$TMPDIR_E2E/nostream-out.txt" ]]; then
+    echo "--- non-streaming output ---"
+    head -20 "$TMPDIR_E2E/nostream-out.txt"
+    echo "--- end non-streaming output ---"
+fi
+
+# -- Extra args passthrough test ----------------------------------------------
+print_header "=== agentic-ci run --backend local: extra args ==="
+
+WORKDIR="$TMPDIR_E2E/extra-args"
+mkdir -p "$WORKDIR"
+
+print_step "Running Claude Code via local backend (extra args: --max-turns 5)..."
+RC=0
+agentic-ci run --backend local \
+    "Reply with only the word pong" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    -- --max-turns 5 --verbose \
+    > "$TMPDIR_E2E/extra-args-out.txt" 2>"$TMPDIR_E2E/extra-args-err.txt" || RC=$?
+
+assert_ok "extra args local run exited successfully" test "$RC" -eq 0
+assert_ok "extra args output file is non-empty" test -s "$TMPDIR_E2E/extra-args-out.txt"
+assert_contains "extra args output contains response" \
+    "$(cat "$TMPDIR_E2E/extra-args-out.txt")" "pong"
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -70,13 +70,15 @@ echo "  claude:     $(claude --version 2>&1 || echo unknown)"
 _has_creds() {
     [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
     [[ -n "${GCLOUD_CREDENTIALS:-}" ]] || \
-    [[ -n "${ANTHROPIC_API_KEY:-}" ]]
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]] || \
+    [[ -f "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]] || \
+    [[ -f "${HOME}/.config/gcloud/application_default_credentials.json" ]]
 }
 
 if ! _has_creds; then
     echo ""
     print_warning "Skipping e2e tests (no credentials set)"
-    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, or ANTHROPIC_API_KEY"
+    print_warning "Set GCP_SERVICE_ACCOUNT_KEY, GCLOUD_CREDENTIALS, ANTHROPIC_API_KEY, or configure gcloud ADC"
     exit 0
 fi
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from agentic_ci.backends import create_backend
+from agentic_ci.backends.local import LocalBackend
 from agentic_ci.backends.openshell import OpenShellBackend
 from agentic_ci.backends.podman import PodmanBackend
 from agentic_ci.harness import ClaudeCodeHarness, create_harness
@@ -27,6 +28,19 @@ def test_create_openshell_backend(harness):
     assert isinstance(backend, OpenShellBackend)
     assert backend.workdir == "/tmp"
     assert backend.harness is harness
+
+
+def test_create_local_backend(harness):
+    backend = create_backend("local", harness=harness, workdir="/tmp")
+    assert isinstance(backend, LocalBackend)
+    assert backend.workdir == "/tmp"
+    assert backend.harness is harness
+    assert backend.image is None
+
+
+def test_create_local_with_extra_env(harness):
+    backend = create_backend("local", harness=harness, extra_env={"FOO": "bar"})
+    assert backend._extra_env == {"FOO": "bar"}
 
 
 def test_create_podman_with_image(harness):
@@ -67,8 +81,10 @@ def test_unknown_backend_raises(harness):
 def test_backends_have_stop_method(harness):
     podman = create_backend("podman", harness=harness, workdir="/tmp")
     openshell = create_backend("openshell", harness=harness, workdir="/tmp")
+    local = create_backend("local", harness=harness, workdir="/tmp")
     assert callable(getattr(podman, "stop", None))
     assert callable(getattr(openshell, "stop", None))
+    assert callable(getattr(local, "stop", None))
 
 
 class TestOpenShellEnvScript:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -116,6 +116,7 @@ class TestClaudeCodeHarness:
         env = ClaudeCodeHarness().build_local_env()
         assert env["AGENT_TOOL"] == "claude"
         assert env["DISABLE_AUTOUPDATER"] == "1"
+        assert env["CLAUDE_CODE_ENTRYPOINT"] == "sdk-cli"
         assert env["CLAUDE_CODE_USE_VERTEX"] == "1"
         assert env["CLOUD_ML_REGION"] == "us-east1"
         assert env["ANTHROPIC_VERTEX_PROJECT_ID"] == "my-proj"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -109,6 +109,45 @@ class TestClaudeCodeHarness:
     def test_build_otel_exec_env_empty_without_port(self):
         assert ClaudeCodeHarness().build_otel_exec_env(otel_port=None) == []
 
+    def test_build_local_env_vertex(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("CLOUD_ML_REGION", "us-east1")
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj")
+        env = ClaudeCodeHarness().build_local_env()
+        assert env["AGENT_TOOL"] == "claude"
+        assert env["DISABLE_AUTOUPDATER"] == "1"
+        assert env["CLAUDE_CODE_USE_VERTEX"] == "1"
+        assert env["CLOUD_ML_REGION"] == "us-east1"
+        assert env["ANTHROPIC_VERTEX_PROJECT_ID"] == "my-proj"
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_build_local_env_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        env = ClaudeCodeHarness().build_local_env()
+        assert env["ANTHROPIC_API_KEY"] == "sk-test-key"
+        assert "CLAUDE_CODE_USE_VERTEX" not in env
+
+    def test_build_local_env_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        env = ClaudeCodeHarness().build_local_env()
+        assert env["ANTHROPIC_VERTEX_PROJECT_ID"] == "gcp-proj"
+
+    def test_build_local_env_with_otel(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        env = ClaudeCodeHarness().build_local_env(otel_port=4318)
+        assert env["CLAUDE_CODE_ENABLE_TELEMETRY"] == "1"
+        assert env["CLAUDE_CODE_ENHANCED_TELEMETRY_BETA"] == "1"
+        assert env["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://127.0.0.1:4318"
+        assert env["OTEL_TRACES_EXPORTER"] == "otlp"
+
+    def test_build_local_env_no_otel_without_port(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        env = ClaudeCodeHarness().build_local_env()
+        assert "CLAUDE_CODE_ENABLE_TELEMETRY" not in env
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in env
+
     def test_build_env_script_lines(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "proj")
@@ -248,6 +287,48 @@ class TestOpenCodeHarness:
 
     def test_build_otel_exec_env_always_empty(self):
         assert OpenCodeHarness().build_otel_exec_env(otel_port=4318) == []
+
+    def test_build_local_env_vertex(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "my-proj")
+        monkeypatch.setenv("VERTEX_LOCATION", "us-central1")
+        env = OpenCodeHarness().build_local_env()
+        assert env["AGENT_TOOL"] == "opencode"
+        assert env["OPENCODE_DISABLE_AUTOUPDATE"] == "1"
+        assert env["GOOGLE_CLOUD_PROJECT"] == "my-proj"
+        assert env["VERTEX_LOCATION"] == "us-central1"
+        assert "ANTHROPIC_API_KEY" not in env
+
+    def test_build_local_env_api_key(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+        env = OpenCodeHarness().build_local_env()
+        assert env["ANTHROPIC_API_KEY"] == "sk-test-key"
+        assert "GOOGLE_CLOUD_PROJECT" not in env
+
+    def test_build_local_env_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+        monkeypatch.setenv("ANTHROPIC_VERTEX_PROJECT_ID", "fallback-proj")
+        monkeypatch.setenv("CLOUD_ML_REGION", "eu-west1")
+        env = OpenCodeHarness().build_local_env()
+        assert env["GOOGLE_CLOUD_PROJECT"] == "fallback-proj"
+        assert env["VERTEX_LOCATION"] == "eu-west1"
+
+    def test_build_local_env_gcp_project_id_fallback(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+        monkeypatch.delenv("ANTHROPIC_VERTEX_PROJECT_ID", raising=False)
+        monkeypatch.delenv("VERTEX_LOCATION", raising=False)
+        monkeypatch.delenv("CLOUD_ML_REGION", raising=False)
+        monkeypatch.setenv("GCP_PROJECT_ID", "gcp-proj")
+        env = OpenCodeHarness().build_local_env()
+        assert env["GOOGLE_CLOUD_PROJECT"] == "gcp-proj"
+
+    def test_build_local_env_no_otel(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        env = OpenCodeHarness().build_local_env(otel_port=4318)
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in env
 
     def test_build_env_script_lines(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- Adds a `LocalBackend` that runs the agent binary directly in the current environment without container or sandbox wrapping
- Adds `build_local_env()` to the `Harness` ABC with implementations for both ClaudeCode and OpenCode harnesses
- Registers `--backend local` as a CLI option alongside `podman` and `openshell`

This is useful when agentic-ci runs inside an existing CI container (e.g. Prow) where an extra isolation layer is unnecessary. The local backend gets OTEL collection, stream parsing, and token/cost summaries for free.

## Test plan
- [x] Unit tests for `LocalBackend` factory creation (`tests/test_backend.py`)
- [x] Unit tests for `build_local_env()` on both harnesses (`tests/test_harness.py`)
- [x] Lint and format checks pass
- [x] Smoke tested with `agentic-ci run --backend local --harness claude-code`