### PR TITLE
feat: add pipeline_metadata, pipeline_jobs, job_trace to GitLabForge

### DIFF
--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -18,7 +18,7 @@ from agentic_ci.forge import (
     parse_gitlab_mr_url,
     repo_path_from_url,
 )
-from agentic_ci.forge.session import build_session, extract_api_error
+from agentic_ci.forge.session import GitLabHTTPAdapter, build_session, extract_api_error
 
 log = logging.getLogger(__name__)
 
@@ -26,8 +26,8 @@ log = logging.getLogger(__name__)
 class GitLabForge(Forge):
     """GitLab REST API implementation of the ``Forge`` interface."""
 
-    def __init__(self) -> None:
-        self._session = build_session()
+    def __init__(self, *, adapter: GitLabHTTPAdapter | None = None) -> None:
+        self._session = build_session(gitlab_adapter=adapter)
 
     def project_id(self, project_path: str) -> int:
         """Look up the numeric GitLab project ID from a project path.
@@ -271,6 +271,60 @@ class GitLabForge(Forge):
                 log_text = "\n".join(lines[-200:])
             failed_jobs.append({"name": job_name, "id": job_id, "log": log_text})
         return {"pipeline_status": pipeline_status, "failed_jobs": failed_jobs}
+
+    def pipeline_metadata(self, project_path: str, pipeline_id: int) -> dict:
+        """Get pipeline metadata.
+
+        Returns the raw pipeline dict from the GitLab API.
+        """
+        pipeline_id = int(pipeline_id)
+        pid = self.project_id(project_path)
+        resp = self._session.get(
+            f"https://gitlab.com/api/v4/projects/{pid}/pipelines/{pipeline_id}",
+        )
+        if resp.status_code != 200:
+            raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
+    def pipeline_jobs(
+        self, project_path: str, pipeline_id: int, *, scope: str | None = None
+    ) -> list[dict]:
+        """Get all jobs for a pipeline (paginated).
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+            pipeline_id: Numeric pipeline ID.
+            scope: Optional job scope filter (e.g. ``"failed"``).
+
+        Returns a list of raw job dicts from the GitLab API.
+        """
+        pipeline_id = int(pipeline_id)
+        pid = self.project_id(project_path)
+        params: dict[str, str] = {}
+        if scope:
+            params["scope[]"] = scope
+        return self._paginate(
+            f"https://gitlab.com/api/v4/projects/{pid}/pipelines/{pipeline_id}/jobs",
+            params=params,
+        )
+
+    def job_trace(self, project_path: str, job_id: int) -> str:
+        """Get the full trace log for a job.
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+            job_id: Numeric job ID.
+
+        Returns the trace text as a string.
+        """
+        job_id = int(job_id)
+        pid = self.project_id(project_path)
+        resp = self._session.get(
+            f"https://gitlab.com/api/v4/projects/{pid}/jobs/{job_id}/trace",
+        )
+        if resp.status_code != 200:
+            raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.text
 
     def mr_diff_position(self, mr_url: str) -> dict:
         """Get the first changed line position and diff refs from a GitLab MR.

--- a/src/agentic_ci/forge/session.py
+++ b/src/agentic_ci/forge/session.py
@@ -84,14 +84,23 @@ class GitHubHTTPAdapter(HTTPAdapter):
         return resp
 
 
-def build_session(github_token: str | None = None) -> requests.Session:
+def build_session(
+    *,
+    gitlab_adapter: GitLabHTTPAdapter | None = None,
+    github_token: str | None = None,
+) -> requests.Session:
     """Build a requests session with forge-specific auth adapters.
 
     The session automatically injects the correct auth headers based
     on the request URL prefix (``gitlab.com`` or ``api.github.com``).
+
+    Args:
+        gitlab_adapter: Custom GitLab HTTP adapter. Defaults to
+            ``GitLabHTTPAdapter()`` which uses ``BOT_PAT``.
+        github_token: Token for GitHub API authentication.
     """
     s = requests.Session()
