### PR TITLE
Fix OpenShell verdict file download and exit code handling

### DIFF
--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -119,6 +119,12 @@ class OpenShellBackend(Backend):
         log.section("Downloading workdir")
         sandbox.download(sandbox_workdir, self.workdir)
 
+        # The base class verdict check in _process_stream() runs before
+        # download, so the file isn't on the host yet. Re-check now.
+        if rc != 0 and self.verdict_path is not None and self.verdict_path.exists():
+            log.info("verdict file found after download (rc=%d), treating as success", rc)
+            rc = 0
+
         return rc
 
     def _write_env_script(self, model, otel_port=None, otel_rate_file=None):

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -106,7 +106,15 @@ def upload(local_path):
 def download(sandbox_path, local_dest):
     """Download a path from the sandbox to a local destination."""
     _run(
-        ["openshell", "sandbox", "download", SANDBOX_NAME, sandbox_path, local_dest],
+        [
+            "openshell",
+            "sandbox",
+            "download",
+            "--no-git-ignore",
+            SANDBOX_NAME,
+            sandbox_path,
+            local_dest,
+        ],
         check=True,
     )
 


### PR DESCRIPTION
## Summary

Two bugs in the OpenShell backend caused the runner to report failure (`rc=-9`, `jira-autofix-blocked`) even when the agent completed successfully (wrote verdict, all work done).

## Bug 1: Missing `--no-git-ignore` on download

**File:** `src/agentic_ci/backends/openshell/sandbox.py`

`upload()` passes `--no-git-ignore` to the openshell CLI but `download()` does not. This means files matching `.gitignore` patterns are silently excluded from the download. The verdict file (`.autofix-verdict.json` inside `autofix-output/`) is commonly gitignored, so it never makes it back to the host.

**Fix:** Add `--no-git-ignore` to the download command to match upload behavior.

## Bug 2: Verdict check runs before download

**File:** `src/agentic_ci/backends/openshell/__init__.py`

The base class `_process_stream()` in `backend.py` has logic to treat a non-zero exit code as success when the stream processor detected completion AND a verdict file exists on the host. This works for the Podman backend because bind-mounts make changes visible immediately. For OpenShell, the workdir download happens *after* `_process_stream()` returns, so `self.verdict_path.exists()` always returns `False`. The rc=-9 (from `proc.kill()` / SIGKILL after stream completion) is preserved as the final exit code.

**Execution order:**
1. `_process_stream()` reads stream, detects completion, kills process (rc=-9)
2. Checks verdict on host -> not found (download hasn't happened yet) -> keeps rc=-9
3. `sandbox.download()` copies workdir from sandbox to host (verdict now exists)
4. Returns rc=-9

**Fix:** Added a post-download re-check in `OpenShellBackend.run()`. After the download completes, if rc is non-zero but the verdict file now exists, override rc to 0.

## Observed failure

From [autofix e2e job](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14941295481):
```
stream completed (rc=-9) but verdict file .../autofix-output/.autofix-verdict.json missing; keeping original exit code
```
Agent completed in 136s, wrote valid verdict, but the ticket was blocked instead of proceeding to review.

## Test plan

- [x] 556 tests pass
- [ ] Verify autofix e2e passes with the fix (via autofix MR !799)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verdict file detection and validation in the sandbox backend. The execution process now re-validates verdict file presence after the work directory download completes, correctly handling cases where the initial process check returns an error but the verdict file is found in the downloaded content.

* **Style**
  * Reformatted command argument lists for improved code readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->