### PR TITLE
feat: add Vale CLI v3.15.1 to CI images

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -22,6 +22,9 @@ ARG GLAB_SHA256=2e06f278bb1762126e9b695f67baf5e3210df431b2039c76c1991252bf9c0868
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 
+ARG VALE_VERSION=3.15.1
+ARG VALE_SHA256=c024d9c157874fb043d4f24a055d60050d1bb18755251f590593eed5bace1857
+
 # System packages (podman is needed as the OpenShell compute driver)
 RUN dnf install -y --nodocs \
         podman \
@@ -80,6 +83,15 @@ RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
     && mv /tmp/gitleaks/gitleaks /usr/local/bin/gitleaks \
     && chmod +x /usr/local/bin/gitleaks \
     && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
+
+# Vale (pinned)
+RUN curl -fsSL -o /tmp/vale.tar.gz \
+        "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
+    && echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c - \
+    && mkdir /tmp/vale && tar -xzf /tmp/vale.tar.gz -C /tmp/vale \
+    && mv /tmp/vale/vale /usr/local/bin/vale \
+    && chmod +x /usr/local/bin/vale \
+    && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
 ARG ACLI_VERSION=1.3.21~stable-1

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -18,6 +18,9 @@ ARG GLAB_SHA256=2e06f278bb1762126e9b695f67baf5e3210df431b2039c76c1991252bf9c0868
 ARG GITLEAKS_VERSION=8.30.1
 ARG GITLEAKS_SHA256=551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
 
+ARG VALE_VERSION=3.15.1
+ARG VALE_SHA256=c024d9c157874fb043d4f24a055d60050d1bb18755251f590593eed5bace1857
+
 # System packages
 RUN dnf install -y --nodocs \
         podman \
@@ -57,6 +60,15 @@ RUN curl -fsSL -o /tmp/gitleaks.tar.gz \
     && mv /tmp/gitleaks/gitleaks /usr/local/bin/gitleaks \
     && chmod +x /usr/local/bin/gitleaks \
     && rm -rf /tmp/gitleaks.tar.gz /tmp/gitleaks
+
+# Vale (pinned)
+RUN curl -fsSL -o /tmp/vale.tar.gz \
+        "https://github.com/vale-cli/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" \
+    && echo "${VALE_SHA256}  /tmp/vale.tar.gz" | sha256sum -c - \
+    && mkdir /tmp/vale && tar -xzf /tmp/vale.tar.gz -C /tmp/vale \
+    && mv /tmp/vale/vale /usr/local/bin/vale \
+    && chmod +x /usr/local/bin/vale \
+    && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
 ARG ACLI_VERSION=1.3.21~stable-1

--- a/renovate.json
+++ b/renovate.json
@@ -113,6 +113,18 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^images/ci/Containerfile\\.podman$",
+        "^images/ci/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG VALE_VERSION=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "vale-cli/vale",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver",
+      "extractVersionTemplate": "^v?(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         "^images/runner/claude-code/Containerfile$",
         "^images/runner/claude-code/Containerfile\\.openshell$"
       ],

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -243,6 +243,23 @@ def bump_gitleaks(check_only):
     return result
 
 
+def bump_vale(check_only):
+    version = _github_latest("vale-cli/vale")
+    url = (
+        f"https://github.com/vale-cli/vale/releases/download/"
+        f"v{version}/vale_{version}_Linux_64-bit.tar.gz"
+    )
+    sha = _sha256_of_url(url)
+
+    result = {"tool": "vale", "version": version, "sha256": sha}
+    if not check_only:
+        for cf in [CI_CF, OPENSHELL_CI_CF]:
+            if cf.exists():
+                _update_arg(cf, "VALE_VERSION", version)
+                _update_arg(cf, "VALE_SHA256", sha)
+    return result
+
+
 def bump_ruff(check_only):
     data = _fetch_json("https://pypi.org/pypi/ruff/json")
     version = data["info"]["version"]
@@ -279,6 +296,7 @@ TOOLS = {
     "gh": bump_gh,
     "glab": bump_glab,
     "gitleaks": bump_gitleaks,
+    "vale": bump_vale,
     "claude": bump_claude,
     "opencode": bump_opencode,
     "acli": bump_acli,
@@ -403,6 +421,27 @@ def sync_gitleaks():
     return {"tool": "gitleaks", "versions": list(versions)}
 
 
+def sync_vale():
+    versions = {}
+    for cf in [CI_CF, OPENSHELL_CI_CF]:
+        if not cf.exists():
+            continue
+        version = _current_value(cf, "VALE_VERSION")
+        if version:
+            versions.setdefault(version, []).append(cf)
+    if not versions:
+        return {"tool": "vale", "skipped": "VALE_VERSION not found"}
+    for version, files in versions.items():
+        url = (
+            f"https://github.com/vale-cli/vale/releases/download/"
+            f"v{version}/vale_{version}_Linux_64-bit.tar.gz"
+        )
+        sha = _sha256_of_url(url)
+        for cf in files:
+            _update_arg(cf, "VALE_SHA256", sha)
+    return {"tool": "vale", "versions": list(versions)}
+
+
 def sync_claude():
     versions = {}
     for cf in [CLAUDE_CF, OPENSHELL_CLAUDE_CF]:
@@ -461,6 +500,7 @@ SYNC_TOOLS = {
     "gh": sync_gh,
     "glab": sync_glab,
     "gitleaks": sync_gitleaks,
+    "vale": sync_vale,
     "claude": sync_claude,
     "opencode": sync_opencode,
     "acli": sync_acli,
@@ -593,6 +633,7 @@ def main():
             "gh": "GH_VERSION",
             "glab": "GLAB_VERSION",
             "gitleaks": "GITLEAKS_VERSION",
+            "vale": "VALE_VERSION",
             "claude": "CLAUDE_VERSION",
             "opencode": "OPENCODE_VERSION",
             "acli": "ACLI_VERSION",


### PR DESCRIPTION
Vale is a prose linter needed for documentation quality checks in CI workflows. Pinned with SHA256 verification, matching the existing pattern for gh/glab/gitleaks. Also adds bump/sync support to bump-versions.py.

Local make container build succeeds.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Vale CLI to CI container images with pinned version and checksum verification.
  * Extended version management so Vale can be detected, checked, and updated automatically.
* **Bug Fixes**
  * Improved the version-sync flow to keep checksum values aligned with the pinned Vale version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->