### PR TITLE
fix: handle ProcessLookupError race in SIGTERM kill fallback

### DIFF
--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -95,7 +95,12 @@ class Backend(ABC):
         try:
             proc.wait(timeout=10)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            # Process may exit between wait() timeout and kill(), raising
+            # ProcessLookupError — catch it so cleanup can continue.
+            try:
+                proc.kill()
+            except OSError:
+                pass
             proc.wait()
         stderr_thread.join(timeout=5)
         rc = proc.returncode


### PR DESCRIPTION
## Problem

Follow-up to #164. In the `subprocess.TimeoutExpired` handler, `proc.kill()` can raise `ProcessLookupError` if the process exits between `wait(timeout=10)` timing out and the `kill()` call. This would crash `_process_stream` during cleanup.

## Fix

Wrap `proc.kill()` in `try/except OSError` so cleanup continues gracefully if the process is already gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)