### PR TITLE
RHAIFIRST-130: Add error handling to strip_committed_files()

### DIFF
--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -443,7 +443,8 @@ def get_changed_files(repo_dir: Path, base_ref: str = "HEAD~1") -> list[str]:
     """Return files changed between *base_ref* and HEAD (committed state only).
 
     Uses the two-ref form ``git diff --name-only <base_ref> HEAD`` so that
-    untracked working-tree files are excluded from the result.
+    files still in HEAD after a failed ``git commit --amend`` are detected
+    even when ``git rm --cached`` already removed them from the index.
 
     Raises GitDiffError if the git command fails.
     """
@@ -476,7 +477,8 @@ def strip_committed_files(
     given fnmatch *patterns* and amends the commit to remove them, keeping
     the working-tree copies intact.
 
-    Returns the list of file paths that were stripped (empty if none matched).
+    Returns the list of file paths actually stripped (empty if none matched
+    or all removals failed).
     """
     try:
         changed = get_changed_files(repo_dir, base_ref=base_ref)
@@ -499,18 +501,39 @@ def strip_committed_files(
         len(to_remove),
         ", ".join(to_remove),
     )
+    actually_removed = []
     for filepath in to_remove:
-        subprocess.run(
+        result = subprocess.run(
             ["git", "rm", "--cached", "--quiet", filepath],
             cwd=str(repo_dir),
             capture_output=True,
+            text=True,
         )
-    subprocess.run(
-        ["git", "commit", "--amend", "--no-edit", "--allow-empty"],
-        cwd=str(repo_dir),
-        capture_output=True,
-    )
-    return to_remove
+        if result.returncode != 0:
+            log.error(
+                "git rm --cached failed for %s (rc=%d): %s",
+                filepath,
+                result.returncode,
+                result.stderr.strip(),
+            )
+        else:
+            actually_removed.append(filepath)
+
+    if actually_removed:
+        result = subprocess.run(
+            ["git", "commit", "--amend", "--no-edit", "--allow-empty"],
+            cwd=str(repo_dir),
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            log.error(
+                "git commit --amend failed after stripping (rc=%d): %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+
+    return actually_removed
 
 
 # -- Git credential setup ----------------------------------------------------

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -211,3 +211,71 @@ class TestStripCommittedFiles:
         changed = get_changed_files(repo, base_ref="origin/HEAD")
         assert "fix.py" in changed
         assert "autofix-output/verdict.json" not in changed
+
+    def test_logs_git_rm_failure(self, tmp_path: Path, caplog):
+        """When git rm --cached fails, log the error with stderr details."""
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "autofix-output").mkdir()
+        (repo / "autofix-output" / "verdict.json").write_text("{}")
+        (repo / "fix.py").write_text("print('fix')\n")
+        subprocess.run(
+            ["git", "add", "-f", "autofix-output/verdict.json", "fix.py"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "fix"], cwd=str(repo), capture_output=True, check=True
+        )
+
+        original_run = subprocess.run
+
+        def _sabotage_rm(cmd, **kw):
+            if cmd[:3] == ["git", "rm", "--cached"] and "verdict.json" in cmd[-1]:
+                return subprocess.CompletedProcess(cmd, 128, "", "fatal: not removing")
+            return original_run(cmd, **kw)
+
+        with patch("agentic_ci.git.subprocess.run", side_effect=_sabotage_rm):
+            with caplog.at_level("ERROR", logger="agentic_ci.git"):
+                stripped = strip_committed_files(repo, ["autofix-output/*"])
+
+        assert stripped == []
+        assert any("git rm --cached failed" in r.message for r in caplog.records)
+        assert any("fatal: not removing" in r.message for r in caplog.records)
+
+    def test_strip_across_multiple_commits(self, tmp_path: Path):
+        """Artifact committed in an earlier commit is stripped by amending HEAD."""
+        repo = _init_repo(tmp_path / "repo")
+        (repo / "autofix-output").mkdir()
+        (repo / "autofix-output" / "verdict.json").write_text('{"v":1}')
+        (repo / "fix.py").write_text("print('fix')\n")
+        subprocess.run(
+            ["git", "add", "-f", "autofix-output/verdict.json", "fix.py"],
+            cwd=str(repo),
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "commit 1"], cwd=str(repo), capture_output=True, check=True
+        )
+        (repo / "fix2.py").write_text("print('fix2')\n")
+        subprocess.run(["git", "add", "fix2.py"], cwd=str(repo), capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "commit 2"], cwd=str(repo), capture_output=True, check=True
+        )
+
+        stripped = strip_committed_files(repo, ["autofix-output/*"])
+
+        assert stripped == ["autofix-output/verdict.json"]
+        result = subprocess.run(
+            ["git", "diff", "--name-only", "origin/HEAD"],
+            cwd=str(repo),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        changed = [f for f in result.stdout.strip().split("\n") if f]
+        assert "autofix-output/verdict.json" not in changed
+        assert "fix.py" in changed
+        assert "fix2.py" in changed
+        assert (repo / "autofix-output" / "verdict.json").exists()


### PR DESCRIPTION
## Summary

Follow-up to #157. `strip_committed_files()` silently swallowed git operation failures, making it impossible to diagnose why artifact files remained committed after stripping.

**This PR is diagnostic, not curative.** It surfaces the git stderr so we can identify the root cause on the next occurrence. The ticket will still be blocked, but we'll know why.

### What changed

**`src/agentic_ci/git.py`**:
- `strip_committed_files()` now checks the return code of `git rm --cached` and `git commit --amend`. On failure, logs an ERROR with git stderr.
- Returns only files actually removed (`actually_removed`) instead of all matched files. Callers no longer log "Stripped X" for files that weren't stripped.
- Skips amend when no files were actually removed from the index.
- Updated `get_changed_files()` docstring: the two-ref form's real value is catching files still in HEAD after a failed amend, not excluding untracked files (single-ref already does that).

**`tests/test_git.py`**:
- `test_logs_git_rm_failure`: Verifies error + stderr are logged when rm fails, and failed files are excluded from the return value.
- `test_strip_across_multiple_commits` (e2e): Verifies stripping across multi-commit branches.

### Investigation findings

**The exclude mechanism works correctly:**
- `autofix-output/` is in `.git/info/exclude` (set up by `exclude_agent_output()` before the container starts)
- `git add .` does NOT stage files under `autofix-output/` (git skips them)
- Even explicit `git add autofix-output/.autofix-verdict.json` fails with exit 1 (git refuses)
- Only `git add -f` can bypass the exclude

**The failing PR (opendatahub-io/ODH-Build-Config#2184) currently has no verdict file in any commit.** The branch was rewritten since the failure. So we can't inspect the git state at the time of the failure.

**Empirical git diff testing (5 scenarios) confirmed:**
- `git diff --name-only origin/HEAD` (single-ref) does NOT show untracked files
- After successful `git rm --cached` + amend, the file disappears from both single-ref and two-ref diffs
- After `git rm --cached` WITHOUT amend: single-ref hides the file, two-ref correctly shows it (defending #157's value)

**Conclusion:** Since the single-ref form showed the file in the [failing job](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/14955663704), and the exclude prevents staging, either `git rm --cached` failed silently (most likely — this PR catches that), or the file was committed via `git add -f` inside the container (which the skill prohibits). The error logs from this PR will reveal which.

## Test plan

- [x] All `TestStripCommittedFiles` tests pass (6/6)
- [x] Gate registry tests pass (7/7)
- [ ] Wait for next CI occurrence to collect diagnostic stderr