### PR TITLE
fix: override OTel endpoint for OpenShell sandbox

### DIFF
--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -213,6 +213,11 @@ class OpenShellBackend(Backend):
         gateway host address.
         """
         lines = self.harness.build_env_script_lines(otel_port=otel_port)
+        if otel_port:
+            # The harness sets the OTel endpoint to 10.200.0.1 (the gateway IP
+            # used by the Podman backend). OpenShell sandboxes can't reach that
+            # address — they resolve the host via host.openshell.internal.
+            lines.append(f"export OTEL_EXPORTER_OTLP_ENDPOINT=http://{_OPENSHELL_HOST}:{otel_port}")
         if not otel_port and self.harness.name == "Claude Code":
             lines.append("export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")
 


### PR DESCRIPTION
The harness sets `OTEL_EXPORTER_OTLP_ENDPOINT` to `10.200.0.1` (the gateway IP used by the Podman backend). OpenShell sandboxes can't reach that address — they resolve the host via `host.openshell.internal`.

This was introduced in #167 which delegated OTel env to the harness but didn't account for the OpenShell sandbox's different network topology.

The fix overrides the endpoint in `_write_env_script` after the harness lines, using `host.openshell.internal` which the sandbox can resolve through the gateway proxy.