### PR TITLE
fix: log experiment lookup errors instead of swallowing

### DIFF
--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -58,8 +58,11 @@ def _resolve_experiment_id(endpoint, name, headers):
         experiments = resp.json().get("experiments", [])
         if experiments:
             return experiments[0]["experiment_id"]
-    except requests.RequestException:
-        pass
+    except requests.RequestException as e:
+        detail = ""
+        if hasattr(e, "response") and e.response is not None:
+            detail = f" ({e.response.status_code}: {e.response.text[:200]})"
+        print(f"Experiment lookup failed{detail}: {e}", file=sys.stderr)
     return None
 
 


### PR DESCRIPTION
The `except RequestException: pass` in `_resolve_experiment_id` silently hid SSL errors, auth failures, and network issues, making trace push failures impossible to debug. Now logs the error details to stderr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for experiment lookups. Failed requests now display HTTP status codes and response details to help diagnose configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->