### PR TITLE
mlflow-push: GenAI-standard usage + cache token breakdown for the Usage dashboard

### DIFF
--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -43,18 +43,24 @@ def _fixup_ids(payload):
     return payload
 
 
-# Claude Code emits bare token attributes (input_tokens, output_tokens,
-# cache_*_tokens) that match no OTEL semantic convention MLflow recognizes.
-# MLflow's OTLP ingestion derives per-span token usage — and from it the
-# trace-level mlflow.trace.tokenUsage and cost that feed the experiment
-# dashboard charts — only from namespaced conventions like these.
+# Claude Code emits per-call token counts as bare span attributes
+# (input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens) — it
+# does not emit the gen_ai.usage.* convention nor MLflow's own usage attribute.
+# From those bare counts we write two things (see _add_token_usage):
+#   - gen_ai.usage.input_tokens / output_tokens — the OTEL GenAI standard, for
+#     any non-MLflow backend that reads the convention.
+#   - mlflow.chat.tokenUsage — MLflow's native attribute, which it aggregates
+#     into mlflow.trace.tokenUsage for the experiment Usage dashboard; this one
+#     carries the cache breakdown (Cache Read / Cache Write) that gen_ai can't.
 _GENAI_INPUT_KEY = "gen_ai.usage.input_tokens"
 _GENAI_OUTPUT_KEY = "gen_ai.usage.output_tokens"
-# Components folded into the GenAI input count. Claude's bare input_tokens
-# excludes cached tokens, which usually dominate, so folding them in keeps the
-# token-usage chart representative of what the model actually processed.
-_INPUT_TOKEN_KEYS = ("input_tokens", "cache_read_tokens", "cache_creation_tokens")
+_CHAT_USAGE_KEY = "mlflow.chat.tokenUsage"
+_INPUT_TOKEN_KEY = "input_tokens"
 _OUTPUT_TOKEN_KEY = "output_tokens"
+_CACHE_READ_KEY = "cache_read_tokens"
+_CACHE_CREATION_KEY = "cache_creation_tokens"
+# Token components that count toward a span's cost-distribution weight.
+_WEIGHT_INPUT_KEYS = (_INPUT_TOKEN_KEY, _CACHE_READ_KEY, _CACHE_CREATION_KEY)
 
 
 def _attr_int(value):
@@ -70,25 +76,35 @@ def _attr_int(value):
     return None
 
 
-def _add_genai_token_usage(payload):
-    """Map Claude Code's bare token attributes onto the OTEL GenAI semconv.
+def _add_token_usage(payload):
+    """Translate Claude's bare token counts into both the OTEL GenAI standard
+    and MLflow's native usage attribute.
 
