### PR TITLE
re-add Renovate custom manager for acli

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,8 @@
     {
       "matchPackageNames": [
         "agentic-ci",
-        "claude-code"
+        "claude-code",
+        "acli"
       ],
       "minimumReleaseAge": "0 days"
     },
@@ -91,6 +92,18 @@
       "registryUrlTemplate": "https://gitlab.com",
       "versioningTemplate": "semver",
       "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG ACLI_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "acli",
+      "datasourceTemplate": "rpm",
+      "registryUrlTemplate": "https://acli.atlassian.com/linux/rpm/repodata/",
+      "versioningTemplate": "rpm"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
The acli custom manager was removed with an incorrect explanation that the "rpm" datasource was invalid. The datasource is officially supported (https://docs.renovatebot.com/modules/datasource/rpm/) and the registry URL was correct all along.

The actual root cause was that the "rpm" datasource provides no release timestamps. With "minimumReleaseAge: 7 days" set globally, Renovate applies "minimumReleaseAgeBehaviour=timestamp-required" and marks any release without a timestamp as pending indefinitely, so no update PR was ever created.

Re-add the custom manager and exempt acli from the minimum release age check by adding it to the existing "0 days" packageRule alongside "agentic-ci" and "claude-code".

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to enhance automated dependency management for additional packages and container image dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->