### PR TITLE
feat: add OpenCode OTel support

### DIFF
--- a/docs/otel-configuration.md
+++ b/docs/otel-configuration.md
@@ -1,0 +1,61 @@
+# OTel Configuration by Harness
+
+Each agent harness configures OpenTelemetry differently based on the
+agent CLI's telemetry implementation. The local OTLP collector accepts
+all signals (metrics, logs, traces) regardless of harness — the
+differences are in what the agent exports and what env vars control it.
+
+## Claude Code
+
+Claude Code has its own telemetry system that exports via the standard
+OTLP protocol.
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `CLAUDE_CODE_ENABLE_TELEMETRY` | `1` | Master switch for telemetry export |
+| `OTEL_METRICS_EXPORTER` | `otlp` | Export metrics (token counts, cost) |
+| `OTEL_LOGS_EXPORTER` | `otlp` | Export log events (API requests, tool decisions) |
+| `OTEL_TRACES_EXPORTER` | `otlp` | Export trace spans (tool calls, LLM requests) |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/json` | OTLP wire format |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://...:{port}` | Collector address |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `10000` | Export metrics every 10s. Controls Claude Code's OTel metrics SDK export frequency. |
+| `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA` | `1` | Rich span hierarchy with tool nesting and subagent spans |
+| `OTEL_LOG_USER_PROMPTS` | `1` | Include user prompt text in spans |
+| `OTEL_LOG_TOOL_DETAILS` | `1` | Include tool input parameters in spans |
+| `OTEL_LOG_TOOL_CONTENT` | `1` | Include tool output/results in spans |
+
+**Not set:** `OTEL_BSP_SCHEDULE_DELAY` — Claude Code manages its own
+span flush lifecycle, so the default batch processor delay is fine.
+
+## OpenCode
+
+OpenCode uses the Vercel AI SDK's OpenTelemetry integration. OTel must
+be enabled in `opencode.json` (`experimental.openTelemetry: true`) in
+addition to the env vars — the harness writes this config automatically
+via `write_sandbox_config()`.
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://...:{port}` | Collector address |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `http/json` | OTLP wire format |
+| `OTEL_BSP_SCHEDULE_DELAY` | `0` | Flush spans immediately. Required because OpenCode calls `process.exit()` which kills the Node.js process before the OTel batch span processor can drain its queue. Without this, spans are lost. |
+
+**Not set:**
+
+- `CLAUDE_CODE_ENABLE_TELEMETRY` — Claude-specific, not used by OpenCode
+- `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` — OpenCode doesn't
+  export metrics or logs via OTel. Cost and token data come from JSON
+  stdout events (`step_finish` type), not from the OTel pipeline.
+- `OTEL_METRIC_EXPORT_INTERVAL` — no OTel metrics to export
+- `OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_*` — Claude-specific flags
+
+## Sandbox config
+
+The `opencode.json` config is written by `write_sandbox_config()` and
+mounted into the container by the backend:
+
+- **Podman**: mounted as a read-only volume via `sandbox_config_mounts()`
+- **OpenShell**: uploaded and moved into place via `_upload_sandbox_config()`
+
+Claude Code does not require sandbox config for OTel — env vars are
+sufficient.

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -132,13 +132,16 @@ class OpenShellBackend(Backend):
     def _upload_sandbox_config(self, otel_enabled=False):
         """Write harness-specific config and upload it to the sandbox."""
         config_dir = tempfile.mkdtemp(prefix="agentic-ci-config-")
-        self.harness.write_sandbox_config(config_dir, otel_enabled=otel_enabled)
-        for host_path, container_path in self.harness.sandbox_config_mounts(config_dir):
-            sandbox.upload(host_path)
-            fname = os.path.basename(host_path)
-            cmd = f"mkdir -p $(dirname {container_path}) && mv {fname} {container_path}"
-            sandbox.exec_cmd(["bash", "-c", cmd])
-        shutil.rmtree(config_dir, ignore_errors=True)
+        try:
+            self.harness.write_sandbox_config(config_dir, otel_enabled=otel_enabled)
+            for host_path, container_path in self.harness.sandbox_config_mounts(config_dir):
+                sandbox.upload(host_path)
+                fname = os.path.basename(host_path)
+                target_dir = os.path.dirname(container_path)
+                sandbox.exec_cmd(["mkdir", "-p", target_dir])
+                sandbox.exec_cmd(["mv", fname, container_path])
+        finally:
+            shutil.rmtree(config_dir, ignore_errors=True)
 
     def stop(self):
         try:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import shlex
+import shutil
 import subprocess
 import tempfile
 import threading
@@ -126,6 +127,19 @@ class OpenShellBackend(Backend):
         log.section("Uploading workdir")
         sandbox.upload(self.workdir)
 
