### PR TITLE
Bump acli to 1.3.20 and remove broken Renovate rule

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -82,7 +82,7 @@ RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
     && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.19~stable-1
+ARG ACLI_VERSION=1.3.20~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -59,7 +59,7 @@ RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
     && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.19~stable-1
+ARG ACLI_VERSION=1.3.20~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/renovate.json
+++ b/renovate.json
@@ -130,18 +130,6 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^images/ci/Containerfile\\.podman$",
-        "^images/ci/Containerfile\\.openshell$"
-      ],
-      "matchStrings": ["ARG ACLI_VERSION=(?<currentValue>[^\\n]+)"],
-      "depNameTemplate": "acli",
-      "datasourceTemplate": "rpm",
-      "registryUrlTemplate": "https://acli.atlassian.com/linux/rpm/repodata/",
-      "versioningTemplate": "rpm"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/shared/Containerfile\\.openshell-base$"
       ],


### PR DESCRIPTION
## Summary

- Bumps acli from `1.3.19~stable-1` to `1.3.20~stable-1` in both CI container images (`ci-podman` and `ci-openshell`)
- The upstream acli RPM repo removed 1.3.19 when publishing 1.3.20 (built 2026-06-19T10:49 UTC), breaking CI image builds
- Removes the broken Renovate custom manager rule for acli, which used `datasourceTemplate: "rpm"` (not a valid Renovate datasource). This rule was silently ignored, so acli was never auto-bumped by Renovate.

## Test plan

- [ ] CI image builds for `ci-podman` and `ci-openshell` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)