### PR TITLE
feat(forge): add pipeline schedule and MR blocking methods

### DIFF
--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -326,6 +326,70 @@ class GitLabForge(Forge):
             raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
         return resp.text
 
+    def pipeline_schedules(self, project_path: str) -> list[dict]:
+        """List all pipeline schedules for a project (paginated).
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+
+        Returns a list of raw schedule dicts from the GitLab API.
+        """
+        pid = self.project_id(project_path)
+        return self._paginate(
+            f"https://gitlab.com/api/v4/projects/{pid}/pipeline_schedules",
+        )
+
+    def pipeline_schedule(self, project_path: str, schedule_id: int) -> dict:
+        """Get details of a specific pipeline schedule.
+
+        The returned dict includes ``last_pipeline`` with the most recent
+        pipeline triggered by this schedule.
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+            schedule_id: Numeric pipeline schedule ID.
+
+        Returns the raw schedule dict from the GitLab API.
+        """
+        schedule_id = int(schedule_id)
+        pid = self.project_id(project_path)
+        resp = self._session.get(
+            f"https://gitlab.com/api/v4/projects/{pid}/pipeline_schedules/{schedule_id}",
+        )
+        if resp.status_code != 200:
+            raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
+    def add_mr_block(self, blocked_mr_url: str, blocking_mr_url: str) -> None:
+        """Set MR dependency: *blocked_mr* cannot merge until *blocking_mr* merges.
+
+        Requires GitLab Premium.
+
+        Args:
+            blocked_mr_url: URL of the MR that should be blocked.
+            blocking_mr_url: URL of the MR that must merge first.
+
+        Raises ``ForgeError`` on failure.
+        """
+        blocked_path, blocked_iid = parse_gitlab_mr_url(blocked_mr_url)
+        blocking_path, blocking_iid = parse_gitlab_mr_url(blocking_mr_url)
+
+        blocking_pid = self.project_id(blocking_path)
+        resp = self._session.get(
+            f"https://gitlab.com/api/v4/projects/{blocking_pid}/merge_requests/{blocking_iid}",
+        )
+        if resp.status_code != 200:
+            raise ForgeError(f"HTTP {resp.status_code} fetching blocking MR: {resp.text}")
+        blocking_internal_id = resp.json()["id"]
+
+        blocked_pid = self.project_id(blocked_path)
+        resp = self._session.post(
+            f"https://gitlab.com/api/v4/projects/{blocked_pid}/merge_requests/{blocked_iid}/blocks",
+            json={"blocking_merge_request_id": blocking_internal_id},
+        )
+        if resp.status_code not in (200, 201):
+            raise ForgeError(f"HTTP {resp.status_code} creating MR block: {resp.text}")
+
     def mr_diff_position(self, mr_url: str) -> dict:
         """Get the first changed line position and diff refs from a GitLab MR.
 

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -584,6 +584,115 @@ class TestJobTrace:
             forge.job_trace("org/repo", 501)
 
 
+class TestPipelineSchedules:
+    def test_returns_schedules(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        schedules_resp = _make_response(
+            200,
+            [
+                {"id": 10, "description": "Nightly", "cron": "0 0 * * *"},
+                {"id": 11, "description": "Weekly", "cron": "0 0 * * 0"},
+            ],
+        )
+        mock_session.get.side_effect = [project_resp, schedules_resp]
+
+        result = forge.pipeline_schedules("org/repo")
+        assert len(result) == 2
+        assert result[0]["description"] == "Nightly"
+        assert result[1]["description"] == "Weekly"
+
+    def test_raises_on_http_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        schedules_resp = _make_response(403, text="Forbidden")
+        mock_session.get.side_effect = [project_resp, schedules_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.pipeline_schedules("org/repo")
+
+
+class TestPipelineSchedule:
+    def test_returns_schedule_with_last_pipeline(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        schedule_resp = _make_response(
+            200,
+            {
+                "id": 10,
+                "description": "Nightly",
+                "cron": "0 0 * * *",
+                "last_pipeline": {
+                    "id": 500,
+                    "status": "success",
+                },
+            },
+        )
+        mock_session.get.side_effect = [project_resp, schedule_resp]
+
+        result = forge.pipeline_schedule("org/repo", 10)
+        assert result["id"] == 10
+        assert result["description"] == "Nightly"
+        assert result["last_pipeline"]["id"] == 500
+        assert result["last_pipeline"]["status"] == "success"
+
+    def test_raises_on_http_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        schedule_resp = _make_response(404, text="Not found")
+        mock_session.get.side_effect = [project_resp, schedule_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 404"):
+            forge.pipeline_schedule("org/repo", 999)
+
+
+class TestAddMrBlock:
+    def test_creates_block(self, forge, mock_session):
+        blocking_project_resp = _make_response(200, {"id": 1})
+        blocking_mr_resp = _make_response(200, {"id": 7001, "iid": 42})
+        blocked_project_resp = _make_response(200, {"id": 2})
+        mock_session.get.side_effect = [
+            blocking_project_resp,
+            blocking_mr_resp,
+            blocked_project_resp,
+        ]
+        mock_session.post.return_value = _make_response(201)
+
+        forge.add_mr_block(
+            "https://gitlab.com/org/blocked/-/merge_requests/10",
+            "https://gitlab.com/org/blocking/-/merge_requests/42",
+        )
+
+        mock_session.post.assert_called_once()
+        call_args = mock_session.post.call_args
+        assert "/merge_requests/10/blocks" in call_args[0][0]
+        assert call_args[1]["json"]["blocking_merge_request_id"] == 7001
+
+    def test_raises_on_blocking_mr_fetch_error(self, forge, mock_session):
+        blocking_project_resp = _make_response(200, {"id": 1})
+        blocking_mr_resp = _make_response(404, text="Not found")
+        mock_session.get.side_effect = [blocking_project_resp, blocking_mr_resp]
+
+        with pytest.raises(ForgeError, match="HTTP 404"):
+            forge.add_mr_block(
+                "https://gitlab.com/org/blocked/-/merge_requests/10",
+                "https://gitlab.com/org/blocking/-/merge_requests/42",
+            )
+
+    def test_raises_on_block_post_error(self, forge, mock_session):
+        blocking_project_resp = _make_response(200, {"id": 1})
+        blocking_mr_resp = _make_response(200, {"id": 7001, "iid": 42})
+        blocked_project_resp = _make_response(200, {"id": 2})
+        mock_session.get.side_effect = [
+            blocking_project_resp,
+            blocking_mr_resp,
+            blocked_project_resp,
+        ]
+        mock_session.post.return_value = _make_response(403, text="Forbidden")
+
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.add_mr_block(
+                "https://gitlab.com/org/blocked/-/merge_requests/10",
+                "https://gitlab.com/org/blocking/-/merge_requests/42",
+            )
+
+
 class TestMrDiffPosition:
     def test_finds_first_added_line(self, forge, mock_session):
         project_resp = _make_response(200, {"id": 1})


### PR DESCRIPTION
## Summary

- Add `pipeline_schedules()` and `pipeline_schedule()` to `GitLabForge` for listing and fetching pipeline schedule details (including `last_pipeline`)
- Add `add_mr_block()` to `GitLabForge` for setting MR blocking dependencies (GitLab Premium)
- Add tests for all three new methods following existing patterns

Enables downstream projects (package-onboarding, pipeline-failure-analyzer) to replace raw REST API calls with forge methods.

## Test plan

- [x] All 48 forge tests pass (`pytest tests/test_forge_gitlab.py`)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [x] `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing GitLab pipeline schedules and individual schedule details.
  * Added the ability to create merge request blocks so one merge request can wait on another.

* **Bug Fixes**
  * Improved error handling for schedule lookups and merge request block creation when GitLab returns an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->