### PR TITLE
Extract GCP credential resolution into shared module

### DIFF
--- a/src/agentic_ci/backends/openshell/provider.py
+++ b/src/agentic_ci/backends/openshell/provider.py
@@ -5,6 +5,9 @@ import os
 import subprocess
 
 from agentic_ci import log
+from agentic_ci.gcp import adc_path as _adc_path
+from agentic_ci.gcp import ensure_adc
+from agentic_ci.gcp import read_credential_type as _adc_credential_type
 
 PROVIDER_NAME = "ci-gcp"
 
@@ -86,10 +89,13 @@ def _create_gcp_provider():
         "VERTEX_LOCATION",
         os.environ.get("CLOUD_ML_REGION", "global"),
     )
+
+    source = ensure_adc()
     cred_type = _adc_credential_type()
 
     print(
-        f"  Creating GCP provider (project={project}, region={region}, creds={cred_type})",
+        f"  Creating GCP provider "
+        f"(project={project}, region={region}, creds={cred_type}, source={source})",
         flush=True,
     )
 
@@ -184,24 +190,3 @@ def _create_gcp_provider_sa(project, region):
         ],
         check=True,
     )
-
-
-def _adc_path():
-    """Return the path to the gcloud ADC file."""
-    return os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
-
-
-def _adc_credential_type():
-    """Read the credential type from the gcloud ADC file.
-
-    Returns 'service_account', 'authorized_user', or 'unknown'.
-    """
-    adc = _adc_path()
-    if not os.path.isfile(adc):
-        return "unknown"
-    try:
-        with open(adc) as f:
-            data = json.load(f)
-        return data.get("type", "unknown")
-    except (json.JSONDecodeError, OSError):
-        return "unknown"

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import base64
-import json
 import os
 import subprocess
 import tempfile
@@ -11,6 +9,7 @@ from typing import TYPE_CHECKING
 
 from agentic_ci import log
 from agentic_ci.backend import Backend
+from agentic_ci.gcp import find_credentials as _find_gcp_credentials
 
 if TYPE_CHECKING:
     from agentic_ci.harness import Harness
@@ -207,7 +206,7 @@ class PodmanBackend(Backend):
         with open(config_path, "w") as f:
             f.write(f"[core]\nproject = {vertex_project}\ndisable_prompts = true\n")
 
-        creds_json, creds_source = self._find_credentials()
+        creds_json, creds_source = _find_gcp_credentials()
         adc_path = os.path.join(
             self._config_dir, ".config", "gcloud", "application_default_credentials.json"
         )
@@ -215,55 +214,6 @@ class PodmanBackend(Backend):
             f.write(creds_json)
 
         log.section(f"Credentials staged ({creds_source})")
-
-    def _find_credentials(self):
-        """Locate and validate gcloud credentials. Returns (json_string, source_label)."""
-        raw = os.environ.get("GCLOUD_CREDENTIALS", "")
-        if raw:
-            if self._is_valid_json(raw):
-                return raw, "GCLOUD_CREDENTIALS env var"
-            decoded = self._try_base64_decode(raw)
-            if decoded and self._is_valid_json(decoded):
-                return decoded, "GCLOUD_CREDENTIALS env var (base64)"
-            raise RuntimeError("GCLOUD_CREDENTIALS is not valid JSON or base64-encoded JSON")
-
-        sa_key = os.environ.get("GCP_SERVICE_ACCOUNT_KEY", "")
-        if sa_key:
-            if os.path.isfile(sa_key):
-                try:
-                    with open(sa_key) as f:
-                        content = f.read().strip()
-                except OSError as exc:
-                    raise RuntimeError(
-                        f"Failed to read GCP_SERVICE_ACCOUNT_KEY file {sa_key}: {exc}"
-                    ) from exc
-                sa_key = content
-                source_label = "GCP_SERVICE_ACCOUNT_KEY file"
-            else:
-                source_label = "GCP_SERVICE_ACCOUNT_KEY env var"
-            if self._is_valid_json(sa_key):
-                return sa_key, source_label
-            decoded = self._try_base64_decode(sa_key)
-            if decoded and self._is_valid_json(decoded):
-                return decoded, source_label
-            raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid JSON or base64-encoded JSON")
-
-        adc = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
-        ga_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
-        for path, label in [
-            (adc, "default ADC file"),
-            (ga_creds, "GOOGLE_APPLICATION_CREDENTIALS file"),
-        ]:
-            if path and os.path.isfile(path):
-                with open(path) as f:
-                    content = f.read()
-                if self._is_valid_json(content):
-                    return content, label
-
-        raise RuntimeError(
-            "No GCP credentials found. Set GCLOUD_CREDENTIALS, "
-            "GCP_SERVICE_ACCOUNT_KEY, or configure gcloud ADC."
-        )
 
     def _build_env_args(self):
         args = list(self.harness.build_env_args())
