### PR TITLE
Fix OpenShell verdict download and split verdict check from stream processing

### DIFF
--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -54,8 +54,9 @@ class Backend(ABC):
     def _process_stream(self, proc, streaming):
         """Read output from proc.stdout through the harness stream processor.
 
-        Returns the exit code, treating stream-complete as success even
-        if the process exit code is non-zero.
+        Returns ``(rc, stream_complete)`` so callers can insert
+        backend-specific steps (e.g. downloading the workdir) before
+        the verdict check in :meth:`_resolve_exit_code`.
         """
         stderr_buf = bytearray()
 
@@ -97,6 +98,22 @@ class Backend(ABC):
         if processor:
             processor.flush_errors()
 
+        if rc != 0 and stderr_buf:
+            filtered = self._filter_stderr_noise(stderr_buf)
+            if filtered:
+                log.section("Agent stderr")
+                sys.stderr.buffer.write(filtered)
+                sys.stderr.buffer.flush()
+
+        return rc, stream_complete
+
+    def _resolve_exit_code(self, rc, stream_complete):
+        """Apply verdict-based exit code override.
+
+        When the stream processor detected a completed run but the
+        process exited non-zero (e.g. SIGKILL after the agent finished),
+        promote the exit code to 0 if the verdict file is present.
+        """
         if stream_complete and rc != 0:
             if self.verdict_path is not None and not self.verdict_path.exists():
                 log.info(
@@ -106,14 +123,6 @@ class Backend(ABC):
             else:
                 log.info(f"stream processor detected run complete (rc={rc}), treating as success")
                 rc = 0
-
-        if rc != 0 and stderr_buf:
-            filtered = self._filter_stderr_noise(stderr_buf)
-            if filtered:
-                log.section("Agent stderr")
-                sys.stderr.buffer.write(filtered)
-                sys.stderr.buffer.flush()
-
         return rc
 
     _STDERR_NOISE = (

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -60,6 +60,7 @@ class LocalBackend(Backend):
             env=env,
         )
 
-        rc = self._process_stream(proc, streaming)
+        rc, stream_complete = self._process_stream(proc, streaming)
+        rc = self._resolve_exit_code(rc, stream_complete)
         self._wait_for_otel_flush(otel_port)
         return rc

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -113,18 +113,13 @@ class OpenShellBackend(Backend):
         ]
         proc = sandbox.exec_cmd_streaming(cmd)
 
-        rc = self._process_stream(proc, streaming)
+        rc, stream_complete = self._process_stream(proc, streaming)
         self._wait_for_otel_flush(otel_port)
 
         log.section("Downloading workdir")
         sandbox.download(sandbox_workdir, self.workdir)
 
-        # The base class verdict check in _process_stream() runs before
-        # download, so the file isn't on the host yet. Re-check now.
-        if rc != 0 and self.verdict_path is not None and self.verdict_path.exists():
-            log.info("verdict file found after download (rc=%d), treating as success", rc)
-            rc = 0
-
+        rc = self._resolve_exit_code(rc, stream_complete)
         return rc
 
     def _write_env_script(self, model, otel_port=None, otel_rate_file=None):

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -106,15 +106,7 @@ def upload(local_path):
 def download(sandbox_path, local_dest):
     """Download a path from the sandbox to a local destination."""
     _run(
-        [
-            "openshell",
-            "sandbox",
-            "download",
-            "--no-git-ignore",
-            SANDBOX_NAME,
-            sandbox_path,
-            local_dest,
-        ],
+        ["openshell", "sandbox", "download", SANDBOX_NAME, sandbox_path, local_dest],
         check=True,
     )
 

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -137,7 +137,8 @@ class PodmanBackend(Backend):
             stderr=subprocess.PIPE,
         )
 
-        rc = self._process_stream(proc, streaming)
+        rc, stream_complete = self._process_stream(proc, streaming)
+        rc = self._resolve_exit_code(rc, stream_complete)
         self._wait_for_otel_flush(otel_port)
         return rc
 

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -310,6 +310,46 @@ POLICY
 
     agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
 
