### PR TITLE
Add OpenShell proxy hang reproducer scripts

### DIFF
--- a/scripts/proxy-probe.py
+++ b/scripts/proxy-probe.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""Probe HTTPS connectivity through the OpenShell proxy to detect hangs.
+
+Makes repeated HTTPS requests to policy-allowed endpoints and logs
+timing.  Designed to run *inside* an OpenShell sandbox to reproduce
+proxy hang / timeout issues (e.g. connections dropping during token
+rotation or L4 CONNECT tunnel idle timeouts).
+
+Runs with stdlib only so it works in minimal sandbox images.
+
+Usage (inside sandbox):
+    python3 proxy-probe.py                        # rapid mode, 2h
+    python3 proxy-probe.py --duration 300         # quick 5-min run
+    python3 proxy-probe.py --mode sustained       # hold connections open
+    python3 proxy-probe.py --vertex               # include Vertex AI calls
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+
+# ── Probe targets (must be in OpenShell default policy) ──────────────
+
+TARGETS = [
+    {"name": "github", "url": "https://api.github.com/zen"},
+    {"name": "pypi", "url": "https://pypi.org/simple/pip/"},
+    {"name": "gitlab", "url": "https://gitlab.com/api/v4/version"},
+]
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+def _ts() -> str:
+    return time.strftime("%H:%M:%S")
+
+
+def _log(elapsed_total: float, marker: str, target: str, elapsed_s: float,
+         status: int | None, error: str | None) -> None:
+    err = f" {error}" if error else ""
+    print(
+        f"[{elapsed_total:8.1f}s] {_ts()} {marker:4s} "
+        f"{target:12s} {elapsed_s:7.3f}s "
+        f"status={status}{err}",
+        flush=True,
+    )
+
+
+# ── Rapid mode ───────────────────────────────────────────────────────
+
+def probe_http(url: str, timeout: int = 30) -> tuple[float, int | None, str | None]:
+    """Make one HTTPS request.  Returns (elapsed_s, status, error)."""
+    start = time.monotonic()
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(url, method="GET")
+    req.add_header("User-Agent", "agentic-ci-proxy-probe/1.0")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            resp.read(1024)
+            return time.monotonic() - start, resp.status, None
+    except urllib.error.HTTPError as exc:
+        return time.monotonic() - start, exc.code, str(exc)
+    except urllib.error.URLError as exc:
+        return time.monotonic() - start, None, f"URLError: {exc.reason}"
+    except (TimeoutError, socket.timeout):
+        return time.monotonic() - start, None, "TIMEOUT"
+    except OSError as exc:
+        return time.monotonic() - start, None, f"OSError: {exc}"
+
+
+def probe_vertex(project: str, region: str, timeout: int = 60,
+                 ) -> tuple[float, int | None, str | None]:
+    """Minimal Vertex AI Claude call (max_tokens=1)."""
+    token = os.environ.get("GCP_SA_ACCESS_TOKEN", "")
+    if not token:
+        return 0.0, None, "GCP_SA_ACCESS_TOKEN not set"
+
+    url = (
+        f"https://{region}-aiplatform.googleapis.com/v1/"
+        f"projects/{project}/locations/{region}/"
+        "publishers/anthropic/models/claude-sonnet-4-20250514:rawPredict"
+    )
+    body = json.dumps({
+        "anthropic_version": "vertex-2023-10-16",
+        "max_tokens": 1,
+        "messages": [{"role": "user", "content": "hi"}],
+    }).encode()
+
+    start = time.monotonic()
+    ctx = ssl.create_default_context()
+    req = urllib.request.Request(url, data=body, method="POST")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            resp.read()
+            return time.monotonic() - start, resp.status, None
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode()[:200]
+        except Exception:
+            pass
+        return time.monotonic() - start, exc.code, f"HTTP {exc.code}: {detail}"
+    except urllib.error.URLError as exc:
+        return time.monotonic() - start, None, f"URLError: {exc.reason}"
+    except (TimeoutError, socket.timeout):
+        return time.monotonic() - start, None, "TIMEOUT"
+    except OSError as exc:
+        return time.monotonic() - start, None, f"OSError: {exc}"
+
+
+def run_rapid(duration: int, interval: int, vertex: bool) -> int:
+    """Rapid mode: short requests in a loop."""
+    project = os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", "")
+    region = os.environ.get("CLOUD_ML_REGION", "us-east5")
+
+    t0 = time.monotonic()
+    total = failures = slow = hangs = 0
+    max_latency = 0.0
+
+    while time.monotonic() - t0 < duration:
+        cycle_start = time.monotonic()
+        elapsed_total = cycle_start - t0
+
+        for tgt in TARGETS:
+            elapsed_s, status, error = probe_http(tgt["url"])
+            total += 1
+            max_latency = max(max_latency, elapsed_s)
+            ok = status is not None and 200 <= status < 400
+            if not ok:
+                failures += 1
+            if elapsed_s > 5:
+                slow += 1
+            if elapsed_s > 30:
+                hangs += 1
+            marker = "FAIL" if not ok else ("SLOW" if elapsed_s > 5 else "OK")
+            _log(elapsed_total, marker, tgt["name"], elapsed_s, status, error)
+
+        if vertex and project:
+            elapsed_s, status, error = probe_vertex(project, region)
+            total += 1
+            max_latency = max(max_latency, elapsed_s)
+            ok = status == 200
+            if not ok:
+                failures += 1
+            if elapsed_s > 5:
+                slow += 1
+            if elapsed_s > 30:
+                hangs += 1
+            marker = "FAIL" if not ok else ("SLOW" if elapsed_s > 5 else "OK")
+            _log(elapsed_total, marker, "vertex", elapsed_s, status, error)
+
+        wait = interval - (time.monotonic() - cycle_start)
+        if wait > 0:
+            time.sleep(wait)
+
+    _print_summary(time.monotonic() - t0, total, failures, slow, hangs, max_latency)
+    return 1 if failures or hangs else 0
+
+
+# ── Sustained mode ───────────────────────────────────────────────────
+
+def run_sustained(duration: int, interval: int) -> int:
+    """Sustained mode: hold HTTPS connections open for long periods.
+
+    Tests whether the L4 CONNECT tunnel drops idle or slow connections.
+    Opens a TLS connection to api.github.com, sends an HTTP request,
+    reads one byte at a time with sleeps to simulate a slow consumer.
+    """
+    t0 = time.monotonic()
+    total = failures = 0
+
+    print(f"Sustained mode: holding connections for {interval}s each", flush=True)
+
+    while time.monotonic() - t0 < duration:
+        elapsed_total = time.monotonic() - t0
+        target = "github"
+        start = time.monotonic()
+
+        try:
+            ctx = ssl.create_default_context()
+            raw = socket.create_connection(("api.github.com", 443), timeout=30)
+            conn = ctx.wrap_socket(raw, server_hostname="api.github.com")
+
+            conn.sendall(
+                b"GET /zen HTTP/1.1\r\n"
+                b"Host: api.github.com\r\n"
+                b"User-Agent: agentic-ci-proxy-probe/1.0\r\n"
+                b"Connection: keep-alive\r\n\r\n"
+            )
+
+            # Read response headers
+            buf = b""
+            while b"\r\n\r\n" not in buf:
+                chunk = conn.recv(1)
+                if not chunk:
+                    raise ConnectionError("connection closed during headers")
+                buf += chunk
+
+            # Now hold the connection open, reading slowly
+            hold_start = time.monotonic()
+            bytes_read = 0
+            while time.monotonic() - hold_start < interval:
+                conn.settimeout(5.0)
+                try:
+                    data = conn.recv(1)
+                    if data:
+                        bytes_read += len(data)
+                except socket.timeout:
+                    pass
+                time.sleep(1)
+
+            conn.close()
+            elapsed_s = time.monotonic() - start
+            total += 1
+            _log(elapsed_total, "OK", target, elapsed_s, 200,
+                 f"held {elapsed_s:.0f}s, read {bytes_read}B")
+
+        except Exception as exc:
+            elapsed_s = time.monotonic() - start
+            error = f"{type(exc).__name__}: {exc}"
+            total += 1
+            failures += 1
+            _log(elapsed_total, "FAIL", target, elapsed_s, None, error)
+
+    _print_summary(time.monotonic() - t0, total, failures, 0, 0, 0)
+    return 1 if failures else 0
+
+
+# ── Summary ──────────────────────────────────────────────────────────
+
+def _print_summary(wall: float, total: int, failures: int,
+                   slow: int, hangs: int, max_latency: float) -> None:
+    pct = f"{failures / total * 100:.1f}%" if total else "N/A"
+    print(flush=True)
+    print("=" * 60, flush=True)
+    print("PROBE SUMMARY", flush=True)
+    print(f"  Wall time:     {wall:.1f}s", flush=True)
+    print(f"  Requests:      {total}", flush=True)
+    print(f"  Failures:      {failures} ({pct})", flush=True)
+    if slow:
+        print(f"  Slow (>5s):    {slow}", flush=True)
+    if hangs:
+        print(f"  Hangs (>30s):  {hangs}", flush=True)
+    if max_latency:
+        print(f"  Max latency:   {max_latency:.3f}s", flush=True)
+    print("=" * 60, flush=True)
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Probe HTTPS connectivity through the OpenShell proxy",
+    )
+    parser.add_argument(
+        "--duration", type=int, default=7200,
+        help="Total run duration in seconds (default: 7200 = 2h)",
+    )
+    parser.add_argument(
+        "--interval", type=int, default=10,
+        help="Seconds between probe cycles in rapid mode, or hold "
+             "duration in sustained mode (default: 10)",
+    )
+    parser.add_argument(
+        "--mode", choices=["rapid", "sustained"], default="rapid",
+        help="rapid = short requests; sustained = hold connections open",
+    )
+    parser.add_argument(
+        "--vertex", action="store_true",
+        help="Include Vertex AI API probes (needs GCP credentials)",
+    )
+    args = parser.parse_args()
+
+    print(f"proxy-probe  mode={args.mode}  duration={args.duration}s  "
+          f"interval={args.interval}s  vertex={args.vertex}", flush=True)
+    print(flush=True)
+
+    if args.mode == "rapid":
+        rc = run_rapid(args.duration, args.interval, args.vertex)
+    else:
+        rc = run_sustained(args.duration, args.interval)
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reproduce-proxy-hang.sh
+++ b/scripts/reproduce-proxy-hang.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Reproduce OpenShell proxy hang / timeout issues.
+#
+# Sets up an OpenShell sandbox using agentic-ci (identical network
+# policy, provider config, and CONNECT tunnel setup), then runs a
+# probe script inside the sandbox that makes sustained HTTPS requests
+# and reports hangs.
+#
+# While the probe runs, the gateway log is tailed for credential
+# rotation events so you can correlate hangs with token refresh.
+#
+# Local usage (run from repo root):
+#
+#   # Build the CI image (has openshell, gateway, podman, agentic-ci)
+#   make openshell-ci-build
+#
+#   # Quick 5-minute test
+#   ./scripts/reproduce-proxy-hang.sh --duration 300
+#
+#   # 2-hour soak with Vertex AI calls
+#   ./scripts/reproduce-proxy-hang.sh --vertex --duration 7200
+#
+#   # Test long-held connections (simulates long inference calls)
+#   ./scripts/reproduce-proxy-hang.sh --mode sustained --interval 120
+#
+# The script auto-detects whether openshell is on PATH. If not, it
+# builds the openshell CI image and re-execs itself inside a
+# privileged container with the repo mounted at /workspace.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKDIR=""
+GW_TAIL_PID=""
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Options:"
+    echo "  --duration SEC   Total run time (default: 7200)"
+    echo "  --interval SEC   Seconds between probes (default: 10)"
+    echo "  --mode MODE      rapid|sustained (default: rapid)"
+    echo "  --vertex         Include Vertex AI API probes"
+    echo "  --image IMAGE    Sandbox image override"
+    echo "  --no-reexec      Skip container re-exec even if openshell is missing"
+    echo "  -h, --help       Show this help"
+}
+
+cleanup() {
+    echo ""
+    echo "--- Cleaning up ---"
+    [[ -n "$GW_TAIL_PID" ]] && kill "$GW_TAIL_PID" 2>/dev/null || true
+    if [[ -n "$WORKDIR" ]]; then
+        agentic-ci stop --backend openshell --workdir "$WORKDIR" 2>/dev/null || true
+        rm -rf "$WORKDIR"
+    fi
+}
+
+# ── Parse arguments ──────────────────────────────────────────────────
+
+DURATION=7200
+INTERVAL=10
+MODE=rapid
+VERTEX=""
+IMAGE=""
+NO_REEXEC=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --duration)   DURATION="$2"; shift 2 ;;
+        --interval)   INTERVAL="$2"; shift 2 ;;
+        --mode)       MODE="$2";     shift 2 ;;
+        --vertex)     VERTEX="--vertex"; shift ;;
+        --image)      IMAGE="$2";    shift 2 ;;
+        --no-reexec)  NO_REEXEC=true; shift ;;
+        -h|--help)    usage; exit 0 ;;
+        *)            echo "Unknown argument: $1"; usage; exit 1 ;;
+    esac
+done
+
+# ── Auto-enter CI container if openshell is not available ────────────
+
+if ! command -v openshell >/dev/null 2>&1 && [[ "$NO_REEXEC" == "false" ]]; then
+    echo "=== openshell not found on PATH, entering CI container ==="
+    echo ""
+
+    CI_IMAGE="openshell:latest"
+    if ! podman image exists "$CI_IMAGE" 2>/dev/null; then
+        echo "Building CI image (make openshell-ci-build)..."
+        make -C "$REPO_ROOT" openshell-ci-build
+    fi
+
+    # The CI image needs a custom supervisor with google-cloud provider
+    # support. See e2e-openshell-sandbox.sh for the tracking issue.
+    SUPERVISOR_IMAGE="${OPENSHELL_SUPERVISOR_IMAGE:-quay.io/mprpic/openshell-supervisor:pr1763}"
+
+    # Forward all original arguments to the re-exec inside the container
+    INNER_ARGS=(--no-reexec --duration "$DURATION" --interval "$INTERVAL" --mode "$MODE")
+    [[ -n "$VERTEX" ]] && INNER_ARGS+=("$VERTEX")
+    [[ -n "$IMAGE" ]] && INNER_ARGS+=(--image "$IMAGE")
+
+    # Build volume mounts: repo + GCP credentials (if present)
+    VOLUMES=(-v "${REPO_ROOT}:/workspace:z")
+    ADC_PATH="$HOME/.config/gcloud/application_default_credentials.json"
+    if [[ -f "$ADC_PATH" ]]; then
+        VOLUMES+=(-v "${ADC_PATH}:/root/.config/gcloud/application_default_credentials.json:ro,z")
+    fi
+
+    # Collect env vars to forward
+    ENV_ARGS=(-e "OPENSHELL_SUPERVISOR_IMAGE=${SUPERVISOR_IMAGE}")
+    [[ -n "${ANTHROPIC_VERTEX_PROJECT_ID:-}" ]] && ENV_ARGS+=(-e "ANTHROPIC_VERTEX_PROJECT_ID")
+    [[ -n "${CLOUD_ML_REGION:-}" ]] && ENV_ARGS+=(-e "CLOUD_ML_REGION")
+    [[ -n "${GOOGLE_CLOUD_PROJECT:-}" ]] && ENV_ARGS+=(-e "GOOGLE_CLOUD_PROJECT")
+    [[ -n "${GCP_PROJECT_ID:-}" ]] && ENV_ARGS+=(-e "GCP_PROJECT_ID")
+    [[ -n "${VERTEX_LOCATION:-}" ]] && ENV_ARGS+=(-e "VERTEX_LOCATION")
+    [[ -n "${ANTHROPIC_API_KEY:-}" ]] && ENV_ARGS+=(-e "ANTHROPIC_API_KEY")
+
+    echo "  CI image:          $CI_IMAGE"
+    echo "  Supervisor image:  $SUPERVISOR_IMAGE"
+    echo "  Mounting repo:     $REPO_ROOT -> /workspace"
+    [[ -f "$ADC_PATH" ]] && echo "  Mounting GCP ADC:  $ADC_PATH"
+    echo ""
+
+    # Re-install agentic-ci from the mounted repo so the probe scripts
+    # and any local changes are picked up.
+    exec podman run --rm -it \
+        --privileged \
+        --security-opt label=disable \
+        "${VOLUMES[@]}" \
+        "${ENV_ARGS[@]}" \
+        "$CI_IMAGE" \
+        bash -c '
+            # subuid/subgid needed for rootless podman inside the container
+            : > /etc/subuid; : > /etc/subgid
+            echo "root:100000:65536" >> /etc/subuid
+            echo "root:100000:65536" >> /etc/subgid
+
+            # Reinstall agentic-ci from mounted source
+            uv pip install --system --quiet /workspace 2>&1 | tail -1
+
+            exec /workspace/scripts/reproduce-proxy-hang.sh '"$(printf "'%s' " "${INNER_ARGS[@]}")"'
+        '
+fi
+
+# ── From here on, openshell is available (native or inside container) ─
+
+trap cleanup EXIT
+
+WORKDIR="$(mktemp -d /tmp/proxy-probe-XXXXXX)"
+cp "$SCRIPT_DIR/proxy-probe.py" "$WORKDIR/"
+
+echo "=== OpenShell proxy hang reproducer ==="
+echo "  Mode:     $MODE"
+echo "  Duration: ${DURATION}s"
+echo "  Interval: ${INTERVAL}s"
+echo "  Vertex:   ${VERTEX:-no}"
+echo "  Workdir:  $WORKDIR"
+echo ""
+
+# Print component versions (same as e2e tests)
+echo "--- Component versions ---"
+echo "  agentic-ci:        $(agentic-ci --version 2>&1 || echo unknown)"
+echo "  openshell:         $(openshell --version 2>&1 || echo unknown)"
+echo "  openshell-gateway: $(openshell-gateway --version 2>&1 || echo unknown)"
+echo "  podman:            $(podman --version 2>&1 || echo unknown)"
+echo ""
+
+# ── Set up sandbox ───────────────────────────────────────────────────
+
+IMAGE_ARG=""
+if [[ -n "$IMAGE" ]]; then
+    IMAGE_ARG="--image $IMAGE"
+fi
+
+# shellcheck disable=SC2086
+agentic-ci setup --backend openshell --workdir "$WORKDIR" $IMAGE_ARG
+
+# ── Tail gateway log for rotation events ─────────────────────────────
+
+GATEWAY_LOG=""
+GATEWAY_LOG=$(find ~/.local/state/openshell -name 'gateway-*.log' -printf '%T@ %p\n' 2>/dev/null \
+    | sort -rn | head -1 | cut -d' ' -f2-) || true
+
+if [[ -n "$GATEWAY_LOG" ]]; then
+    echo ""
+    echo "--- Gateway log: $GATEWAY_LOG ---"
+    echo "    (filtering for rotate/refresh/error/timeout events)"
+    echo ""
+    tail -f "$GATEWAY_LOG" 2>/dev/null \
+        | grep --line-buffered -iE 'rotat|refresh|error|timeout|disconnect|expire' \
+        | sed 's/^/  [gateway] /' &
+    GW_TAIL_PID=$!
+fi
+
+# ── Run probe inside sandbox ─────────────────────────────────────────
+
+WORKDIR_BASE="$(basename "$WORKDIR")"
+SANDBOX_PROBE="/sandbox/${WORKDIR_BASE}/proxy-probe.py"
+
+echo ""
+echo "=== Running probe inside sandbox ==="
+echo ""
+
+# shellcheck disable=SC2086
+openshell sandbox exec --name ci --no-tty -- \
+    python3 "$SANDBOX_PROBE" \
+    --duration "$DURATION" \
+    --interval "$INTERVAL" \
+    --mode "$MODE" \
+    $VERTEX
+
+echo ""
+echo "=== Probe complete ==="


