### PR TITLE
add checks for already open PR/MRs

### DIFF
--- a/src/agentic_ci/forge/github.py
+++ b/src/agentic_ci/forge/github.py
@@ -46,6 +46,23 @@ class GitHubForge(Forge):
         description: str,
     ) -> tuple[str | None, str | None]:
         repo_path = repo_path_from_url(repo_url)
+
+        owner = repo_path.split("/")[0]
+        existing = self._session.get(
+            f"https://api.github.com/repos/{repo_path}/pulls",
+            params={
+                "head": f"{owner}:{source_branch}",
+                "base": target_branch,
+                "state": "open",
+            },
+        )
+        if existing.status_code == 200:
+            prs = existing.json()
+            if prs:
+                existing_url = prs[0].get("html_url")
+                log.info("Found existing open PR: %s", existing_url)
+                return existing_url, None
+
         payload = {
             "head": source_branch,
             "base": target_branch,

--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -52,6 +52,22 @@ class GitLabForge(Forge):
     ) -> tuple[str | None, str | None]:
         project_path = repo_path_from_url(repo_url)
         pid = self.project_id(project_path)
+
+        existing = self._session.get(
+            f"https://gitlab.com/api/v4/projects/{pid}/merge_requests",
+            params={
+                "source_branch": source_branch,
+                "target_branch": target_branch,
+                "state": "opened",
+            },
+        )
+        if existing.status_code == 200:
+            mrs = existing.json()
+            if mrs:
+                existing_url = mrs[0].get("web_url")
+                log.info("Found existing open MR: %s", existing_url)
+                return existing_url, None
+
         payload: dict[str, str | bool] = {
             "source_branch": source_branch,
             "target_branch": target_branch,

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -35,6 +35,7 @@ def _make_response(status_code, json_data=None, text=""):
 
 class TestCreateMergeRequest:
     def test_success_returns_url(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, [])
         mock_session.post.return_value = _make_response(
             201, {"html_url": "https://github.com/owner/repo/pull/42"}
         )
@@ -49,6 +50,7 @@ class TestCreateMergeRequest:
         assert error is None
 
     def test_failure_returns_error(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, [])
         mock_session.post.return_value = _make_response(
             422, {"message": "Validation Failed"}, "error body"
         )
@@ -61,6 +63,36 @@ class TestCreateMergeRequest:
         )
         assert url is None
         assert error == "Validation Failed"
+
+    def test_returns_existing_open_pr(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(
+            200, [{"html_url": "https://github.com/owner/repo/pull/99"}]
+        )
+        url, error = forge.create_merge_request(
+            "https://github.com/owner/repo",
+            "feature-branch",
+            "main",
+            "Fix bug",
+            "Description",
+        )
+        assert url == "https://github.com/owner/repo/pull/99"
+        assert error is None
+        mock_session.post.assert_not_called()
+
+    def test_existing_pr_check_failure_falls_through(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(403, text="Forbidden")
+        mock_session.post.return_value = _make_response(
+            201, {"html_url": "https://github.com/owner/repo/pull/42"}
+        )
+        url, error = forge.create_merge_request(
+            "https://github.com/owner/repo",
+            "feature-branch",
+            "main",
+            "Fix bug",
+            "Description",
+        )
+        assert url == "https://github.com/owner/repo/pull/42"
+        assert error is None
 
 
 class TestUpdateMergeRequest:

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -42,7 +42,9 @@ class TestProjectId:
 
 class TestCreateMergeRequest:
     def test_success_returns_url(self, forge, mock_session):
-        mock_session.get.return_value = _make_response(200, {"id": 1})
+        project_resp = _make_response(200, {"id": 1})
+        no_existing = _make_response(200, [])
+        mock_session.get.side_effect = [project_resp, no_existing]
         mock_session.post.return_value = _make_response(
             201, {"web_url": "https://gitlab.com/org/repo/-/merge_requests/99"}
         )
@@ -57,7 +59,9 @@ class TestCreateMergeRequest:
         assert error is None
 
     def test_failure_returns_error(self, forge, mock_session):
-        mock_session.get.return_value = _make_response(200, {"id": 1})
+        project_resp = _make_response(200, {"id": 1})
+        no_existing = _make_response(200, [])
+        mock_session.get.side_effect = [project_resp, no_existing]
         error_resp = _make_response(422, {"message": "Branch already exists"}, "error body")
         mock_session.post.return_value = error_resp
         url, error = forge.create_merge_request(
@@ -69,6 +73,40 @@ class TestCreateMergeRequest:
         )
         assert url is None
         assert error == "Branch already exists"
+
+    def test_returns_existing_open_mr(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        existing_mr = _make_response(
+            200, [{"web_url": "https://gitlab.com/org/repo/-/merge_requests/50"}]
+        )
+        mock_session.get.side_effect = [project_resp, existing_mr]
+        url, error = forge.create_merge_request(
+            "https://gitlab.com/org/repo",
+            "feature-branch",
+            "main",
+            "Fix bug",
+            "Description",
+        )
+        assert url == "https://gitlab.com/org/repo/-/merge_requests/50"
+        assert error is None
+        mock_session.post.assert_not_called()
+
+    def test_existing_mr_check_failure_falls_through(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        check_fail = _make_response(403, text="Forbidden")
+        mock_session.get.side_effect = [project_resp, check_fail]
+        mock_session.post.return_value = _make_response(
+            201, {"web_url": "https://gitlab.com/org/repo/-/merge_requests/99"}
+        )
+        url, error = forge.create_merge_request(
+            "https://gitlab.com/org/repo",
+            "feature-branch",
+            "main",
+            "Fix bug",
+            "Description",
+        )
+        assert url == "https://gitlab.com/org/repo/-/merge_requests/99"
+        assert error is None
 
 
 class TestUpdateMergeRequest:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When create_merge_request is called on a branch that already has an open PR/MR (e.g. retrying a blocked ticket), the GitHub API returns HTTP 422 "Validation Failed" because duplicate PRs from the same head branch are not allowed.

Both GitHubForge and GitLabForge now check for an existing open PR/MR on the same source→target branch pair before attempting to create a new one. If one exists, its URL is returned directly. The check is best-effort — if the lookup fails, creation proceeds normally.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

-  Updated existing test_success_returns_url and test_failure_returns_error tests to account for the new GET call
-  Added test_returns_existing_open_pr / test_returns_existing_open_mr — verifies existing PR/MR URL is returned and no POST is made
-  Added test_existing_pr_check_failure_falls_through / test_existing_mr_check_failure_falls_through — verifies a failed lookup doesn't block creation
-  All 99 forge tests pass, ruff lint clean, ruff format clean, no new mypy errors

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved merge request creation by detecting and reusing existing pull requests (GitHub) and merge requests (GitLab) instead of creating duplicates.

* **Tests**
  * Enhanced test coverage for the new pre-flight detection logic across both GitHub and GitLab integrations, including fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->