### PR TITLE
RHAIFIRST-77: Make skill runner backend-agnostic

### DIFF
--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -23,6 +23,8 @@ class Backend(ABC):
     execution environments (OpenShell sandbox, Podman container, etc.).
     """
 
+    collector_bind_address: str = "127.0.0.1"
+
     def __init__(self, workdir=".", image=None, *, harness: Harness):
         self.workdir = os.path.abspath(workdir)
         self.image = image

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -33,6 +33,7 @@ class OpenShellBackend(Backend):
     written elsewhere in the sandbox (e.g. /tmp) are not retrieved.
     """
 
+    collector_bind_address = "0.0.0.0"
     _ENV_SCRIPT = "/tmp/.agentic-ci-env.sh"
 
     def __init__(

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -109,9 +109,8 @@ def cmd_run(args, backend, harness):
     try:
         if not args.no_otel and harness.supports_otel:
             log.section("Starting OTEL collector")
-            bind_addr = "0.0.0.0" if args.backend == "openshell" else "127.0.0.1"
             otel_proc, otel_port, otel_log, otel_rate = otel.start_collector(
-                run_dir, bind_addr=bind_addr
+                run_dir, bind_addr=backend.collector_bind_address
             )
             os.environ["OTEL_RATE_FILE"] = otel_rate
             log.detail("pid", str(otel_proc.pid))

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -28,8 +28,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, TypedDict
 
-from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import ClaudeCodeHarness
+from agentic_ci.backends import create_backend
+from agentic_ci.harness import create_harness
 from agentic_ci.otel import parse_metrics, start_collector, stop_collector
 
 log = logging.getLogger(__name__)
@@ -82,6 +82,8 @@ class SkillConfig:
     max_retries: int = 1
     retryable_modes: frozenset[str] = frozenset({"resolve"})
 
+    backend_name: str = "podman"
+    harness_name: str = "claude-code"
     container_image: str | None = None
     container_env: dict[str, str] = field(default_factory=dict)
     container_runner: Callable[..., int] | None = None
@@ -119,15 +121,24 @@ def _load_otel_cost(work_dir: Path) -> dict | None:
 
 
 def _default_run_container(
-    work_dir, prompt, output_file, *, image=None, verdict_path=None, container_env=None
+    work_dir,
+    prompt,
+    output_file,
+    *,
+    image=None,
+    verdict_path=None,
+    container_env=None,
+    backend_name="podman",
+    harness_name="claude-code",
 ):
-    """Default container runner using PodmanBackend."""
-    harness = ClaudeCodeHarness()
+    """Default container runner using the configured backend."""
+    harness = create_harness(harness_name)
     model = os.environ.get(harness.model_env_var()) or harness.default_model()
-    backend = PodmanBackend(
+    backend = create_backend(
+        backend_name,
+        harness=harness,
         workdir=str(work_dir),
         image=image,
-        harness=harness,
         extra_env=container_env or {},
     )
     if verdict_path is not None:
@@ -139,12 +150,14 @@ def _default_run_container(
         run_dir = Path(work_dir) / "_run"
         run_dir.mkdir(parents=True, exist_ok=True)
         try:
-            otel_proc, otel_port, _, _ = start_collector(str(run_dir))
+            otel_proc, otel_port, _, _ = start_collector(
+                str(run_dir), bind_addr=backend.collector_bind_address
+            )
         except Exception:
             log.warning("Failed to start OTEL collector, continuing without telemetry")
 
     try:
-        backend.setup()
+        backend.setup(otel_port=otel_port)
         return backend.run(prompt, model=model, otel_port=otel_port)
     finally:
         if otel_proc:
@@ -238,13 +251,13 @@ def run_skill(
     output_file = work_dir / "agent-output.txt"
 
     runner = config.container_runner or _default_run_container
-    # verdict_path is only passed to the default runner so _process_stream
-    # can verify the verdict file exists before promoting SIGKILL to success.
     runner_kwargs: dict = {"image": config.container_image}
     if config.container_env:
         runner_kwargs["container_env"] = config.container_env
     if config.container_runner is None:
         runner_kwargs["verdict_path"] = config.verdict_path_fn(work_dir)
+        runner_kwargs["backend_name"] = config.backend_name
+        runner_kwargs["harness_name"] = config.harness_name
 
     if dry_run:
         if dry_run_verdict_path:


### PR DESCRIPTION
## Summary

- Replace hardcoded `PodmanBackend`/`ClaudeCodeHarness` in `_default_run_container` with `create_backend()`/`create_harness()` factories
- Add `backend_name` and `harness_name` fields to `SkillConfig` (defaults: `"podman"` and `"claude-code"` for backward compatibility)
- Move the OTEL collector bind address into a `Backend.collector_bind_address` class attribute (`"0.0.0.0"` for OpenShell, `"127.0.0.1"` default), replacing the `backend_name == "openshell"` checks in both `cli.py` and `skill.py`
- Pass `otel_port` to `backend.setup()` so OpenShell can configure sandbox network policy

This eliminates the need for downstream repos (autofix) to duplicate the ~35-line container runner boilerplate. Callers can now set `backend_name="openshell"` in `SkillConfig` instead of providing a custom `container_runner` callback.

## Test plan

- [x] All 556 existing agentic-ci tests pass
- [x] Lint, format, and typecheck all pass
- [x] Verified backward compatibility: `backend_name` defaults to `"podman"`, existing callers with no `backend_name` work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)