### PR TITLE
Add wildcard subdomain for gitlab.com in OpenShell policy

### DIFF
--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -15,6 +15,7 @@ DEFAULT_ENDPOINTS = [
     "github.com:443:full",
     "*.github.com:443:full",
     "gitlab.com:443:full",
+    "*.gitlab.com:443:full",
     "pypi.org:443:read-only",
     "files.pythonhosted.org:443:read-only",
     "aiplatform.googleapis.com:443:read-write",


### PR DESCRIPTION
## Summary

- Add `*.gitlab.com:443:full` to the default OpenShell network policy, matching the existing `*.github.com` wildcard pattern

The proxy probe reproducer (`scripts/reproduce-proxy-hang.sh` from #151) showed consistent `403 Forbidden` CONNECT tunnel rejections for `gitlab.com` after ~74 minutes of a long-running sandbox session, while `github.com` and `pypi.org` kept working. The difference: GitHub had both `github.com` and `*.gitlab.com` in the policy, GitLab only had the bare domain.

## Test plan

- [x] `tox -e py313` passes (566 tests)
- [x] `tox -e lint` passes
- [x] `tox -e check-format` passes
- [x] `tox -e typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenShell now supports GitLab subdomain endpoints by default, enabling broader integration with GitLab instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->