@@ -297,18 +247,3 @@ class PodmanBackend(Backend):
                 ]
             )
         return vols
-
-    @staticmethod
-    def _is_valid_json(text):
-        try:
-            json.loads(text)
-            return True
-        except (json.JSONDecodeError, ValueError):
-            return False
-
-    @staticmethod
-    def _try_base64_decode(text):
-        try:
-            return base64.b64decode(text).decode("utf-8")
-        except Exception:
-            return None

--- a/src/agentic_ci/gcp.py
+++ b/src/agentic_ci/gcp.py
@@ -1,0 +1,147 @@
+"""GCP credential resolution for agentic-ci backends.
+
+Locates GCP service account or user credentials from environment
+variables, files, or the default gcloud ADC path. Used by both the
+Podman and OpenShell backends.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+
+_ADC_PATH = "~/.config/gcloud/application_default_credentials.json"
+
+
+def adc_path() -> str:
+    """Return the expanded path to the gcloud ADC file."""
+    return os.path.expanduser(_ADC_PATH)
+
+
+def find_credentials() -> tuple[str, str]:
+    """Locate GCP credentials. Returns (json_string, source_label).
+
+    Search order:
+    1. GCLOUD_CREDENTIALS env var (inline JSON or base64)
+    2. GCP_SERVICE_ACCOUNT_KEY env var (file path, inline JSON, or base64)
+    3. Default ADC file (~/.config/gcloud/application_default_credentials.json)
+    4. GOOGLE_APPLICATION_CREDENTIALS file
+
+    Raises RuntimeError if no valid credentials are found.
+    """
+    raw = os.environ.get("GCLOUD_CREDENTIALS", "")
+    if raw:
+        content, is_b64 = _resolve_json(raw)
+        if content:
+            suffix = " (base64)" if is_b64 else ""
+            return content, f"GCLOUD_CREDENTIALS env var{suffix}"
+        raise RuntimeError("GCLOUD_CREDENTIALS is not valid JSON or base64-encoded JSON")
+
+    sa_key = os.environ.get("GCP_SERVICE_ACCOUNT_KEY", "")
+    if sa_key:
+        if os.path.isfile(sa_key):
+            try:
+                with open(sa_key) as f:
+                    sa_key = f.read().strip()
+            except OSError as exc:
+                raise RuntimeError(
+                    f"Failed to read GCP_SERVICE_ACCOUNT_KEY file {sa_key}: {exc}"
+                ) from exc
+            source_label = "GCP_SERVICE_ACCOUNT_KEY file"
+        else:
+            source_label = "GCP_SERVICE_ACCOUNT_KEY env var"
+        content, _ = _resolve_json(sa_key)
+        if content:
+            return content, source_label
+        raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid JSON or base64-encoded JSON")
+
+    adc = adc_path()
+    ga_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    for path, label in [
+        (adc, "default ADC file"),
+        (ga_creds, "GOOGLE_APPLICATION_CREDENTIALS file"),
+    ]:
+        if path and os.path.isfile(path):
+            with open(path) as f:
+                text = f.read()
+            if _is_valid_json(text):
+                return text, label
+
+    raise RuntimeError(
+        "No GCP credentials found. Set GCLOUD_CREDENTIALS, "
+        "GCP_SERVICE_ACCOUNT_KEY, or configure gcloud ADC."
+    )
+
+
+def ensure_adc() -> str:
+    """Ensure the gcloud ADC file exists, writing it from env vars if needed.
+
+    When env vars are set they take precedence over an existing ADC file,
+    matching the priority order in find_credentials(). When no env vars
+    are set, an existing ADC file is left untouched (developer laptop).
+
+    Returns the source label describing where the credentials came from.
+    Raises RuntimeError if no credentials are found.
+    """
+    adc = adc_path()
+    has_env_creds = bool(
+        os.environ.get("GCLOUD_CREDENTIALS") or os.environ.get("GCP_SERVICE_ACCOUNT_KEY")
+    )
+    if os.path.isfile(adc) and not has_env_creds:
+        cred_type = _read_credential_type(adc)
+        return f"existing ADC file ({cred_type})"
+
+    creds_json, source = find_credentials()
+    os.makedirs(os.path.dirname(adc), exist_ok=True)
+    with open(adc, "w") as f:
+        f.write(creds_json)
+    return source
+
+
+def read_credential_type() -> str:
+    """Read the credential type from the gcloud ADC file.
+
+    Returns 'service_account', 'authorized_user', or 'unknown'.
+    """
+    return _read_credential_type(adc_path())
+
+
+def _read_credential_type(path: str) -> str:
+    if not os.path.isfile(path):
+        return "unknown"
+    try:
+        with open(path) as f:
+            data = json.load(f)
+        return data.get("type", "unknown")
+    except (json.JSONDecodeError, OSError):
+        return "unknown"
+
+
+def _resolve_json(val: str) -> tuple[str | None, bool]:
+    """Try to extract valid JSON from a raw or base64-encoded string.
+
+    Returns (json_string, was_base64). json_string is None if neither
+    raw nor base64-decoded content is valid JSON.
+    """
+    if _is_valid_json(val):
+        return val, False
+    decoded = _try_base64_decode(val)
+    if decoded and _is_valid_json(decoded):
+        return decoded, True
+    return None, False
+
+
+def _is_valid_json(text: str) -> bool:
+    try:
+        json.loads(text)
+        return True
+    except (json.JSONDecodeError, ValueError):
+        return False
+
+
+def _try_base64_decode(text: str) -> str | None:
+    try:
+        return base64.b64decode(text).decode("utf-8")
+    except Exception:
+        return None

--- a/tests/test_gcp.py
+++ b/tests/test_gcp.py
@@ -1,0 +1,194 @@
+"""Tests for GCP credential resolution."""
+
+import base64
+import json
+
+import pytest
+
+from agentic_ci.gcp import (
+    _is_valid_json,
+    _try_base64_decode,
+    ensure_adc,
+    find_credentials,
+    read_credential_type,
+)
+
+
+def test_find_credentials_from_gcloud_credentials_json(monkeypatch):
+    creds = json.dumps({"type": "authorized_user", "client_id": "test"})
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
+
+    result, source = find_credentials()
+    assert json.loads(result)["client_id"] == "test"
+    assert source == "GCLOUD_CREDENTIALS env var"
+
+
+def test_find_credentials_from_base64(monkeypatch):
+    creds = json.dumps({"type": "service_account", "project_id": "test"})
+    encoded = base64.b64encode(creds.encode()).decode()
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", encoded)
+
+    result, source = find_credentials()
+    assert json.loads(result)["project_id"] == "test"
+    assert source == "GCLOUD_CREDENTIALS env var (base64)"
+
+
+def test_find_credentials_from_service_account_key(monkeypatch):
+    creds = json.dumps({"type": "service_account", "project_id": "sa-test"})
+    encoded = base64.b64encode(creds.encode()).decode()
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", encoded)
+
+    result, source = find_credentials()
+    assert json.loads(result)["project_id"] == "sa-test"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY env var"
+
+
+def test_find_credentials_from_service_account_key_json_file(monkeypatch, tmp_path):
+    creds = json.dumps({"type": "service_account", "project_id": "sa-file-test"})
+    key_file = tmp_path / "sa-key.json"
+    key_file.write_text(creds)
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    result, source = find_credentials()
+    assert json.loads(result)["project_id"] == "sa-file-test"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
+
+
+def test_find_credentials_from_service_account_key_base64_file(monkeypatch, tmp_path):
+    creds = json.dumps({"type": "service_account", "project_id": "sa-b64-file"})
+    encoded = base64.b64encode(creds.encode()).decode()
+    key_file = tmp_path / "sa-key.b64"
+    key_file.write_text(encoded)
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    result, source = find_credentials()
+    assert json.loads(result)["project_id"] == "sa-b64-file"
+    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
+
+
+def test_find_credentials_from_service_account_key_file_invalid(monkeypatch, tmp_path):
+    key_file = tmp_path / "bad-key.json"
+    key_file.write_text("not valid json or base64")
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
+
+    with pytest.raises(RuntimeError, match="not valid JSON or base64"):
+        find_credentials()
+
+
+def test_find_credentials_from_adc_file(monkeypatch, tmp_path):
+    creds = json.dumps({"type": "authorized_user", "client_id": "file-test"})
+    adc_file = tmp_path / "adc.json"
+    adc_file.write_text(creds)
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(adc_file))
+    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+
+    result, source = find_credentials()
+    assert json.loads(result)["client_id"] == "file-test"
+    assert source == "GOOGLE_APPLICATION_CREDENTIALS file"
+
+
+def test_find_credentials_raises_when_missing(monkeypatch, tmp_path):
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+
+    with pytest.raises(RuntimeError, match="No GCP credentials found"):
+        find_credentials()
+
+
+def test_find_credentials_invalid_json_raises(monkeypatch):
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", "not-json-not-base64")
+
+    with pytest.raises(RuntimeError, match="not valid JSON"):
+        find_credentials()
+
+
+def test_is_valid_json():
+    assert _is_valid_json('{"key": "value"}')
+    assert not _is_valid_json("not json")
+    assert not _is_valid_json("")
+
+
+def test_try_base64_decode():
+    encoded = base64.b64encode(b"hello").decode()
+    assert _try_base64_decode(encoded) == "hello"
+    assert _try_base64_decode("!!!invalid!!!") is None
+
+
+def test_ensure_adc_writes_from_env_var(monkeypatch, tmp_path):
+    creds = json.dumps({"type": "service_account", "project_id": "test"})
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    source = ensure_adc()
+    assert source == "GCLOUD_CREDENTIALS env var"
+
+    adc_file = tmp_path / ".config" / "gcloud" / "application_default_credentials.json"
+    assert adc_file.exists()
+    assert json.loads(adc_file.read_text())["project_id"] == "test"
+
+
+def test_ensure_adc_env_var_overrides_existing_file(monkeypatch, tmp_path):
+    old_creds = json.dumps({"type": "authorized_user", "client_id": "stale"})
+    adc_dir = tmp_path / ".config" / "gcloud"
+    adc_dir.mkdir(parents=True)
+    (adc_dir / "application_default_credentials.json").write_text(old_creds)
+
+    new_creds = json.dumps({"type": "service_account", "project_id": "fresh"})
+    monkeypatch.setenv("GCLOUD_CREDENTIALS", new_creds)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    source = ensure_adc()
+    assert source == "GCLOUD_CREDENTIALS env var"
+
+    written = json.loads((adc_dir / "application_default_credentials.json").read_text())
+    assert written["project_id"] == "fresh"
+
+
+def test_ensure_adc_keeps_existing_when_no_env_vars(monkeypatch, tmp_path):
+    creds = json.dumps({"type": "authorized_user", "client_id": "existing"})
+    adc_dir = tmp_path / ".config" / "gcloud"
+    adc_dir.mkdir(parents=True)
+    (adc_dir / "application_default_credentials.json").write_text(creds)
+
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    source = ensure_adc()
+    assert "existing ADC file" in source
+
+    written = json.loads((adc_dir / "application_default_credentials.json").read_text())
+    assert written["client_id"] == "existing"
+
+
+def test_ensure_adc_raises_when_no_creds(monkeypatch, tmp_path):
+    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+
+    with pytest.raises(RuntimeError, match="No GCP credentials found"):
+        ensure_adc()
+
+
+def test_read_credential_type_service_account(tmp_path, monkeypatch):
+    creds = json.dumps({"type": "service_account"})
+    adc_dir = tmp_path / ".config" / "gcloud"
+    adc_dir.mkdir(parents=True)
+    (adc_dir / "application_default_credentials.json").write_text(creds)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    assert read_credential_type() == "service_account"
+
+
+def test_read_credential_type_missing_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
+    assert read_credential_type() == "unknown"

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -1,6 +1,5 @@
 """Tests for Podman backend."""
 
-import base64
 import json
 import os
 
@@ -18,115 +17,6 @@ def claude_harness():
 @pytest.fixture()
 def opencode_harness():
     return OpenCodeHarness()
-
-
-def test_find_credentials_from_gcloud_credentials_json(monkeypatch, tmp_path, claude_harness):
-    creds = json.dumps({"type": "authorized_user", "client_id": "test"})
-    monkeypatch.setenv("GCLOUD_CREDENTIALS", creds)
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["client_id"] == "test"
-    assert source == "GCLOUD_CREDENTIALS env var"
-
-
-def test_find_credentials_from_base64(monkeypatch, tmp_path, claude_harness):
-    creds = json.dumps({"type": "service_account", "project_id": "test"})
-    encoded = base64.b64encode(creds.encode()).decode()
-    monkeypatch.setenv("GCLOUD_CREDENTIALS", encoded)
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["project_id"] == "test"
-    assert source == "GCLOUD_CREDENTIALS env var (base64)"
-
-
-def test_find_credentials_from_service_account_key(monkeypatch, tmp_path, claude_harness):
-    creds = json.dumps({"type": "service_account", "project_id": "sa-test"})
-    encoded = base64.b64encode(creds.encode()).decode()
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", encoded)
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["project_id"] == "sa-test"
-    assert source == "GCP_SERVICE_ACCOUNT_KEY env var"
-
-
-def test_find_credentials_from_service_account_key_json_file(monkeypatch, tmp_path, claude_harness):
-    creds = json.dumps({"type": "service_account", "project_id": "sa-file-test"})
-    key_file = tmp_path / "sa-key.json"
-    key_file.write_text(creds)
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["project_id"] == "sa-file-test"
-    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
-
-
-def test_find_credentials_from_service_account_key_base64_file(
-    monkeypatch, tmp_path, claude_harness
-):
-    creds = json.dumps({"type": "service_account", "project_id": "sa-b64-file"})
-    encoded = base64.b64encode(creds.encode()).decode()
-    key_file = tmp_path / "sa-key.b64"
-    key_file.write_text(encoded)
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["project_id"] == "sa-b64-file"
-    assert source == "GCP_SERVICE_ACCOUNT_KEY file"
-
-
-def test_find_credentials_from_service_account_key_file_invalid(
-    monkeypatch, tmp_path, claude_harness
-):
-    key_file = tmp_path / "bad-key.json"
-    key_file.write_text("not valid json or base64")
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.setenv("GCP_SERVICE_ACCOUNT_KEY", str(key_file))
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    with pytest.raises(RuntimeError, match="not valid JSON or base64"):
-        backend._find_credentials()
-
-
-def test_find_credentials_from_adc_file(monkeypatch, tmp_path, claude_harness):
-    creds = json.dumps({"type": "authorized_user", "client_id": "file-test"})
-    adc_path = tmp_path / "adc.json"
-    adc_path.write_text(creds)
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
-    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(adc_path))
-    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    result, source = backend._find_credentials()
-    assert json.loads(result)["client_id"] == "file-test"
-    assert source == "GOOGLE_APPLICATION_CREDENTIALS file"
-
-
-def test_find_credentials_raises_when_missing(monkeypatch, tmp_path, claude_harness):
-    monkeypatch.delenv("GCLOUD_CREDENTIALS", raising=False)
-    monkeypatch.delenv("GCP_SERVICE_ACCOUNT_KEY", raising=False)
-    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
-    monkeypatch.setenv("HOME", str(tmp_path / "nonexistent"))
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    with pytest.raises(RuntimeError, match="No GCP credentials found"):
-        backend._find_credentials()
-
-
-def test_find_credentials_invalid_json_raises(monkeypatch, tmp_path, claude_harness):
-    monkeypatch.setenv("GCLOUD_CREDENTIALS", "not-json-not-base64")
-
-    backend = PodmanBackend(workdir=str(tmp_path), harness=claude_harness)
-    with pytest.raises(RuntimeError, match="not valid JSON"):
-        backend._find_credentials()
 
 
 def test_build_env_args_claude_code(tmp_path, claude_harness):
@@ -154,18 +44,6 @@ def test_build_env_args_extra_env(tmp_path, claude_harness):
     )
     args = backend._build_env_args()
     assert "MY_VAR=value" in args
-
-
-def test_is_valid_json():
-    assert PodmanBackend._is_valid_json('{"key": "value"}')
-    assert not PodmanBackend._is_valid_json("not json")
-    assert not PodmanBackend._is_valid_json("")
-
-
-def test_try_base64_decode():
-    encoded = base64.b64encode(b"hello").decode()
-    assert PodmanBackend._try_base64_decode(encoded) == "hello"
-    assert PodmanBackend._try_base64_decode("!!!invalid!!!") is None
 
 
 def test_resolve_credentials_creates_config(monkeypatch, tmp_path, claude_harness):


### PR DESCRIPTION
## Summary

The OpenShell provider only read credentials from `~/.config/gcloud/application_default_credentials.json`. In CI, credentials arrive via env vars (`GCP_SERVICE_ACCOUNT_KEY` as a GitLab File variable, `GCLOUD_CREDENTIALS` as inline JSON or base64). This forced every consumer repo (autofix, code-review) to add a `setup_gcp_adc()` workaround that copied env var credentials to the ADC path before the provider ran.

Meanwhile, the Podman backend already had full credential resolution (env vars, file paths, base64, ADC file) but it was implemented as private instance methods on `PodmanBackend`.

## Changes

- **New `src/agentic_ci/gcp.py` module** with shared credential resolution:
  - `find_credentials()`: searches env vars, file paths, base64, ADC file (same priority order as the old Podman code)
  - `ensure_adc()`: writes env var credentials to the ADC path so the OpenShell provider can read them. When env vars are set they take precedence over an existing ADC file (CI scenario). When no env vars are set, an existing ADC file is left untouched (developer laptop scenario).
  - `adc_path()`, `read_credential_type()`: utilities used by the OpenShell provider

- **OpenShell provider** (`backends/openshell/provider.py`): calls `ensure_adc()` at the start of `_create_gcp_provider()` so credentials from env vars are written to the ADC path before the provider reads it. Removed local `_adc_path()` and `_adc_credential_type()` in favor of the shared module.

- **Podman backend** (`backends/podman.py`): replaced `_find_credentials()`, `_is_valid_json()`, `_try_base64_decode()` instance methods with a call to `gcp.find_credentials()`. Removed `base64` and `json` imports that are no longer needed.

- **Tests**: moved credential resolution tests from `test_podman.py` to `test_gcp.py`. Added new tests for `ensure_adc()` (env var override, stale file, no creds) and `read_credential_type()`.

## Backward compatibility

100% backward compatible:

- **Podman backend**: `_resolve_credentials()` still writes the same ADC file to the same temp dir. The credential lookup is now `gcp.find_credentials()` instead of `self._find_credentials()`, with identical search order, env var names, error messages, and source labels.
- **OpenShell provider**: previously required the ADC file to already exist. Now it writes it from env vars if missing, so it works in strictly more environments than before. If the ADC file already exists and no env vars are set, behavior is identical (uses the existing file).
- **API key auth**: completely untouched. It branches before `_create_gcp_provider()`, so `ensure_adc()` is never reached.
- **Public API**: no exported functions were removed. The removed methods (`PodmanBackend._find_credentials`, `_is_valid_json`, `_try_base64_decode`) were all private (underscore-prefixed).

## What this unblocks

Once this merges and is released, the `setup_gcp_adc()` workaround can be removed from:
- `autofix` repo (`src/jira_autofix/git_auth.py`, `cli.py`, both runners)
- `code-review` repo (`_normalize_aipcc_env()` in `cli.py`)

## Test plan

- [x] 572 tests pass (566 existing + 6 new for `ensure_adc` / `read_credential_type`)
- [x] Adversarial code review: fixed stale ADC file bug (env vars now override existing file)
- [ ] Verify autofix e2e passes after bumping to this version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced centralized GCP credential discovery supporting multiple credential sources (environment variables, service account files, and default gcloud configurations) with enhanced validation and source tracking.

* **Refactor**
  * Consolidated duplicate credential handling logic from individual backends into a shared GCP module for improved consistency and maintainability across the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->