+        self._upload_sandbox_config(otel_enabled=otel_port is not None)
+
+    def _upload_sandbox_config(self, otel_enabled=False):
+        """Write harness-specific config and upload it to the sandbox."""
+        config_dir = tempfile.mkdtemp(prefix="agentic-ci-config-")
+        self.harness.write_sandbox_config(config_dir, otel_enabled=otel_enabled)
+        for host_path, container_path in self.harness.sandbox_config_mounts(config_dir):
+            sandbox.upload(host_path)
+            fname = os.path.basename(host_path)
+            cmd = f"mkdir -p $(dirname {container_path}) && mv {fname} {container_path}"
+            sandbox.exec_cmd(["bash", "-c", cmd])
+        shutil.rmtree(config_dir, ignore_errors=True)
+
     def stop(self):
         try:
             if gateway.is_running() and sandbox.exists():
@@ -190,26 +204,13 @@ class OpenShellBackend(Backend):
     def _write_env_script(self, model, otel_port=None, otel_rate_file=None):
         """Write env vars to a script inside the sandbox, sourced before the agent runs.
 
-        Uses the harness's native env script (Vertex AI vars or API key)
-        since the google-cloud provider injects GCP credentials directly.
-
-        For OTEL, uses ``host.openshell.internal`` to reach the host-side
-        collector through the gateway proxy instead of the harness default
-        (which uses an IP unreachable from the sandbox).
+        Uses the harness's native env script (Vertex AI vars, API key, and
+        OTEL vars) since the google-cloud provider injects GCP credentials
+        directly. The harness handles OTEL endpoint configuration using the
+        gateway host address.
         """
-        lines = self.harness.build_env_script_lines()
-        if otel_port:
-            lines.extend(
-                [
-                    "export CLAUDE_CODE_ENABLE_TELEMETRY=1",
-                    "export OTEL_METRICS_EXPORTER=otlp",
-                    "export OTEL_LOGS_EXPORTER=otlp",
-                    "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
-                    f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://{_OPENSHELL_HOST}:{otel_port}",
-                    "export OTEL_METRIC_EXPORT_INTERVAL=5000",
-                ]
-            )
-        else:
+        lines = self.harness.build_env_script_lines(otel_port=otel_port)
+        if not otel_port and self.harness.name == "Claude Code":
             lines.append("export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")
 
         if self.harness.auth_mode == "vertex":

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -44,6 +44,7 @@ class PodmanBackend(Backend):
         self._resolve_image()
         if self.harness.auth_mode == "vertex":
             self._resolve_credentials()
+        self._resolve_sandbox_config(otel_enabled=otel_port is not None)
 
         if self.is_running():
             log.section("Podman container already running")
@@ -221,6 +222,11 @@ class PodmanBackend(Backend):
             args.extend(["--env", f"{key}={val}"])
         return args
 
+    def _resolve_sandbox_config(self, otel_enabled=False):
+        if self._config_dir is None:
+            self._config_dir = tempfile.mkdtemp(prefix="agentic-ci-podman-")
+        self.harness.write_sandbox_config(self._config_dir, otel_enabled=otel_enabled)
+
     def _build_vol_args(self):
         vols = ["-v", f"{self.workdir}:/workspace:z"]
         if self._config_dir is not None:
@@ -238,12 +244,15 @@ class PodmanBackend(Backend):
                 "configurations",
                 "config_default",
             )
-            vols.extend(
-                [
-                    "-v",
-                    f"{adc}:{mount_target}/.config/gcloud/application_default_credentials.json:ro,z",
-                    "-v",
-                    f"{config}:{mount_target}/.config/gcloud/configurations/config_default:ro,z",
-                ]
-            )
+            if os.path.exists(adc):
+                vols.extend(
+                    [
+                        "-v",
+                        f"{adc}:{mount_target}/.config/gcloud/application_default_credentials.json:ro,z",
+                        "-v",
+                        f"{config}:{mount_target}/.config/gcloud/configurations/config_default:ro,z",
+                    ]
+                )
+            for host_path, container_path in self.harness.sandbox_config_mounts(self._config_dir):
+                vols.extend(["-v", f"{host_path}:{container_path}:ro,z"])
         return vols

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -324,6 +324,8 @@ class OpenCodeHarness(Harness):
             "--env",
             "AGENT_TOOL=opencode",
             "--env",
+            f"OPENCODE_CONFIG_DIR={self._CONTAINER_CONFIG_DIR}",
+            "--env",
             "OPENCODE_DISABLE_AUTOUPDATE=1",
         ]
         if self.auth_mode == "api-key":
@@ -447,7 +449,7 @@ class OpenCodeHarness(Harness):
     def autoupdater_env_var(self):
         return "OPENCODE_DISABLE_AUTOUPDATE"
 