+    # --- Verdict file download test ---
+    # Verifies that files written to gitignored directories inside the
+    # sandbox (like autofix-output/) are downloaded back to the host.
+    # This was broken when sandbox.download() used --no-git-ignore
+    # (unsupported flag) and when the verdict check ran before download.
+    print_header "=== agentic-ci run: verdict file download ==="
+
+    WORKDIR="$TMPDIR_E2E/verdict-download"
+    mkdir -p "$WORKDIR"
+    # Add a .gitignore that excludes the output directory, matching the
+    # real autofix layout where the verdict lives in a gitignored path.
+    cat > "$WORKDIR/.gitignore" <<'GITIGNORE'
+autofix-output/
+GITIGNORE
+    git -C "$WORKDIR" init -q
+
+    print_step "Running Claude Code to create a file in a gitignored directory..."
+    VERDICT_LOG="$TMPDIR_E2E/verdict-download.log"
+    RC=0
+    agentic-ci run \
+        "Create the directory autofix-output/ then write the file autofix-output/verdict.json with the content {\"verdict\": \"committed\"}. Do not say anything else." \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel 2>&1 | tee "$VERDICT_LOG" || RC=$?
+
+    assert_ok "verdict-download run exited successfully" test "$RC" -eq 0
+    assert_ok "verdict-download: verdict file downloaded to host" \
+        test -f "$WORKDIR/autofix-output/verdict.json"
+
+    if [[ -f "$WORKDIR/autofix-output/verdict.json" ]]; then
+        VERDICT_CONTENT="$(cat "$WORKDIR/autofix-output/verdict.json")"
+        assert_contains "verdict-download: file has expected content" \
+            "$VERDICT_CONTENT" "committed"
+    fi
+    dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+
     # --- AGENT_ENABLED_PLUGINS via OpenShell ---
     # Verifies that the env script sources entrypoint.sh and calls
     # _enable_plugins so only the requested plugins are loaded.

--- a/tests/test_completion_validator.py
+++ b/tests/test_completion_validator.py
@@ -88,7 +88,8 @@ class TestVerdictPathGuard:
         """Without a verdict_path set, stream_complete promotes rc to 0."""
         backend = ConcreteBackend(harness=FakeHarness())
         proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
-        rc = backend._process_stream(proc, streaming=True)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+        rc = backend._resolve_exit_code(rc, stream_complete)
         assert rc == 0
 
     def test_verdict_exists_promotes_rc(self, tmp_path):
@@ -98,7 +99,8 @@ class TestVerdictPathGuard:
         backend = ConcreteBackend(harness=FakeHarness())
         backend.verdict_path = verdict
         proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
-        rc = backend._process_stream(proc, streaming=True)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+        rc = backend._resolve_exit_code(rc, stream_complete)
         assert rc == 0
 
     def test_verdict_missing_keeps_original_rc(self, tmp_path):
@@ -106,7 +108,8 @@ class TestVerdictPathGuard:
         backend = ConcreteBackend(harness=FakeHarness())
         backend.verdict_path = tmp_path / "verdict.json"
         proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
-        rc = backend._process_stream(proc, streaming=True)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+        rc = backend._resolve_exit_code(rc, stream_complete)
         assert rc == -9
 
     def test_no_stream_complete_no_promotion(self):
@@ -114,8 +117,146 @@ class TestVerdictPathGuard:
         backend = ConcreteBackend(harness=FakeHarness())
         backend.verdict_path = None
         proc = _make_proc(['{"type": "system"}\n'], returncode=1)
-        rc = backend._process_stream(proc, streaming=True)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+        rc = backend._resolve_exit_code(rc, stream_complete)
         assert rc == 1
