### PR TITLE
RHAIFIRST-130: Compare committed state in get_changed_files()

### DIFF
--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -440,7 +440,10 @@ class GitDiffError(Exception):
 
 
 def get_changed_files(repo_dir: Path, base_ref: str = "HEAD~1") -> list[str]:
-    """Get list of files changed relative to base_ref.
+    """Return files changed between *base_ref* and HEAD (committed state only).
+
+    Uses the two-ref form ``git diff --name-only <base_ref> HEAD`` so that
+    untracked working-tree files are excluded from the result.
 
     Raises GitDiffError if the git command fails.
     """
@@ -448,7 +451,7 @@ def get_changed_files(repo_dir: Path, base_ref: str = "HEAD~1") -> list[str]:
         raise GitDiffError(f"Invalid ref name: {base_ref}")
     try:
         result = subprocess.run(
-            ["git", "diff", "--name-only", base_ref],
+            ["git", "diff", "--name-only", base_ref, "HEAD"],
             cwd=str(repo_dir),
             capture_output=True,
             text=True,

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -4,7 +4,13 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
-from agentic_ci.git import checkout_branch, get_default_branch, git_output, strip_committed_files
+from agentic_ci.git import (
+    checkout_branch,
+    get_changed_files,
+    get_default_branch,
+    git_output,
+    strip_committed_files,
+)
 
 
 class TestCheckoutBranch:
@@ -183,3 +189,25 @@ class TestStripCommittedFiles:
         strip_committed_files(repo, ["output/*"])
 
         assert verdict.exists()
+
+    def test_stripped_file_excluded_from_get_changed_files(self, tmp_path: Path):
+        """After stripping, get_changed_files must not report the file."""
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "autofix-output").mkdir()
+        (repo / "autofix-output" / "verdict.json").write_text("{}")
+        (repo / "fix.py").write_text("print('fix')\n")
+        subprocess.run(
+            ["git", "add", "-f", "autofix-output/verdict.json", "fix.py"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "fix"], cwd=str(repo), capture_output=True, check=True
+        )
+
+        strip_committed_files(repo, ["autofix-output/*"])
+
+        changed = get_changed_files(repo, base_ref="origin/HEAD")
+        assert "fix.py" in changed
+        assert "autofix-output/verdict.json" not in changed


### PR DESCRIPTION
## Summary

`get_changed_files()` uses the single-ref form `git diff --name-only <base_ref>`, which compares `<base_ref>` to the **working tree**. This includes untracked files that exist on disk but are not committed, causing false positive post-gate blocks after artifact stripping.

The fix switches to the two-ref form `git diff --name-only <base_ref> HEAD`, which compares only committed state. All three callers (`strip_committed_files`, `run_all_post_gates` in autofix, and the `_run_sensitive_files` CLI gate) need committed-state comparison only.

### Root cause

In the autofix iterate pipeline, after the agent runs:

1. `strip_committed_files()` successfully removes `autofix-output/.autofix-verdict.json` from the commit (`git rm --cached` + `git commit --amend`)
2. The file remains in the working tree (by design, needed for verdict validation)
3. `run_all_post_gates()` calls `get_changed_files("origin/HEAD")` which runs `git diff --name-only origin/HEAD` — this still sees the file because it compares to the working tree, not HEAD
4. `check_sensitive_files()` matches it against the `autofix-output/*` blocklist → gate failure → ticket blocked

### What changed

- **`src/agentic_ci/git.py`**: `get_changed_files()` now uses `["git", "diff", "--name-only", base_ref, "HEAD"]` instead of `["git", "diff", "--name-only", base_ref]`. Updated docstring to clarify it returns committed-state-only diffs.
- **`tests/test_git.py`**: Added `test_stripped_file_excluded_from_get_changed_files` which verifies that after stripping an artifact file from the commit, `get_changed_files()` does not report it (even though it persists in the working tree).

### Observed failure

- **Pipeline job**: https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14955663704
- **Ticket**: RHOAIENG-68311 (iterate mode, ODH-Build-Config)
- **Error**: `Post-gate failures: ['Sensitive files modified: autofix-output/.autofix-verdict.json']`
- **Jira**: https://redhat.atlassian.net/browse/RHAIFIRST-130

## Test plan

- [x] Existing `TestStripCommittedFiles` tests pass (3/3)
- [x] New `test_stripped_file_excluded_from_get_changed_files` passes
- [x] `TestRunSensitiveFiles` gate registry tests pass (2/2)
- [ ] Re-run RHOAIENG-68311 iterate after deploying updated `agentic-ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced change detection accuracy by restricting results to only committed modifications between specified references, ensuring untracked working-tree files are properly excluded from results.

* **Tests**
  * Added test coverage for file stripping functionality integrated with change detection to verify that excluded files are correctly omitted from change reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->