### PR TITLE
mlflow-push: populate experiment token & cost charts from OTel traces

### DIFF
--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -82,10 +82,11 @@ def _add_genai_token_usage(payload):
     charts stay empty even though the data is present on the spans.
 
     The GenAI input count folds ``cache_read`` + ``cache_creation`` into
-    ``input_tokens`` so the chart reflects the total tokens processed. MLflow
-    then prices that whole amount at the standard input rate, so the derived
-    cost is approximate (it over-counts cheap cache reads); Claude's exact cost
-    is reported separately in the ``/v1/metrics`` stream.
+    ``input_tokens`` so the chart reflects the total tokens processed. Cost is
+    driven separately by :func:`_add_span_costs` from Claude's reported
+    ``/v1/metrics`` spend; only when that is absent does MLflow fall back to
+    pricing the folded input at the standard rate (approximate, over-counting
+    cheap cache reads).
 
     Existing ``gen_ai.usage.*`` attributes are left untouched.
     """
@@ -106,6 +107,99 @@ def _add_genai_token_usage(payload):
                 attrs.append({"key": _GENAI_INPUT_KEY, "value": {"intValue": str(inp)}})
                 attrs.append({"key": _GENAI_OUTPUT_KEY, "value": {"intValue": str(out)}})
     return payload
+
+
+# Claude reports exact spend as a delta-temporality OTEL metric
+# (claude_code.cost.usage, tagged session.id) in the /v1/metrics records —
+# never as a span attribute. To drive MLflow's experiment cost chart, that
+# total is distributed across the session's LLM spans as mlflow.llm.cost,
+# which MLflow aggregates into mlflow.trace.cost. A pre-set mlflow.llm.cost is
+# used verbatim (MLflow does not recompute it), so this yields the exact billed
+# total rather than MLflow's token-derived approximation.
+_COST_METRIC = "claude_code.cost.usage"
+_SESSION_ID_KEY = "session.id"
+_LLM_COST_KEY = "mlflow.llm.cost"
+
+
+def _value_str(value):
+    """Return the string content of an OTLP attribute value dict, or None."""
+    if isinstance(value, dict):
+        return value.get("stringValue", value.get("string_value"))
+    return None
+
+
+def _cost_by_session(metric_records):
+    """Sum claude_code.cost.usage per session.id across /v1/metrics records.
+
+    The metric is delta temporality, so the session total is a plain sum of
+    its data points.
+    """
+    totals = {}
+    for rec in metric_records:
+        payload = rec.get("payload") or {}
+        for rm in payload.get("resourceMetrics", []):
+            for sm in rm.get("scopeMetrics", []):
+                for metric in sm.get("metrics", []):
+                    if metric.get("name") != _COST_METRIC:
+                        continue
+                    for dp in metric.get("sum", {}).get("dataPoints", []):
+                        sid = next(
+                            (
+                                _value_str(a.get("value"))
+                                for a in dp.get("attributes", [])
+                                if isinstance(a, dict) and a.get("key") == _SESSION_ID_KEY
+                            ),
+                            None,
+                        )
+                        value = dp.get("asDouble", dp.get("asInt"))
+                        if sid is None or value is None:
+                            continue
+                        totals[sid] = totals.get(sid, 0.0) + float(value)
+    return totals
+
+
+def _add_span_costs(payloads, cost_by_session):
+    """Distribute each session's reported cost across its LLM spans.
+
+    Spans are weighted by token volume (input + output + cache). The per-span
+    share is written as mlflow.llm.cost so MLflow aggregates the exact session
+    total into mlflow.trace.cost. Only the total is authoritative (the metric
+    carries no input/output split); the in/out split is apportioned by tokens
+    so the values stay self-consistent. Existing mlflow.llm.cost is preserved.
+    """
+    if not cost_by_session:
+        return
+    buckets = {}  # session id -> list of (attrs, in_weight, out_weight)
+    weights = {}  # session id -> total token weight
+    for payload in payloads:
+        for rs in payload.get("resourceSpans", []):
+            for ss in rs.get("scopeSpans", []):
+                for span in ss.get("spans", []):
+                    attrs = span.get("attributes")
+                    if not isinstance(attrs, list):
+                        continue
+                    by_key = {a.get("key"): a.get("value") for a in attrs if isinstance(a, dict)}
+                    sid = _value_str(by_key.get(_SESSION_ID_KEY))
+                    if sid is None or sid not in cost_by_session:
+                        continue
+                    in_w = sum(_attr_int(by_key.get(k)) or 0 for k in _INPUT_TOKEN_KEYS)
+                    out_w = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
+                    if in_w + out_w <= 0:
+                        continue
+                    buckets.setdefault(sid, []).append((attrs, in_w, out_w))
+                    weights[sid] = weights.get(sid, 0) + in_w + out_w
+    for sid, spans in buckets.items():
+        total_cost = cost_by_session[sid]
+        total_weight = weights[sid]
+        if total_cost <= 0 or total_weight <= 0:
+            continue
+        for attrs, in_w, out_w in spans:
+            if any(isinstance(a, dict) and a.get("key") == _LLM_COST_KEY for a in attrs):
+                continue
+            share = total_cost * (in_w + out_w) / total_weight
+            in_cost = share * in_w / (in_w + out_w)
+            cost = {"input_cost": in_cost, "output_cost": share - in_cost, "total_cost": share}
+            attrs.append({"key": _LLM_COST_KEY, "value": {"stringValue": json.dumps(cost)}})
 
 
 def _resolve_experiment_id(endpoint, name, headers):
@@ -149,7 +243,8 @@ def push_traces(log_file, endpoint, experiment, token=None):
     if token:
         headers["Authorization"] = f"Bearer {token}"
 
-    records = []
+    trace_records = []
+    metric_records = []
     try:
         with open(log_file) as f:
             for line in f:
@@ -158,14 +253,17 @@ def push_traces(log_file, endpoint, experiment, token=None):
                     continue
                 try:
                     rec = json.loads(line)
-                    if "/v1/traces" in rec.get("path", ""):
-                        records.append(rec)
                 except json.JSONDecodeError:
-                    pass
+                    continue
+                path = rec.get("path", "")
+                if "/v1/traces" in path:
+                    trace_records.append(rec)
+                elif "/v1/metrics" in path:
+                    metric_records.append(rec)
     except FileNotFoundError:
         return 0, 0
 
-    if not records:
+    if not trace_records:
         return 0, 0
 
     experiment_id = _resolve_experiment_id(endpoint, experiment, headers)
@@ -176,13 +274,14 @@ def push_traces(log_file, endpoint, experiment, token=None):
         )
         return 0, 0
 
+    payloads = [rec["payload"] for rec in trace_records if rec.get("payload")]
+    # Annotate spans with Claude's reported cost before serialization.
+    _add_span_costs(payloads, _cost_by_session(metric_records))
+
     traces_url = f"{endpoint}/v1/traces"
     ok, err = 0, 0
 
-    for rec in records:
-        payload = rec.get("payload")
-        if not payload:
-            continue
+    for payload in payloads:
         try:
             data = _serialize_traces(payload)
             resp = requests.post(

--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -43,6 +43,71 @@ def _fixup_ids(payload):
     return payload
 
 
+# Claude Code emits bare token attributes (input_tokens, output_tokens,
+# cache_*_tokens) that match no OTEL semantic convention MLflow recognizes.
+# MLflow's OTLP ingestion derives per-span token usage — and from it the
+# trace-level mlflow.trace.tokenUsage and cost that feed the experiment
+# dashboard charts — only from namespaced conventions like these.
+_GENAI_INPUT_KEY = "gen_ai.usage.input_tokens"
+_GENAI_OUTPUT_KEY = "gen_ai.usage.output_tokens"
+# Components folded into the GenAI input count. Claude's bare input_tokens
+# excludes cached tokens, which usually dominate, so folding them in keeps the
+# token-usage chart representative of what the model actually processed.
+_INPUT_TOKEN_KEYS = ("input_tokens", "cache_read_tokens", "cache_creation_tokens")
+_OUTPUT_TOKEN_KEY = "output_tokens"
+
+
+def _attr_int(value):
+    """Extract an int from an OTLP JSON attribute value dict, or None."""
+    if not isinstance(value, dict):
+        return None
+    for key in ("intValue", "int_value", "stringValue", "string_value"):
+        if key in value:
+            try:
+                return int(value[key])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _add_genai_token_usage(payload):
+    """Map Claude Code's bare token attributes onto the OTEL GenAI semconv.
+
+    MLflow's OTLP translators recognize ``gen_ai.usage.input_tokens`` /
+    ``gen_ai.usage.output_tokens`` and use them to populate the per-span token
+    usage, the aggregated ``mlflow.trace.tokenUsage``, and the cost (via
+    MLflow's pricing table) that drive the experiment-level token and cost
+    charts. Claude Code instead emits bare ``input_tokens`` / ``output_tokens``
+    / ``cache_*_tokens``, which match nothing — so without this mapping those
+    charts stay empty even though the data is present on the spans.
+
+    The GenAI input count folds ``cache_read`` + ``cache_creation`` into
+    ``input_tokens`` so the chart reflects the total tokens processed. MLflow
+    then prices that whole amount at the standard input rate, so the derived
+    cost is approximate (it over-counts cheap cache reads); Claude's exact cost
+    is reported separately in the ``/v1/metrics`` stream.
+
+    Existing ``gen_ai.usage.*`` attributes are left untouched.
+    """
+    for rs in payload.get("resourceSpans", []):
+        for ss in rs.get("scopeSpans", []):
+            for span in ss.get("spans", []):
+                attrs = span.get("attributes")
+                if not isinstance(attrs, list):
+                    continue
+                by_key = {a.get("key"): a.get("value") for a in attrs if isinstance(a, dict)}
+                if _GENAI_INPUT_KEY in by_key or _GENAI_OUTPUT_KEY in by_key:
+                    continue
+                inp = sum(_attr_int(by_key.get(k)) or 0 for k in _INPUT_TOKEN_KEYS)
+                out = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
+                # MLflow only records usage when both input and output are > 0.
+                if inp <= 0 or out <= 0:
+                    continue
+                attrs.append({"key": _GENAI_INPUT_KEY, "value": {"intValue": str(inp)}})
+                attrs.append({"key": _GENAI_OUTPUT_KEY, "value": {"intValue": str(out)}})
+    return payload
+
+
 def _resolve_experiment_id(endpoint, name, headers):
     """Look up an MLflow experiment by name. Returns ID or None."""
     url = f"{endpoint}/api/2.0/mlflow/experiments/search"
@@ -68,7 +133,7 @@ def _resolve_experiment_id(endpoint, name, headers):
 
 def _serialize_traces(payload):
     """Convert an OTLP JSON trace payload dict to protobuf bytes."""
-    payload = _fixup_ids(copy.deepcopy(payload))
+    payload = _add_genai_token_usage(_fixup_ids(copy.deepcopy(payload)))
     request = ExportTraceServiceRequest()
     json_format.ParseDict(payload, request)
     return request.SerializeToString()

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -11,7 +11,13 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
 )
 
-from agentic_ci.mlflow import _fixup_ids, _hex_to_base64, _serialize_traces, push_traces
+from agentic_ci.mlflow import (
+    _add_genai_token_usage,
+    _fixup_ids,
+    _hex_to_base64,
+    _serialize_traces,
+    push_traces,
+)
 
 # Hex-encoded IDs (what Claude Code / OTLP JSON exporters produce)
 HEX_TRACE_PAYLOAD = {
@@ -111,6 +117,75 @@ class TestSerializeTraces:
         deserialized.ParseFromString(serialized)
         resource_attrs = deserialized.resource_spans[0].resource.attributes
         assert any(a.key == "service.name" for a in resource_attrs)
+
+
+def _llm_span(attrs):
+    return {
+        "resourceSpans": [
+            {"scopeSpans": [{"spans": [{"name": "claude_code.llm_request", "attributes": attrs}]}]}
+        ]
+    }
+
+
+def _span_attrs(payload):
+    span = payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    return {a["key"]: a["value"] for a in span["attributes"]}
+
+
+class TestAddGenAiTokenUsage:
+    def test_maps_and_folds_cache_into_input(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "3"}},
+                {"key": "output_tokens", "value": {"intValue": "148"}},
+                {"key": "cache_read_tokens", "value": {"intValue": "0"}},
+                {"key": "cache_creation_tokens", "value": {"intValue": "39565"}},
+            ]
+        )
+        _add_genai_token_usage(payload)
+        attrs = _span_attrs(payload)
+        # input folds 3 + 0 + 39565
+        assert int(attrs["gen_ai.usage.input_tokens"]["intValue"]) == 39568
+        assert int(attrs["gen_ai.usage.output_tokens"]["intValue"]) == 148
+
+    def test_skips_span_without_output(self):
+        payload = _llm_span([{"key": "input_tokens", "value": {"intValue": "5"}}])
+        _add_genai_token_usage(payload)
+        assert "gen_ai.usage.input_tokens" not in _span_attrs(payload)
+
+    def test_skips_when_both_zero(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "0"}},
+                {"key": "output_tokens", "value": {"intValue": "0"}},
+            ]
+        )
+        _add_genai_token_usage(payload)
+        assert "gen_ai.usage.input_tokens" not in _span_attrs(payload)
+
+    def test_does_not_override_existing_genai_attrs(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "5"}},
+                {"key": "output_tokens", "value": {"intValue": "7"}},
+                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "999"}},
+            ]
+        )
+        _add_genai_token_usage(payload)
+        assert int(_span_attrs(payload)["gen_ai.usage.input_tokens"]["intValue"]) == 999
+
+    def test_serialize_traces_emits_genai_attrs(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "10"}},
+                {"key": "output_tokens", "value": {"intValue": "20"}},
+            ]
+        )
+        parsed = ExportTraceServiceRequest()
+        parsed.ParseFromString(_serialize_traces(payload))
+        keys = {a.key for a in parsed.resource_spans[0].scope_spans[0].spans[0].attributes}
+        assert "gen_ai.usage.input_tokens" in keys
+        assert "gen_ai.usage.output_tokens" in keys
 
 
 class TestPushTraces:

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -13,6 +13,8 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 
 from agentic_ci.mlflow import (
     _add_genai_token_usage,
+    _add_span_costs,
+    _cost_by_session,
     _fixup_ids,
     _hex_to_base64,
     _serialize_traces,
@@ -186,6 +188,114 @@ class TestAddGenAiTokenUsage:
         keys = {a.key for a in parsed.resource_spans[0].scope_spans[0].spans[0].attributes}
         assert "gen_ai.usage.input_tokens" in keys
         assert "gen_ai.usage.output_tokens" in keys
+
+
+class TestCostFromMetrics:
+    def _metric_rec(self, points):
+        return {
+            "path": "/v1/metrics",
+            "payload": {
+                "resourceMetrics": [
+                    {
+                        "scopeMetrics": [
+                            {
+                                "metrics": [
+                                    {
+                                        "name": "claude_code.cost.usage",
+                                        "sum": {
+                                            "aggregationTemporality": 1,
+                                            "dataPoints": [
+                                                {
+                                                    "asDouble": v,
+                                                    "attributes": [
+                                                        {
+                                                            "key": "session.id",
+                                                            "value": {"stringValue": sid},
+                                                        }
+                                                    ],
+                                                }
+                                                for sid, v in points
+                                            ],
+                                        },
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+        }
+
+    def _span(self, sid, inp, out):
+        return {
+            "name": "claude_code.llm_request",
+            "attributes": [
+                {"key": "session.id", "value": {"stringValue": sid}},
+                {"key": "input_tokens", "value": {"intValue": str(inp)}},
+                {"key": "output_tokens", "value": {"intValue": str(out)}},
+            ],
+        }
+
+    def _payload(self, spans):
+        return {"resourceSpans": [{"scopeSpans": [{"spans": spans}]}]}
+
+    def _costs(self, payload):
+        out = []
+        for sp in payload["resourceSpans"][0]["scopeSpans"][0]["spans"]:
+            c = next(
+                (
+                    a["value"]["stringValue"]
+                    for a in sp["attributes"]
+                    if a["key"] == "mlflow.llm.cost"
+                ),
+                None,
+            )
+            out.append(json.loads(c)["total_cost"] if c else None)
+        return out
+
+    def test_cost_by_session_sums_deltas(self):
+        rec = self._metric_rec([("S1", 0.10), ("S1", 0.30), ("S2", 1.0)])
+        result = _cost_by_session([rec])
+        assert abs(result["S1"] - 0.40) < 1e-9
+        assert abs(result["S2"] - 1.0) < 1e-9
+
+    def test_cost_by_session_ignores_other_metrics(self):
+        rec = {
+            "path": "/v1/metrics",
+            "payload": {
+                "resourceMetrics": [
+                    {"scopeMetrics": [{"metrics": [{"name": "x.other.metric", "sum": {}}]}]}
+                ]
+            },
+        }
+        assert _cost_by_session([rec]) == {}
+
+    def test_distributes_cost_by_token_weight(self):
+        payload = self._payload([self._span("S1", 100, 0), self._span("S1", 0, 300)])
+        _add_span_costs([payload], {"S1": 0.40})
+        costs = self._costs(payload)
+        assert abs(costs[0] - 0.10) < 1e-9
+        assert abs(costs[1] - 0.30) < 1e-9
+        assert abs(sum(costs) - 0.40) < 1e-9
+
+    def test_does_not_override_existing_cost(self):
+        sp = self._span("S1", 100, 100)
+        sp["attributes"].append(
+            {"key": "mlflow.llm.cost", "value": {"stringValue": '{"total_cost": 9.9}'}}
+        )
+        payload = self._payload([sp])
+        _add_span_costs([payload], {"S1": 0.5})
+        assert self._costs(payload) == [9.9]
+
+    def test_noop_without_metrics(self):
+        payload = self._payload([self._span("S1", 1, 1)])
+        _add_span_costs([payload], {})
+        assert self._costs(payload) == [None]
+
+    def test_skips_session_without_cost(self):
+        payload = self._payload([self._span("S2", 10, 10)])
+        _add_span_costs([payload], {"S1": 1.0})
+        assert self._costs(payload) == [None]
 
 
 class TestPushTraces:


### PR DESCRIPTION
Makes the experiment dashboard's **token usage** and **cost** charts populate from the OTel traces `mlflow-push` already sends — no MLflow or Claude Code change, and no pricing table to maintain.

## Background

MLflow's OTLP ingestion auto-derives per-span token usage, aggregates it into `mlflow.trace.tokenUsage`, and (with token usage + model) computes cost — these trace-level fields are what the experiment charts read. But its translators only recognize **namespaced** token conventions (`gen_ai.usage.*`, `llm.token_count.*`, …). Claude Code emits **bare** `input_tokens`/`output_tokens`/`cache_*_tokens`, so today nothing matches and both charts are empty (verified: `mlflow.trace.tokenUsage` and `mlflow.trace.cost` are `None` on real pushed traces).

## Changes

**1. Token usage → GenAI semconv** (`_add_genai_token_usage`)
Maps the bare token attrs onto `gen_ai.usage.input_tokens` / `output_tokens` per LLM span. MLflow then aggregates `mlflow.trace.tokenUsage` → **token chart populates**. `cache_read` + `cache_creation` are folded into the input count so the chart reflects total tokens processed (without it, a 40k-token cached turn shows ~3 tokens).

**2. Exact cost → from `/v1/metrics`** (`_cost_by_session`, `_add_span_costs`)
Claude reports exact spend as a delta-temporality metric (`claude_code.cost.usage`, tagged `session.id`) — never on a span. We sum it per session and distribute it across that session's LLM spans (by token weight) as `mlflow.llm.cost`. MLflow **uses a pre-set per-span cost verbatim** (it doesn't recompute) and aggregates it into `mlflow.trace.cost` → **cost chart shows Claude's exact billed total**.

This deliberately avoids MLflow's token-derived auto-cost, which can't price Claude's cache tiers correctly. Trade-off: the metric is a single total, so `mlflow.llm.cost` carries an accurate `total_cost` with the input/output split apportioned by tokens (only the total is authoritative).

## Verified end-to-end (live MLflow 3.12)

- A trace pushed with bare tokens + a cost metric →
  `trace.tokenUsage = {input:3000, output:1300, total:4300}` and `trace.cost.total_cost = 0.5` (the metric total).
- Confirmed independently that MLflow auto-aggregates trace-level usage/cost for OTLP traces, and that a pre-set `mlflow.llm.cost` is respected (not overwritten).

## Tests

`TestAddGenAiTokenUsage` + `TestCostFromMetrics` (mapping, cache fold, delta-sum, token-weighted distribution, no-override, skips). Full `test_mlflow.py` passes (24); ruff clean.