+
+    def test_process_stream_returns_tuple(self):
+        """_process_stream returns (rc, stream_complete) tuple."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        result = backend._process_stream(proc, streaming=True)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        rc, stream_complete = result
+        assert rc == -9
+        assert stream_complete is True
+
+    def test_process_stream_no_completion(self):
+        """_process_stream returns stream_complete=False when stream doesn't complete."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        proc = _make_proc(['{"type": "system"}\n'], returncode=1)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+        assert rc == 1
+        assert stream_complete is False
+
+
+class TestOpenShellDownloadBeforeVerdict:
+    """Verify OpenShellBackend downloads the workdir before checking the verdict."""
+
+    def test_verdict_found_after_download(self, tmp_path):
+        """When download creates the verdict file, _resolve_exit_code sees it and promotes rc."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        verdict = tmp_path / "autofix-output" / ".autofix-verdict.json"
+        backend.verdict_path = verdict
+
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+
+        assert not verdict.exists()
+        assert rc == -9
+        assert stream_complete is True
+
+        verdict.parent.mkdir(parents=True)
+        verdict.write_text('{"verdict": "committed"}')
+
+        rc = backend._resolve_exit_code(rc, stream_complete)
+        assert rc == 0
+
+    def test_verdict_still_missing_after_download(self, tmp_path):
+        """When download doesn't produce the verdict file, rc is preserved."""
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.verdict_path = tmp_path / "autofix-output" / ".autofix-verdict.json"
+
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
+
+        rc = backend._resolve_exit_code(rc, stream_complete)
+        assert rc == -9
+
+
+class TestOpenShellRunVerdictOrdering:
+    """Integration test: OpenShellBackend.run() downloads before verdict check."""
+
+    def test_run_downloads_before_verdict_check(self, tmp_path, monkeypatch):
+        """OpenShellBackend.run() must download the workdir before checking the verdict.
+
+        Simulates an agent that writes a verdict file inside the sandbox.
+        The mock download copies it to the host. The verdict check should
+        find it and promote the exit code to 0.
+        """
+        from agentic_ci.backends.openshell import OpenShellBackend
+        from agentic_ci.harness import ClaudeCodeHarness
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        harness = ClaudeCodeHarness()
+        workdir = tmp_path / "repo"
+        workdir.mkdir()
+        backend = OpenShellBackend(workdir=str(workdir), harness=harness)
+        verdict = workdir / "autofix-output" / ".autofix-verdict.json"
+        backend.verdict_path = verdict
+
+        call_order = []
+
+        def mock_exec_cmd_streaming(cmd):
+            call_order.append("exec")
+            return _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+
+        def mock_download(sandbox_path, local_dest):
+            call_order.append("download")
+            verdict.parent.mkdir(parents=True, exist_ok=True)
+            verdict.write_text('{"verdict": "committed"}')
+
+        with (
+            mock.patch.object(backend, "_write_env_script"),
+            mock.patch(
+                "agentic_ci.backends.openshell.sandbox.exec_cmd_streaming",
+                side_effect=mock_exec_cmd_streaming,
+            ),
+            mock.patch(
+                "agentic_ci.backends.openshell.sandbox.download",
+                side_effect=mock_download,
+            ),
+        ):
+            rc = backend.run(prompt="test", model="test-model", otel_port=None)
+
+        assert rc == 0, f"Expected rc=0 (verdict found after download), got {rc}"
+        assert call_order == ["exec", "download"]
+
+    def test_run_preserves_rc_when_verdict_missing_after_download(self, tmp_path, monkeypatch):
+        """If the verdict file is still missing after download, rc is preserved."""
+        from agentic_ci.backends.openshell import OpenShellBackend
+        from agentic_ci.harness import ClaudeCodeHarness
+
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+
+        harness = ClaudeCodeHarness()
+        workdir = tmp_path / "repo"
+        workdir.mkdir()
+        backend = OpenShellBackend(workdir=str(workdir), harness=harness)
+        backend.verdict_path = workdir / "autofix-output" / ".autofix-verdict.json"
+
+        def mock_exec_cmd_streaming(cmd):
+            return _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+
+        def mock_download(sandbox_path, local_dest):
+            pass
+
+        with (
+            mock.patch.object(backend, "_write_env_script"),
+            mock.patch(
+                "agentic_ci.backends.openshell.sandbox.exec_cmd_streaming",
+                side_effect=mock_exec_cmd_streaming,
+            ),
+            mock.patch(
+                "agentic_ci.backends.openshell.sandbox.download",
+                side_effect=mock_download,
+            ),
+        ):
+            rc = backend.run(prompt="test", model="test-model", otel_port=None)
+
+        assert rc == -9, f"Expected rc=-9 (verdict still missing), got {rc}"
 
 
 class TestRunSkillVerdictWiring:


