### PR TITLE
Bump UBI base images to 10.2 and add Renovate tracking

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -11,7 +11,7 @@
 #
 # x86_64 only.
 
-FROM registry.access.redhat.com/ubi10/ubi:10.1
+FROM registry.access.redhat.com/ubi10/ubi:10.2
 
 ARG GH_VERSION=2.94.0
 ARG GH_SHA256=a757f1ba6db18f4de8cbadb244843a5f89bc75b5e7c6fc127d2bd77fbd12ed62

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -7,7 +7,7 @@
 #
 # x86_64 only.
 
-FROM registry.access.redhat.com/ubi10/ubi:10.1
+FROM registry.access.redhat.com/ubi10/ubi:10.2
 
 ARG GH_VERSION=2.94.0
 ARG GH_SHA256=a757f1ba6db18f4de8cbadb244843a5f89bc75b5e7c6fc127d2bd77fbd12ed62

--- a/images/openshell-supervisor/Containerfile
+++ b/images/openshell-supervisor/Containerfile
@@ -15,7 +15,7 @@
 #   podman build -t openshell-supervisor:pr1763 \
 #     -f images/openshell-supervisor/Containerfile .
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1 AS builder
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2 AS builder
 
 RUN microdnf install -y gcc gcc-c++ make openssl-devel unzip && microdnf clean all
 
@@ -33,6 +33,6 @@ COPY openshell-src/ .
 
 RUN cargo build --release --package openshell-sandbox
 
-FROM registry.access.redhat.com/ubi10/ubi-micro:10.1
+FROM registry.access.redhat.com/ubi10/ubi-micro:10.2
 COPY --from=builder --chmod=0550 /src/target/release/openshell-sandbox /openshell-sandbox
 ENTRYPOINT ["/openshell-sandbox"]

--- a/images/runner/shared/Containerfile.base
+++ b/images/runner/shared/Containerfile.base
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 
 ARG UV_VERSION=0.11.20
 ARG UV_SHA256=a7545a1360d29baa696753af2f41849047b332bcb90e8ea75ad0568e7f865e35

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -11,7 +11,7 @@
 #
 # x86_64 only.
 
-FROM registry.access.redhat.com/ubi10/ubi-minimal:10.1
+FROM registry.access.redhat.com/ubi10/ubi-minimal:10.2
 
 ARG UV_VERSION=0.11.20
 ARG UV_SHA256=a7545a1360d29baa696753af2f41849047b332bcb90e8ea75ad0568e7f865e35

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
         "claude-code"
       ],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackagePrefixes": ["ubi10/"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customDatasources": {
@@ -155,6 +160,16 @@
       "matchStrings": ["agentic-ci==(?<currentValue>[^\\s]+)"],
       "depNameTemplate": "agentic-ci",
       "datasourceTemplate": "pypi"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/.*Containerfile[^/]*$"
+      ],
+      "matchStrings": ["FROM registry\\.access\\.redhat\\.com/(?<depName>ubi10/ubi[^:]*):(?<currentValue>[0-9]+\\.[0-9]+)"],
+      "datasourceTemplate": "docker",
+      "registryUrlTemplate": "https://registry.access.redhat.com",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)$"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add a Renovate custom regex manager to track UBI 10 base image tags via the Docker datasource against `registry.access.redhat.com`, with `minimumReleaseAge: 0` so UBI updates are picked up immediately.
- Bump all Containerfiles from UBI 10.1 to 10.2 (the latest available release).

## Test plan

- [ ] Verify Renovate picks up the new custom manager (check Renovate dashboard after merge)
- [ ] Build images locally with `make base-build` and `make ci-build` to confirm UBI 10.2 pulls correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)