-    _SANDBOX_CONFIG_DIR = "/sandbox/.config/opencode"
+    _CONTAINER_CONFIG_DIR = "/sandbox/.config/opencode"
 
     def write_sandbox_config(self, config_dir, otel_enabled=False):
         opencode_dir = os.path.join(config_dir, ".config", "opencode")
@@ -461,7 +463,7 @@ class OpenCodeHarness(Harness):
     def sandbox_config_mounts(self, config_dir):
         host_path = os.path.join(config_dir, ".config", "opencode", "opencode.json")
         if os.path.exists(host_path):
-            return [(host_path, f"{self._SANDBOX_CONFIG_DIR}/opencode.json")]
+            return [(host_path, f"{self._CONTAINER_CONFIG_DIR}/opencode.json")]
         return []
 
 

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -5,6 +5,7 @@ A harness encapsulates everything specific to a particular agent CLI
 it needs, where credentials are mounted, and how to parse its output.
 """
 
+import json
 import os
 import shlex
 from abc import ABC, abstractmethod
@@ -101,6 +102,20 @@ class Harness(ABC):
     def autoupdater_env_var(self) -> str:
         """Env var name to disable auto-updates."""
         return "DISABLE_AUTOUPDATER"
+
+    def write_sandbox_config(self, config_dir, otel_enabled=False):
+        """Write agent-specific config files to the sandbox config dir.
+
+        Called by backends before container start. Default is a no-op.
+        """
+
+    def sandbox_config_mounts(self, config_dir):
+        """Return list of (host_path, container_path) for config file mounts.
+
+        Called by backends to mount config files written by write_sandbox_config().
+        Default returns empty list.
+        """
+        return []
 
 
 class ClaudeCodeHarness(Harness):
@@ -346,26 +361,51 @@ class OpenCodeHarness(Harness):
         if enabled_plugins:
             common.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
         if self.auth_mode == "api-key":
-            return [
+            lines = [
                 f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",
                 *common,
             ]
-        project = os.environ.get(
-            "GOOGLE_CLOUD_PROJECT",
-            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
-        )
-        location = os.environ.get(
-            "VERTEX_LOCATION",
-            os.environ.get("CLOUD_ML_REGION", "global"),
-        )
-        return [
-            f"export GOOGLE_CLOUD_PROJECT={shlex.quote(project)}",
-            f"export VERTEX_LOCATION={shlex.quote(location)}",
-            *common,
-        ]
+        else:
+            project = os.environ.get(
+                "GOOGLE_CLOUD_PROJECT",
+                os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+            )
+            location = os.environ.get(
+                "VERTEX_LOCATION",
+                os.environ.get("CLOUD_ML_REGION", "global"),
+            )
+            lines = [
+                f"export GOOGLE_CLOUD_PROJECT={shlex.quote(project)}",
+                f"export VERTEX_LOCATION={shlex.quote(location)}",
+                *common,
+            ]
+        if otel_port:
+            lines.extend(
+                [
+                    f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://{_OPENSHELL_GATEWAY_HOST}:{otel_port}",
+                    "export OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+                    "export OTEL_BSP_SCHEDULE_DELAY=0",
+                ]
+            )
+        return lines
 
     def build_otel_exec_env(self, otel_port=None):
-        return []
+        """Return OTel env vars for OpenCode.
+
+        See docs/otel-configuration.md for why these differ from Claude Code.
+        """
+        if not otel_port:
+            return []
+        return [
+            "--env",
+            f"OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:{otel_port}",
+            "--env",
+            "OTEL_EXPORTER_OTLP_PROTOCOL=http/json",
+            "--env",
+            # Flush spans immediately — OpenCode's process.exit() kills the
+            # Node.js process before the batch processor can drain its queue.
+            "OTEL_BSP_SCHEDULE_DELAY=0",
+        ]
 
     def build_local_env(self, otel_port=None, otel_rate_file=None):
         env = {
@@ -400,8 +440,29 @@ class OpenCodeHarness(Harness):
         return "google-vertex/claude-opus-4-6@default"
 
     @property
+    def supports_otel(self) -> bool:
+        return True
+
+    @property
     def autoupdater_env_var(self):
         return "OPENCODE_DISABLE_AUTOUPDATE"
+
+    _SANDBOX_CONFIG_DIR = "/sandbox/.config/opencode"
+
+    def write_sandbox_config(self, config_dir, otel_enabled=False):
+        opencode_dir = os.path.join(config_dir, ".config", "opencode")
+        os.makedirs(opencode_dir, exist_ok=True)
+        config = {"$schema": "https://opencode.ai/config.json"}
+        if otel_enabled:
+            config["experimental"] = {"openTelemetry": True}
+        with open(os.path.join(opencode_dir, "opencode.json"), "w") as f:
+            json.dump(config, f, indent=2)
+
+    def sandbox_config_mounts(self, config_dir):
+        host_path = os.path.join(config_dir, ".config", "opencode", "opencode.json")
+        if os.path.exists(host_path):
+            return [(host_path, f"{self._SANDBOX_CONFIG_DIR}/opencode.json")]
+        return []
 
 
 def create_harness(name: str) -> Harness:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -286,8 +286,15 @@ class TestOpenCodeHarness:
         lines = harness.build_env_script_lines()
         assert any("GOOGLE_CLOUD_PROJECT=gcp-proj" in line for line in lines)
 
-    def test_build_otel_exec_env_always_empty(self):
-        assert OpenCodeHarness().build_otel_exec_env(otel_port=4318) == []
+    def test_build_otel_exec_env(self):
+        env = OpenCodeHarness().build_otel_exec_env(otel_port=4318)
+        assert "--env" in env
+        assert "OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318" in env
+        assert "OTEL_EXPORTER_OTLP_PROTOCOL=http/json" in env
+        assert "OTEL_BSP_SCHEDULE_DELAY=0" in env
+
+    def test_build_otel_exec_env_none_port(self):
+        assert OpenCodeHarness().build_otel_exec_env(otel_port=None) == []
 
     def test_build_local_env_vertex(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -391,3 +391,47 @@ class TestOpenCodeHarness:
 
     def test_default_model(self):
         assert OpenCodeHarness().default_model() == "google-vertex/claude-opus-4-6@default"
+
+    def test_build_env_script_lines_with_otel(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+        harness = OpenCodeHarness()
+        lines = harness.build_env_script_lines(otel_port=4318)
+        assert any("OTEL_EXPORTER_OTLP_ENDPOINT=" in line for line in lines)
+        assert any("OTEL_EXPORTER_OTLP_PROTOCOL=http/json" in line for line in lines)
+        assert any("OTEL_BSP_SCHEDULE_DELAY=0" in line for line in lines)
+
+    def test_write_sandbox_config_otel_enabled(self, tmp_path):
+        harness = OpenCodeHarness()
+        harness.write_sandbox_config(str(tmp_path), otel_enabled=True)
+        config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+        assert config_file.exists()
+        import json
+
+        config = json.loads(config_file.read_text())
+        assert config["$schema"] == "https://opencode.ai/config.json"
+        assert config["experimental"]["openTelemetry"] is True
+
+    def test_write_sandbox_config_otel_disabled(self, tmp_path):
+        harness = OpenCodeHarness()
+        harness.write_sandbox_config(str(tmp_path), otel_enabled=False)
+        config_file = tmp_path / ".config" / "opencode" / "opencode.json"
+        assert config_file.exists()
+        import json
+
+        config = json.loads(config_file.read_text())
+        assert config["$schema"] == "https://opencode.ai/config.json"
+        assert "experimental" not in config
+
+    def test_sandbox_config_mounts_with_config(self, tmp_path):
+        harness = OpenCodeHarness()
+        harness.write_sandbox_config(str(tmp_path), otel_enabled=True)
+        mounts = harness.sandbox_config_mounts(str(tmp_path))
+        assert len(mounts) == 1
+        host_path, container_path = mounts[0]
+        assert host_path.endswith("opencode.json")
+        assert container_path == "/sandbox/.config/opencode/opencode.json"
+
+    def test_sandbox_config_mounts_without_config(self, tmp_path):
+        harness = OpenCodeHarness()
+        mounts = harness.sandbox_config_mounts(str(tmp_path))
+        assert mounts == []


### PR DESCRIPTION
Reopened from fork (upstream push access changed).

## Changes

- Enable OTel trace export for the OpenCode harness
- Add `write_sandbox_config()` and `sandbox_config_mounts()` to write `opencode.json` with `experimental.openTelemetry`
- OpenShell backend delegates OTel env to harness, uploads sandbox config
- Podman backend mounts config via sandbox_config_mounts
- Set `OPENCODE_CONFIG_DIR` in Podman `build_env_args` to match mount path

## Review feedback addressed

- Tests for `write_sandbox_config`, `sandbox_config_mounts`, `build_env_script_lines` with OTel
- Temp dir cleanup via try/finally
- Shell injection fix: separate `mkdir`/`mv` commands instead of `bash -c`
- Fixed Podman config path mismatch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenTelemetry configuration guide for agent harnesses, covering setup for Claude Code and OpenCode implementations.

* **New Features**
  * Agent harnesses now support sandbox-specific configuration management and mounting.
  * Enhanced OpenTelemetry integration capabilities across agent implementations.

* **Tests**
  * Added test coverage for sandbox configuration and OpenTelemetry settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->