-    MLflow's OTLP translators recognize ``gen_ai.usage.input_tokens`` /
-    ``gen_ai.usage.output_tokens`` and use them to populate the per-span token
-    usage, the aggregated ``mlflow.trace.tokenUsage``, and the cost (via
-    MLflow's pricing table) that drive the experiment-level token and cost
-    charts. Claude Code instead emits bare ``input_tokens`` / ``output_tokens``
-    / ``cache_*_tokens``, which match nothing — so without this mapping those
-    charts stay empty even though the data is present on the spans.
+    Claude Code emits bare input_tokens / output_tokens / cache_read_tokens /
+    cache_creation_tokens (input_tokens is *fresh*, non-cached) — never the
+    gen_ai.usage.* convention or MLflow's own attribute. We synthesize both per
+    LLM span:
 
-    The GenAI input count folds ``cache_read`` + ``cache_creation`` into
-    ``input_tokens`` so the chart reflects the total tokens processed. Cost is
-    driven separately by :func:`_add_span_costs` from Claude's reported
-    ``/v1/metrics`` spend; only when that is absent does MLflow fall back to
-    pricing the folded input at the standard rate (approximate, over-counting
-    cheap cache reads).
+    - ``gen_ai.usage.input_tokens`` / ``output_tokens`` — the OTEL GenAI
+      convention (fresh input + output), so non-MLflow backends see standard
+      usage. The convention has no cache field, so cache volume isn't there.
+    - ``mlflow.chat.tokenUsage`` — MLflow's native attribute in its disjoint
+      cache schema, which MLflow aggregates into ``mlflow.trace.tokenUsage``:
+          input_tokens                 fresh input
+          output_tokens                generated
+          total_tokens                 input + output (cache excluded)
+          cache_read_input_tokens      -> dashboard "Cache Read"
+          cache_creation_input_tokens  -> dashboard "Cache Write"
+      MLflow uses a pre-set value verbatim, so all four lines show on the
+      experiment Usage dashboard.
 
-    Existing ``gen_ai.usage.*`` attributes are left untouched.
+    Cost is set separately by :func:`_add_span_costs` from Claude's reported
+    /v1/metrics spend. We deliberately do not rely on MLflow's cache-aware
+    auto-cost: fed Anthropic's disjoint counts it assumes prompt_tokens
+    includes the cached tokens and can go negative. (That fallback only runs
+    when no cost metric is present, so mlflow.llm.cost is left unset.)
+
+    Existing values for any of these attributes are left untouched.
     """
     for rs in payload.get("resourceSpans", []):
         for ss in rs.get("scopeSpans", []):
@@ -97,15 +113,27 @@ def _add_genai_token_usage(payload):
                 if not isinstance(attrs, list):
                     continue
                 by_key = {a.get("key"): a.get("value") for a in attrs if isinstance(a, dict)}
-                if _GENAI_INPUT_KEY in by_key or _GENAI_OUTPUT_KEY in by_key:
-                    continue
-                inp = sum(_attr_int(by_key.get(k)) or 0 for k in _INPUT_TOKEN_KEYS)
+                inp = _attr_int(by_key.get(_INPUT_TOKEN_KEY)) or 0
                 out = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
-                # MLflow only records usage when both input and output are > 0.
-                if inp <= 0 or out <= 0:
+                cache_read = _attr_int(by_key.get(_CACHE_READ_KEY)) or 0
+                cache_creation = _attr_int(by_key.get(_CACHE_CREATION_KEY)) or 0
+                if inp + out + cache_read + cache_creation <= 0:
                     continue
-                attrs.append({"key": _GENAI_INPUT_KEY, "value": {"intValue": str(inp)}})
-                attrs.append({"key": _GENAI_OUTPUT_KEY, "value": {"intValue": str(out)}})
+                # OTEL GenAI standard (fresh input + output; no cache field).
+                if _GENAI_INPUT_KEY not in by_key:
+                    attrs.append({"key": _GENAI_INPUT_KEY, "value": {"intValue": str(inp)}})
+                if _GENAI_OUTPUT_KEY not in by_key:
+                    attrs.append({"key": _GENAI_OUTPUT_KEY, "value": {"intValue": str(out)}})
+                # MLflow native usage (disjoint, with cache lines).
+                if _CHAT_USAGE_KEY not in by_key:
+                    usage = {"input_tokens": inp, "output_tokens": out, "total_tokens": inp + out}
+                    if cache_read:
+                        usage["cache_read_input_tokens"] = cache_read
+                    if cache_creation:
+                        usage["cache_creation_input_tokens"] = cache_creation
+                    attrs.append(
+                        {"key": _CHAT_USAGE_KEY, "value": {"stringValue": json.dumps(usage)}}
+                    )
     return payload
 
 
@@ -182,7 +210,7 @@ def _add_span_costs(payloads, cost_by_session):
                     sid = _value_str(by_key.get(_SESSION_ID_KEY))
                     if sid is None or sid not in cost_by_session:
                         continue
-                    in_w = sum(_attr_int(by_key.get(k)) or 0 for k in _INPUT_TOKEN_KEYS)
+                    in_w = sum(_attr_int(by_key.get(k)) or 0 for k in _WEIGHT_INPUT_KEYS)
                     out_w = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
                     if in_w + out_w <= 0:
                         continue
@@ -227,7 +255,7 @@ def _resolve_experiment_id(endpoint, name, headers):
 
 def _serialize_traces(payload):
     """Convert an OTLP JSON trace payload dict to protobuf bytes."""
-    payload = _add_genai_token_usage(_fixup_ids(copy.deepcopy(payload)))
+    payload = _add_token_usage(_fixup_ids(copy.deepcopy(payload)))
     request = ExportTraceServiceRequest()
     json_format.ParseDict(payload, request)
     return request.SerializeToString()

--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -117,7 +117,9 @@ def _add_token_usage(payload):
                 out = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
                 cache_read = _attr_int(by_key.get(_CACHE_READ_KEY)) or 0
                 cache_creation = _attr_int(by_key.get(_CACHE_CREATION_KEY)) or 0
-                if inp + out + cache_read + cache_creation <= 0:
+                counts = (inp, out, cache_read, cache_creation)
+                # Skip malformed (negative) counts; require some positive usage.
+                if any(c < 0 for c in counts) or sum(counts) <= 0:
                     continue
                 # OTEL GenAI standard (fresh input + output; no cache field).
                 if _GENAI_INPUT_KEY not in by_key:
@@ -210,8 +212,11 @@ def _add_span_costs(payloads, cost_by_session):
                     sid = _value_str(by_key.get(_SESSION_ID_KEY))
                     if sid is None or sid not in cost_by_session:
                         continue
-                    in_w = sum(_attr_int(by_key.get(k)) or 0 for k in _WEIGHT_INPUT_KEYS)
+                    input_weights = [_attr_int(by_key.get(k)) or 0 for k in _WEIGHT_INPUT_KEYS]
                     out_w = _attr_int(by_key.get(_OUTPUT_TOKEN_KEY)) or 0
+                    if any(w < 0 for w in (*input_weights, out_w)):
+                        continue
+                    in_w = sum(input_weights)
                     if in_w + out_w <= 0:
                         continue
                     buckets.setdefault(sid, []).append((attrs, in_w, out_w))

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -206,15 +206,29 @@ class TestAddTokenUsage:
     def test_does_not_override_existing(self):
         usage_json = '{"input_tokens": 999}'
         preset = {"key": "mlflow.chat.tokenUsage", "value": {"stringValue": usage_json}}
+        genai_preset = {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "111"}}
         payload = _llm_span(
             [
                 {"key": "input_tokens", "value": {"intValue": "5"}},
                 {"key": "output_tokens", "value": {"intValue": "7"}},
                 preset,
+                genai_preset,
             ]
         )
         _add_token_usage(payload)
         assert _chat_usage(payload) == {"input_tokens": 999}
+        assert _genai(payload, "gen_ai.usage.input_tokens") == 111
+
+    def test_skips_negative_components(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "-10"}},
+                {"key": "output_tokens", "value": {"intValue": "20"}},
+            ]
+        )
+        _add_token_usage(payload)
+        assert _chat_usage(payload) is None
+        assert _genai(payload, "gen_ai.usage.input_tokens") is None
 
     def test_serialize_traces_emits_chat_usage(self):
         payload = _llm_span(

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -12,8 +12,8 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 )
 
 from agentic_ci.mlflow import (
-    _add_genai_token_usage,
     _add_span_costs,
+    _add_token_usage,
     _cost_by_session,
     _fixup_ids,
     _hex_to_base64,
@@ -134,60 +134,104 @@ def _span_attrs(payload):
     return {a["key"]: a["value"] for a in span["attributes"]}
 
 
-class TestAddGenAiTokenUsage:
-    def test_maps_and_folds_cache_into_input(self):
+def _chat_usage(payload):
+    raw = _span_attrs(payload).get("mlflow.chat.tokenUsage")
+    return json.loads(raw["stringValue"]) if raw else None
+
+
+def _genai(payload, key):
+    raw = _span_attrs(payload).get(key)
+    return int(raw["intValue"]) if raw else None
+
+
+class TestAddTokenUsage:
+    def test_disjoint_breakdown_with_cache(self):
         payload = _llm_span(
             [
                 {"key": "input_tokens", "value": {"intValue": "3"}},
                 {"key": "output_tokens", "value": {"intValue": "148"}},
-                {"key": "cache_read_tokens", "value": {"intValue": "0"}},
+                {"key": "cache_read_tokens", "value": {"intValue": "1000"}},
                 {"key": "cache_creation_tokens", "value": {"intValue": "39565"}},
             ]
         )
-        _add_genai_token_usage(payload)
-        attrs = _span_attrs(payload)
-        # input folds 3 + 0 + 39565
-        assert int(attrs["gen_ai.usage.input_tokens"]["intValue"]) == 39568
-        assert int(attrs["gen_ai.usage.output_tokens"]["intValue"]) == 148
+        _add_token_usage(payload)
+        # MLflow native usage: disjoint, with cache
+        assert _chat_usage(payload) == {
+            "input_tokens": 3,
+            "output_tokens": 148,
+            "total_tokens": 151,  # cache excluded
+            "cache_read_input_tokens": 1000,
+            "cache_creation_input_tokens": 39565,
+        }
+        # OTEL GenAI standard: fresh input + output (no cache field)
+        assert _genai(payload, "gen_ai.usage.input_tokens") == 3
+        assert _genai(payload, "gen_ai.usage.output_tokens") == 148
 
-    def test_skips_span_without_output(self):
-        payload = _llm_span([{"key": "input_tokens", "value": {"intValue": "5"}}])
-        _add_genai_token_usage(payload)
-        assert "gen_ai.usage.input_tokens" not in _span_attrs(payload)
-
-    def test_skips_when_both_zero(self):
-        payload = _llm_span(
-            [
-                {"key": "input_tokens", "value": {"intValue": "0"}},
-                {"key": "output_tokens", "value": {"intValue": "0"}},
-            ]
-        )
-        _add_genai_token_usage(payload)
-        assert "gen_ai.usage.input_tokens" not in _span_attrs(payload)
-
-    def test_does_not_override_existing_genai_attrs(self):
-        payload = _llm_span(
-            [
-                {"key": "input_tokens", "value": {"intValue": "5"}},
-                {"key": "output_tokens", "value": {"intValue": "7"}},
-                {"key": "gen_ai.usage.input_tokens", "value": {"intValue": "999"}},
-            ]
-        )
-        _add_genai_token_usage(payload)
-        assert int(_span_attrs(payload)["gen_ai.usage.input_tokens"]["intValue"]) == 999
-
-    def test_serialize_traces_emits_genai_attrs(self):
+    def test_omits_zero_cache_keys(self):
         payload = _llm_span(
             [
                 {"key": "input_tokens", "value": {"intValue": "10"}},
                 {"key": "output_tokens", "value": {"intValue": "20"}},
             ]
         )
+        _add_token_usage(payload)
+        usage = _chat_usage(payload)
+        assert usage == {"input_tokens": 10, "output_tokens": 20, "total_tokens": 30}
+        assert "cache_read_input_tokens" not in usage
+
+    def test_sets_usage_for_cache_only_turn(self):
+        # all cache read (fresh input 0) still counts
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "0"}},
+                {"key": "output_tokens", "value": {"intValue": "271"}},
+                {"key": "cache_read_tokens", "value": {"intValue": "39774"}},
+            ]
+        )
+        _add_token_usage(payload)
+        usage = _chat_usage(payload)
+        assert usage["cache_read_input_tokens"] == 39774
+        assert usage["total_tokens"] == 271
+
+    def test_skips_when_all_zero(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "0"}},
+                {"key": "output_tokens", "value": {"intValue": "0"}},
+            ]
+        )
+        _add_token_usage(payload)
+        assert "mlflow.chat.tokenUsage" not in _span_attrs(payload)
+
+    def test_does_not_override_existing(self):
+        usage_json = '{"input_tokens": 999}'
+        preset = {"key": "mlflow.chat.tokenUsage", "value": {"stringValue": usage_json}}
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "5"}},
+                {"key": "output_tokens", "value": {"intValue": "7"}},
+                preset,
+            ]
+        )
+        _add_token_usage(payload)
+        assert _chat_usage(payload) == {"input_tokens": 999}
+
+    def test_serialize_traces_emits_chat_usage(self):
+        payload = _llm_span(
+            [
+                {"key": "input_tokens", "value": {"intValue": "10"}},
+                {"key": "output_tokens", "value": {"intValue": "20"}},
+                {"key": "cache_read_tokens", "value": {"intValue": "5"}},
+            ]
+        )
         parsed = ExportTraceServiceRequest()
         parsed.ParseFromString(_serialize_traces(payload))
-        keys = {a.key for a in parsed.resource_spans[0].scope_spans[0].spans[0].attributes}
-        assert "gen_ai.usage.input_tokens" in keys
-        assert "gen_ai.usage.output_tokens" in keys
+        span = parsed.resource_spans[0].scope_spans[0].spans[0]
+        attrs = {a.key: a.value for a in span.attributes}
+        assert "mlflow.chat.tokenUsage" in attrs
+        usage = json.loads(attrs["mlflow.chat.tokenUsage"].string_value)
+        assert usage["cache_read_input_tokens"] == 5
+        assert usage["total_tokens"] == 30
 
 
 class TestCostFromMetrics:


### PR DESCRIPTION
Follow-up to #180. Makes the experiment **Usage** dashboard show the **Cache Read / Cache Write** lines (parity with agent-eval-harness claude-trace #143), and keeps the token data OTEL-standard.

## Change
`_add_token_usage` maps Claude's bare `input_tokens`/`output_tokens`/`cache_*_tokens` onto **both**:
- `gen_ai.usage.input_tokens` / `output_tokens` — the OTEL GenAI standard (fresh in/out), for any non-MLflow backend.
- `mlflow.chat.tokenUsage` — MLflow's native attribute in its disjoint cache schema (`cache_read_input_tokens` / `cache_creation_input_tokens`), which MLflow aggregates into `mlflow.trace.tokenUsage` → all four Usage lines.

Cost stays explicit from `/v1/metrics` (we don't rely on MLflow's cache-aware auto-cost, which mis-prices Anthropic's disjoint counts and goes negative — measured −$0.15 for `claude-opus-4-6`).

## Verified end-to-end (live MLflow 3.12)
A trace with cache tokens + a cost metric → `trace.tokenUsage` with all four lines and `trace.cost.total_cost` = the metric total.

## Tests
`TestAddTokenUsage` + existing cost/serialize suites; ruff clean.