### PR DESCRIPTION
## Context

The [autofix e2e job](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14943078615) started failing after commit 7103caa, which added `--no-git-ignore` to `openshell sandbox download`. The agent completed successfully (wrote and validated the verdict file inside the sandbox), but the workdir download crashed and the run was reported as failed.

## Root cause

Two issues:

1. **`--no-git-ignore` doesn't exist on `openshell sandbox download`** — it's only supported on `upload` and `create`. The flag was added based on a misdiagnosis that download applies gitignore filtering (it doesn't). The invalid flag caused `subprocess.CalledProcessError` on every download, preventing the workdir from being copied back to the host.

2. **Verdict check ran before download** — `_process_stream()` in the base `Backend` class bundled stream I/O with the verdict-file exit code check. For Podman/Local the verdict file is on the host immediately (bind-mount or local exec), so the check works. For OpenShell, the file only reaches the host after `sandbox.download()`, which runs *after* `_process_stream()` returns. This produced a confusing `stream completed (rc=-9) but verdict file ... missing` log even when the agent succeeded.

## Changes

### Commit 1: Remove unsupported `--no-git-ignore` from download

Removes the invalid flag from `sandbox.download()`. OpenShell doesn't filter by gitignore on downloads, so the flag was unnecessary.

### Commit 2: Split verdict check from stream processing

Separates `_process_stream()` into two concerns:

- **`_process_stream(proc, streaming)`** — handles stream I/O, returns `(rc, stream_complete)` tuple
- **`_resolve_exit_code(rc, stream_complete)`** — applies verdict-based exit code override

This lets each backend insert steps between stream processing and the verdict check. OpenShell now downloads the workdir first, then checks the verdict:

```python
rc, stream_complete = self._process_stream(proc, streaming)
# ... otel flush ...
sandbox.download(sandbox_workdir, self.workdir)  # verdict file lands on host
rc = self._resolve_exit_code(rc, stream_complete)  # now finds it
```

Podman and Local call both methods in sequence (same behavior as before).

Also removes the post-download re-check hack that was added in 7103caa:
```python
# Removed:
if rc != 0 and self.verdict_path is not None and self.verdict_path.exists():
    log.info("verdict file found after download ...")
    rc = 0
```

**Minor behavioral improvement:** stderr is now printed based on the original exit code (inside `_process_stream`) before verdict promotion (in `_resolve_exit_code`). Previously, if the verdict promoted rc to 0, stderr was suppressed. Now diagnostic output is preserved even on successful runs.

### Tests

**Unit tests** (`tests/test_completion_validator.py`):
- Updated existing tests for the new `(rc, stream_complete)` return type
- `test_process_stream_returns_tuple` / `test_process_stream_no_completion` — verify the new return contract
- `test_verdict_found_after_download` — simulates the OpenShell flow: stream returns, verdict missing, file appears (download), resolve promotes rc
- `test_verdict_still_missing_after_download` — negative case

**Integration tests** (`tests/test_completion_validator.py`):
- `test_run_downloads_before_verdict_check` — exercises full `OpenShellBackend.run()` with mocked sandbox, verifies call ordering (`["exec", "download"]`) and rc promotion
- `test_run_preserves_rc_when_verdict_missing_after_download` — same flow but verdict stays missing

**E2E test** (`tests/e2e/e2e-openshell-sandbox.sh`):
- New "verdict file download" section: creates a workdir with `.gitignore` excluding `autofix-output/`, runs an agent that writes a verdict file there, verifies the file is downloaded to the host with correct content

## Test plan

- [x] `tox -e py313` — 566 tests pass
- [x] `tox -e lint` — clean
- [x] `tox -e check-format` — clean
- [x] `tox -e typecheck` — clean
- [ ] e2e: run `tests/e2e/e2e-openshell-sandbox.sh` with OpenShell credentials
- [ ] e2e: re-run the [autofix e2e pipeline](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/) to confirm the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exit code resolution for streaming operations to account for completion status
  * Enhanced verdict file handling in sandboxed environments

* **Tests**
  * Added end-to-end test coverage for verdict file downloads in sandboxed environments
  * Expanded test suite for exit code and stream completion scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->