-    s.mount("https://gitlab.com", GitLabHTTPAdapter())
+    s.mount("https://gitlab.com", gitlab_adapter or GitLabHTTPAdapter())
     s.mount(
         "https://api.github.com",
         GitHubHTTPAdapter(token=github_token),

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -29,6 +29,17 @@ def _make_response(status_code, json_data=None, text=""):
     return resp
 
 
+class TestCustomAdapter:
+    def test_adapter_passed_to_build_session(self):
+        from agentic_ci.forge.session import GitLabHTTPAdapter
+
+        custom = GitLabHTTPAdapter()
+        with patch("agentic_ci.forge.gitlab.build_session") as mock_build:
+            mock_build.return_value = MagicMock()
+            GitLabForge(adapter=custom)
+            mock_build.assert_called_once_with(gitlab_adapter=custom)
+
+
 class TestProjectId:
     def test_returns_numeric_id(self, forge, mock_session):
         mock_session.get.return_value = _make_response(200, {"id": 12345})
@@ -475,6 +486,102 @@ class TestPipelineFailures:
         result = forge.pipeline_failures("https://gitlab.com/org/repo/-/merge_requests/1")
         assert result["pipeline_status"] == "none"
         assert result["failed_jobs"] == []
+
+
+class TestPipelineMetadata:
+    def test_returns_metadata(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        pipeline_resp = _make_response(
+            200,
+            {
+                "id": 100,
+                "status": "failed",
+                "ref": "main",
+                "sha": "abc123",
+                "source": "schedule",
+                "web_url": "https://gitlab.com/org/repo/-/pipelines/100",
+                "created_at": "2025-01-01T00:00:00Z",
+                "updated_at": "2025-01-01T01:00:00Z",
+                "duration": 3600,
+            },
+        )
+        mock_session.get.side_effect = [project_resp, pipeline_resp]
+
+        result = forge.pipeline_metadata("org/repo", 100)
+        assert result["id"] == 100
+        assert result["status"] == "failed"
+        assert result["ref"] == "main"
+        assert result["sha"] == "abc123"
+        assert result["source"] == "schedule"
+        assert result["web_url"] == "https://gitlab.com/org/repo/-/pipelines/100"
+        assert result["duration"] == 3600
+
+    def test_raises_on_http_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        pipeline_resp = _make_response(404, text="Not found")
+        mock_session.get.side_effect = [project_resp, pipeline_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 404"):
+            forge.pipeline_metadata("org/repo", 999)
+
+
+class TestPipelineJobs:
+    def test_returns_all_jobs(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        jobs_resp = _make_response(
+            200,
+            [
+                {"id": 501, "name": "build", "stage": "build", "status": "success"},
+                {"id": 502, "name": "test", "stage": "test", "status": "failed"},
+            ],
+        )
+        mock_session.get.side_effect = [project_resp, jobs_resp]
+
+        result = forge.pipeline_jobs("org/repo", 100)
+        assert len(result) == 2
+        assert result[0]["name"] == "build"
+        assert result[1]["name"] == "test"
+
+    def test_scope_filter(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        jobs_resp = _make_response(
+            200,
+            [{"id": 502, "name": "test", "stage": "test", "status": "failed"}],
+        )
+        mock_session.get.side_effect = [project_resp, jobs_resp]
+
+        result = forge.pipeline_jobs("org/repo", 100, scope="failed")
+        assert len(result) == 1
+        assert result[0]["status"] == "failed"
+        call_args = mock_session.get.call_args_list[1]
+        assert call_args[1]["params"]["scope[]"] == "failed"
+
+    def test_raises_on_http_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        jobs_resp = _make_response(500, text="Server error")
+        mock_session.get.side_effect = [project_resp, jobs_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 500"):
+            forge.pipeline_jobs("org/repo", 100)
+
+
+class TestJobTrace:
+    def test_returns_trace_text(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        trace_resp = _make_response(200)
+        trace_resp.text = "line1\nline2\nERROR: build failed"
+        mock_session.get.side_effect = [project_resp, trace_resp]
+
+        result = forge.job_trace("org/repo", 501)
+        assert "ERROR: build failed" in result
+
+    def test_raises_on_http_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        trace_resp = _make_response(403, text="Forbidden")
+        mock_session.get.side_effect = [project_resp, trace_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.job_trace("org/repo", 501)
 
 
 class TestMrDiffPosition:


### PR DESCRIPTION
Expose pipeline-level GitLab API endpoints on GitLabForge for fetching pipeline metadata, listing jobs, and downloading job traces.

 Adds three new methods to GitLabForge:

 ```
  ┌──────────────────────────────────────────────────────┬────────────────────────────────────────────────────┐
  │                        Method                        │                  GitLab Endpoint                   │
  ├──────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ pipeline_metadata(project_path, pipeline_id)         │ GET /projects/{id}/pipelines/{id}                  │
  ├──────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ pipeline_jobs(project_path, pipeline_id, scope=None) │ GET /projects/{id}/pipelines/{id}/jobs (paginated) │
  ├──────────────────────────────────────────────────────┼────────────────────────────────────────────────────┤
  │ job_trace(project_path, job_id)                      │ GET /projects/{id}/jobs/{id}/trace                 │
  └──────────────────────────────────────────────────────┴────────────────────────────────────────────────────┘
```

Also adds an optional adapter keyword argument to `GitLabForge.__init__` (and a corresponding gitlab_adapter parameter to build_session) so callers can provide a custom `GitLabHTTPAdapter` (instead of BOT_PAT).

How Has This Been Tested?

- 7 new unit tests added in `test_forge_gitlab.py` covering success and error paths for all three methods, including scope filtering for `pipeline_jobs`.
- End-to-end validation: wrote a downstream pipeline job that consumes these methods (replacing the `glab` CLI) and its full CI pipeline passes against a demo pipeline pointed at this branch of `agentic-ci`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitLab pipeline metadata, pipeline job listings (with optional scope filtering), and job trace retrieval.
  * Enhanced session setup to allow injecting a custom GitLab HTTP adapter for more control.
* **Bug Fixes**
  * Improved error handling for non-successful GitLab requests with clearer HTTP status messages.
* **Tests**
  * Added unit coverage for metadata, scoped job listing, trace retrieval, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->