### PR DESCRIPTION
## Summary

Add reproducer scripts to help diagnose the OpenShell MITM proxy hang/timeout issue that caused the [rfe-assessor job](https://gitlab.com/redhat/rhel-ai/agentic-ci/rfe-assessor/-/jobs/14934166475) to fail at wave 40 (1200/1995 issues assessed, $211 spent, 95 minutes in). The agent's Vertex AI API call timed out around 5 minutes, and Claude Code did not retry, ending the run.

Jason confirmed via local experiments that Claude Code does not retry on timeouts, and suspects the root cause is in OpenShell's MITM proxy — possibly related to token rotation or a hung connection in the CONNECT tunnel.

## Run it on your laptop

```bash
# From the repo root — that's it. The script builds the CI image
# (openshell + gateway + podman) and re-execs itself inside a
# privileged container with the repo and GCP credentials mounted.

# Quick 5-minute connectivity test
./scripts/reproduce-proxy-hang.sh --duration 300

# 2-hour soak test with Vertex AI calls (exact production code path)
./scripts/reproduce-proxy-hang.sh --vertex --duration 7200

# Simulate long inference calls (hold connections for 2 min each)
./scripts/reproduce-proxy-hang.sh --mode sustained --interval 120
```

**Prerequisites**: `podman` and GCP credentials at `~/.config/gcloud/application_default_credentials.json`. Set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` in your shell for `--vertex` mode.

**How it works**: The script checks if `openshell` is on PATH. If not, it runs `make openshell-ci-build` to build the CI image (UBI10 + OpenShell 0.0.55 + gateway + podman), then `podman run --privileged` into it with the repo mounted at `/workspace` and your GCP ADC file mounted read-only. Inside the container, it reinstalls `agentic-ci` from the mounted source (so local changes are picked up), then runs the probe. On exit, the sandbox and gateway are cleaned up via `agentic-ci stop`.

If you already have `openshell` and `openshell-gateway` installed natively, the script runs directly without the container layer.

## Context & Investigation

### What happened

The rfe-assessor ran for 95 minutes inside an OpenShell sandbox, processing 40 waves of 30 issues each. At wave 40, a Vertex AI API call hung for ~5 minutes, then Claude Code stopped (`stop_sequence` after 402 turns). The `_assessment_incomplete` check correctly caught the missing `scores.csv` and failed the job.

### Key observations

- OTEL rate dropped to 1 token/s at 06:39 (from hundreds/s earlier)
- No `[token-keepalive] rotate failed` messages in the logs
- The process exit was `rc=-9` (normal `proc.kill()` teardown from [`backend.py`](https://github.com/opendatahub-io/agentic-ci/blob/main/src/agentic_ci/backend.py)), not an external kill
- Jason's local experiments confirmed **timeouts are not retried** by Claude Code

### How agentic-ci routes Vertex AI traffic through OpenShell

agentic-ci configures Vertex AI endpoints as **L4-only** (CONNECT tunneling), not L7 — see [`policy.py:13-14`](https://github.com/opendatahub-io/agentic-ci/blob/main/src/agentic_ci/backends/openshell/policy.py#L13-L14):

```python
# No protocol is specified so endpoints are L4-only (CONNECT tunneling).
# Using protocol=rest would enable L7 inspection which blocks CONNECT
# requests that Vertex AI streaming/gRPC clients use.
```

The credential refresh worker in the gateway mints JWT tokens on a 60s interval ([`provider.py:173-186`](https://github.com/opendatahub-io/agentic-ci/blob/main/src/agentic_ci/backends/openshell/provider.py#L173-L186)). If a rotation races with an active API call, or the supervisor loses its gateway session, the CONNECT tunnel could hang.

### Relevant OpenShell issues

| Issue | Title | Relevance |
|-------|-------|-----------|
| [#866](https://github.com/NVIDIA/OpenShell/issues/866) | L7 proxy `CHUNK_IDLE_TIMEOUT` hardcoded to 120s | L7-only (doesn't apply to L4 CONNECT tunnels), but an analogous L4 timeout may exist in the relay code |
| [#1954](https://github.com/NVIDIA/OpenShell/issues/1954) | Supervisor session token expiry with proactive reconnect | **Most likely root cause**: the `ConnectSupervisor` bidirectional stream isn't re-authenticated when the gateway rotates tokens — if the session expires, all active CONNECT tunnels through that supervisor die |
| [#1306](https://github.com/NVIDIA/OpenShell/issues/1306) | Gateway-owned credential refresh for short-lived tokens | The feature agentic-ci uses for token rotation; still in progress, may have edge cases |
| [#1942](https://github.com/NVIDIA/OpenShell/issues/1942) | Forward proxy stale-policy race at startup | Startup race in the forward proxy; related but not the long-running failure mode |
| [PR #1349](https://github.com/NVIDIA/OpenShell/pull/1349) | Credential refresh foundation (merged May 19) | The implementation of `provider refresh configure/rotate` that agentic-ci calls |

### Hypotheses for the 5-minute hang

1. **Supervisor session token expiry** ([#1954](https://github.com/NVIDIA/OpenShell/issues/1954)): The supervisor's gateway session token expires mid-run, the bidirectional stream dies, and all active L4 CONNECT tunnels through it are severed. The application sees a connection hang until TCP keepalive kicks in (~5 min on some Linux defaults).
2. **Token rotation race**: The gateway rotates the GCP access token while a Vertex AI request is in-flight. The old token is revoked, the new one isn't yet propagated to the sandbox, and the request fails with no retry.
3. **L4 CONNECT tunnel idle timeout**: An undocumented idle timeout in the OpenShell supervisor's TCP relay code kills long-lived connections.

## What this PR adds

### `scripts/proxy-probe.py`

A stdlib-only Python script that runs inside the OpenShell sandbox:

- **Rapid mode** (default): Makes HTTPS GET requests to `github.com`, `pypi.org`, `gitlab.com` every N seconds through the L4 CONNECT tunnel. Logs precise timing, flags slow (>5s) and hung (>30s) requests.
- **Sustained mode** (`--mode sustained`): Opens TLS connections and holds them for configurable periods, reading one byte at a time with sleeps. Simulates what Claude Code does during a long inference call — tests whether the L4 CONNECT tunnel drops idle or slow connections.
- **Vertex AI mode** (`--vertex`): Adds minimal Vertex AI API calls (`max_tokens=1`) to test the exact code path that failed. Requires GCP credentials in the sandbox.
- Prints a summary at the end with failure count, max latency, and hang count.

### `scripts/reproduce-proxy-hang.sh`

Shell wrapper that orchestrates the full reproduction:

1. Checks if `openshell` is on PATH; if not, builds the CI image (`make openshell-ci-build`) and re-execs inside a privileged container with the repo and GCP credentials mounted
2. Creates a temp workdir with the probe script
3. Runs `agentic-ci setup --backend openshell` (identical gateway/provider/policy/sandbox config as production)
4. Tails the gateway log filtered for `rotate|refresh|error|timeout|disconnect|expire` events
5. Runs the probe inside the sandbox via `openshell sandbox exec`
6. Cleans up on exit (trap)

### Example output

```
[     0.0s] 09:15:01 OK   github         0.234s status=200
[     0.0s] 09:15:01 OK   pypi           0.189s status=200
[     0.0s] 09:15:02 OK   gitlab         0.312s status=200
[    10.0s] 09:15:12 OK   github         0.198s status=200
...
[  3601.2s] 10:15:02 FAIL github         30.001s status=None TIMEOUT
...
============================================================
PROBE SUMMARY
  Wall time:     7200.1s
  Requests:      2160
  Failures:      3 (0.1%)
  Slow (>5s):    3
  Hangs (>30s):  1
  Max latency:   30.001s
============================================================
```

Gateway log tail (runs in parallel):
```
  [gateway] 2026-06-19T10:14:58Z INFO credential refresh: rotating GCP_SA_ACCESS_TOKEN for ci-gcp
  [gateway] 2026-06-19T10:15:00Z ERROR credential refresh: rotation failed for ci-gcp: timeout
```

## Test plan

- [ ] Run `python3 -m py_compile scripts/proxy-probe.py` — passes
- [ ] Run `shellcheck scripts/reproduce-proxy-hang.sh` — passes
- [ ] Run `ruff check scripts/proxy-probe.py` — passes
- [ ] Run `./scripts/reproduce-proxy-hang.sh --duration 300` on a laptop with podman — auto-builds CI image, probe completes
- [ ] Run with `--mode sustained` — connections held without premature drops
- [ ] Run with `--vertex` on a machine with GCP credentials — Vertex calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)