### PR TITLE
feat(forge): Add draft parameter to create_merge_request

### DIFF
--- a/src/agentic_ci/forge/__init__.py
+++ b/src/agentic_ci/forge/__init__.py
@@ -62,6 +62,7 @@ class Forge(ABC):
         target_branch: str,
         title: str,
         description: str,
+        draft: bool = False,
     ) -> tuple[str | None, str | None]:
         """Create an MR/PR.
 

--- a/src/agentic_ci/forge/github.py
+++ b/src/agentic_ci/forge/github.py
@@ -44,6 +44,7 @@ class GitHubForge(Forge):
         target_branch: str,
         title: str,
         description: str,
+        draft: bool = False,
     ) -> tuple[str | None, str | None]:
         repo_path = repo_path_from_url(repo_url)
 
@@ -63,11 +64,12 @@ class GitHubForge(Forge):
                 log.info("Found existing open PR: %s", existing_url)
                 return existing_url, None
 
-        payload = {
+        payload: dict[str, str | bool] = {
             "head": source_branch,
             "base": target_branch,
             "title": title,
             "body": description,
+            "draft": draft,
         }
         resp = self._session.post(
             f"https://api.github.com/repos/{repo_path}/pulls",

--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -49,6 +49,7 @@ class GitLabForge(Forge):
         target_branch: str,
         title: str,
         description: str,
+        draft: bool = False,
     ) -> tuple[str | None, str | None]:
         project_path = repo_path_from_url(repo_url)
         pid = self.project_id(project_path)
@@ -75,6 +76,8 @@ class GitLabForge(Forge):
             "description": description,
             "remove_source_branch": True,
         }
+        if draft:
+            payload["draft"] = True
         resp = self._session.post(
             f"https://gitlab.com/api/v4/projects/{pid}/merge_requests",
             json=payload,

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -79,6 +79,37 @@ class TestCreateMergeRequest:
         assert error is None
         mock_session.post.assert_not_called()
 
+    def test_draft_includes_draft_field(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, [])
+        mock_session.post.return_value = _make_response(
+            201, {"html_url": "https://github.com/owner/repo/pull/42"}
+        )
+        forge.create_merge_request(
+            "https://github.com/owner/repo",
+            "feature-branch",
+            "main",
+            "Draft PR",
+            "Description",
+            draft=True,
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["draft"] is True
+
+    def test_non_draft_sends_draft_false(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, [])
+        mock_session.post.return_value = _make_response(
+            201, {"html_url": "https://github.com/owner/repo/pull/42"}
+        )
+        forge.create_merge_request(
+            "https://github.com/owner/repo",
+            "feature-branch",
+            "main",
+            "Normal PR",
+            "Description",
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["draft"] is False
+
     def test_existing_pr_check_failure_falls_through(self, forge, mock_session):
         mock_session.get.return_value = _make_response(403, text="Forbidden")
         mock_session.post.return_value = _make_response(

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -102,6 +102,41 @@ class TestCreateMergeRequest:
         assert error is None
         mock_session.post.assert_not_called()
 
+    def test_draft_includes_draft_field(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        no_existing = _make_response(200, [])
+        mock_session.get.side_effect = [project_resp, no_existing]
+        mock_session.post.return_value = _make_response(
+            201, {"web_url": "https://gitlab.com/org/repo/-/merge_requests/99"}
+        )
+        forge.create_merge_request(
+            "https://gitlab.com/org/repo",
+            "feature-branch",
+            "main",
+            "Draft MR",
+            "Description",
+            draft=True,
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload["draft"] is True
+
+    def test_non_draft_omits_draft_field(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        no_existing = _make_response(200, [])
+        mock_session.get.side_effect = [project_resp, no_existing]
+        mock_session.post.return_value = _make_response(
+            201, {"web_url": "https://gitlab.com/org/repo/-/merge_requests/99"}
+        )
+        forge.create_merge_request(
+            "https://gitlab.com/org/repo",
+            "feature-branch",
+            "main",
+            "Normal MR",
+            "Description",
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert "draft" not in payload
+
     def test_existing_mr_check_failure_falls_through(self, forge, mock_session):
         project_resp = _make_response(200, {"id": 1})
         check_fail = _make_response(403, text="Forbidden")


### PR DESCRIPTION
## Summary
- Add optional `draft: bool = False` parameter to `Forge.create_merge_request()` (ABC, GitLab, GitHub)
- GitLab: conditionally includes `"draft": true` in API payload
- GitHub: always sends `"draft"` field (API supports it natively)
- Tests for both backends verifying draft payload handling

## Why
package-onboarding creates draft MRs for builder, probe-test, and rhai-pipeline onboarding. Without this parameter we can't fully migrate off glab CLI.

## Test plan
- [x] `tox -e py314` -- 118 tests pass
- [x] `tox -e lint` -- clean
- [x] `tox -e check-format` -- clean
- [x] `tox -e typecheck` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Merge requests can now be created as drafts.
  * Support for draft merge requests is available for both GitHub and GitLab integrations.

* **Tests**
  * Added coverage to confirm draft and non-draft merge request payloads are sent correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->