### PR TITLE
fix: use ADF format for add_comment

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -533,26 +533,10 @@ class JiraClient:
         """Post a comment, optionally restricted to a visibility group.
 
         The body is plain text (with optional markdown markup, converted
-        to ADF for the REST API).  Uses acli when no visibility
-        restriction is needed.  Returns True on success, False on failure.
+        to ADF for the REST API).  Always uses the REST API because acli
+        ``comment create`` does not support ``--body-adf``.  Returns True
+        on success, False on failure.
         """
-        if self._acli_available and not visibility_group:
-            try:
-                acli_mod.run_acli(
-                    "jira",
-                    "workitem",
-                    "comment",
-                    "create",
-                    "--key",
-                    key,
-                    "--body",
-                    body,
-                )
-                log.info("Commented on %s (via acli)", key)
-                return True
-            except acli_mod.AcliError as exc:
-                log.warning("acli comment failed, falling back to REST: %s", exc)
-
         payload: dict = {"body": text_to_adf(body)}
         if visibility_group:
             payload["visibility"] = {"type": "group", "value": visibility_group}

--- a/tests/test_acli_client.py
+++ b/tests/test_acli_client.py
@@ -96,19 +96,17 @@ class TestAssignAcli:
 
 class TestCommentAcli:
     @patch("agentic_ci.jira.client.acli_mod.run_acli")
-    def test_uses_acli_without_visibility(self, mock_run, acli_client):
+    @patch("agentic_ci.jira.client.requests")
+    def test_always_uses_rest_with_adf(self, mock_requests, mock_run, acli_client):
+        resp = MagicMock()
+        resp.status_code = 201
+        mock_requests.post.return_value = resp
+
         result = acli_client.add_comment("TEST-1", "Fixed it")
         assert result is True
-        mock_run.assert_called_once_with(
-            "jira",
-            "workitem",
-            "comment",
-            "create",
-            "--key",
-            "TEST-1",
-            "--body",
-            "Fixed it",
-        )
+        mock_run.assert_not_called()
+        call_json = mock_requests.post.call_args.kwargs["json"]
+        assert call_json["body"]["type"] == "doc"
 
     @patch("agentic_ci.jira.client.requests")
     def test_uses_rest_with_visibility(self, mock_requests, acli_client):


### PR DESCRIPTION
`add_comment` was passing raw markdown text via `--body` to `acli`, causing comments on existing tickets to render as plain text instead of formatted content.

Since acli `comment create` does not support `--body-adf`, skip acli entirely and use the REST API with `text_to_adf()` directly.

## How Has This Been Tested?
- Updated `test_acli_client.py::TestCommentAcli::test_always_uses_rest_with_adf` to assert acli is not called and the REST payload contains an ADF document
- Manually tested this code with a real Jira ticket and confirmed that rich text renders properly on new comments.

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Comment creation now consistently uses the REST API, ensuring rich-text comment bodies are sent correctly.
  * Group-restricted comments continue to support visibility settings while preserving the updated comment format.
* **Tests**
  * Updated automated coverage to reflect the new comment submission behavior and verify the CLI path is no longer used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->