### PR TITLE
ci: Update podman-login action to Node.js 24

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -227,7 +227,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -297,7 +297,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -370,7 +370,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
@@ -443,7 +443,7 @@ jobs:
 
       - name: Log in to quay.io
         if: env.HAS_SECRETS == 'true'
-        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
+        uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}


### PR DESCRIPTION
## Summary
- Pin `redhat-actions/podman-login` to main branch commit (`2e76993`) which targets Node.js 24
- Replaces v1.7 pin that targeted deprecated Node.js 20
- Fixes deprecation warnings across all 6 image build jobs

## Context
GitHub Actions deprecated Node.js 20 runners. The `redhat-actions/podman-login` action merged a Node.js 24 update on main but hasn't cut a new release tag since March 2024, so we pin to the commit directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container image build workflow to use a newer pinned login action version across all affected build jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->