### PR TITLE
mlflow-push: surface Claude's query_source on trace spans

### DIFF
--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -150,6 +150,13 @@ _COST_METRIC = "claude_code.cost.usage"
 _SESSION_ID_KEY = "session.id"
 _LLM_COST_KEY = "mlflow.llm.cost"
 
+# Claude tags each LLM call with a query_source (e.g. "sdk", "agent:custom",
+# "generate_session_title") in the /v1/logs api_request events, joinable to
+# spans by request_id. It's not on the spans, so surface it so the origin of a
+# trace/span is visible in MLflow (e.g. the standalone title-generation call).
+_QUERY_SOURCE_KEY = "query_source"
+_REQUEST_ID_KEY = "request_id"
+
 
 def _value_str(value):
     """Return the string content of an OTLP attribute value dict, or None."""
@@ -235,6 +242,48 @@ def _add_span_costs(payloads, cost_by_session):
             attrs.append({"key": _LLM_COST_KEY, "value": {"stringValue": json.dumps(cost)}})
 
 
+def _query_source_by_request(log_records):
+    """Map request_id -> query_source from the /v1/logs api_request events."""
+    mapping = {}
+    for rec in log_records:
+        payload = rec.get("payload") or {}
+        for rl in payload.get("resourceLogs", []):
+            for sl in rl.get("scopeLogs", []):
+                for lr in sl.get("logRecords", []):
+                    attrs = {
+                        a.get("key"): a.get("value")
+                        for a in lr.get("attributes", [])
+                        if isinstance(a, dict)
+                    }
+                    rid = _value_str(attrs.get(_REQUEST_ID_KEY))
+                    source = _value_str(attrs.get(_QUERY_SOURCE_KEY))
+                    if rid and source:
+                        mapping[rid] = source
+    return mapping
+
+
+def _add_query_source(payloads, source_by_request):
+    """Tag each LLM span with its query_source, joined from the logs by
+    request_id, so the call's origin (e.g. generate_session_title) is visible in
+    MLflow. Existing query_source attributes are left untouched."""
+    if not source_by_request:
+        return
+    for payload in payloads:
+        for rs in payload.get("resourceSpans", []):
+            for ss in rs.get("scopeSpans", []):
+                for span in ss.get("spans", []):
+                    attrs = span.get("attributes")
+                    if not isinstance(attrs, list):
+                        continue
+                    by_key = {a.get("key"): a.get("value") for a in attrs if isinstance(a, dict)}
+                    if _QUERY_SOURCE_KEY in by_key:
+                        continue
+                    rid = _value_str(by_key.get(_REQUEST_ID_KEY))
+                    source = source_by_request.get(rid) if rid else None
+                    if source:
+                        attrs.append({"key": _QUERY_SOURCE_KEY, "value": {"stringValue": source}})
+
+
 def _resolve_experiment_id(endpoint, name, headers):
     """Look up an MLflow experiment by name. Returns ID or None."""
     url = f"{endpoint}/api/2.0/mlflow/experiments/search"
@@ -278,6 +327,7 @@ def push_traces(log_file, endpoint, experiment, token=None):
 
     trace_records = []
     metric_records = []
+    log_records = []
     try:
         with open(log_file) as f:
             for line in f:
@@ -293,6 +343,8 @@ def push_traces(log_file, endpoint, experiment, token=None):
                     trace_records.append(rec)
                 elif "/v1/metrics" in path:
                     metric_records.append(rec)
+                elif "/v1/logs" in path:
+                    log_records.append(rec)
     except FileNotFoundError:
         return 0, 0
 
@@ -308,8 +360,9 @@ def push_traces(log_file, endpoint, experiment, token=None):
         return 0, 0
 
     payloads = [rec["payload"] for rec in trace_records if rec.get("payload")]
-    # Annotate spans with Claude's reported cost before serialization.
+    # Annotate spans (from the metrics/logs streams) before serialization.
     _add_span_costs(payloads, _cost_by_session(metric_records))
+    _add_query_source(payloads, _query_source_by_request(log_records))
 
     traces_url = f"{endpoint}/v1/traces"
     ok, err = 0, 0

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -12,11 +12,13 @@ from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
 )
 
 from agentic_ci.mlflow import (
+    _add_query_source,
     _add_span_costs,
     _add_token_usage,
     _cost_by_session,
     _fixup_ids,
     _hex_to_base64,
+    _query_source_by_request,
     _serialize_traces,
     push_traces,
 )
@@ -354,6 +356,88 @@ class TestCostFromMetrics:
         payload = self._payload([self._span("S2", 10, 10)])
         _add_span_costs([payload], {"S1": 1.0})
         assert self._costs(payload) == [None]
+
+
+def _log_rec(entries):
+    return {
+        "path": "/v1/logs",
+        "payload": {
+            "resourceLogs": [
+                {
+                    "scopeLogs": [
+                        {
+                            "logRecords": [
+                                {
+                                    "attributes": [
+                                        {"key": "request_id", "value": {"stringValue": rid}},
+                                        {"key": "query_source", "value": {"stringValue": qs}},
+                                    ]
+                                }
+                                for rid, qs in entries
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+
+
+class TestQuerySource:
+    def test_maps_request_to_source(self):
+        recs = [_log_rec([("req-1", "sdk"), ("req-2", "generate_session_title")])]
+        assert _query_source_by_request(recs) == {
+            "req-1": "sdk",
+            "req-2": "generate_session_title",
+        }
+
+    def test_ignores_records_missing_fields(self):
+        rec = {
+            "path": "/v1/logs",
+            "payload": {
+                "resourceLogs": [
+                    {
+                        "scopeLogs": [
+                            {
+                                "logRecords": [
+                                    {
+                                        "attributes": [
+                                            {"key": "request_id", "value": {"stringValue": "req-x"}}
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+        }
+        assert _query_source_by_request([rec]) == {}
+
+    def test_tags_span_by_request_id(self):
+        payload = _llm_span([{"key": "request_id", "value": {"stringValue": "req-2"}}])
+        _add_query_source([payload], {"req-2": "generate_session_title"})
+        assert _span_attrs(payload)["query_source"]["stringValue"] == "generate_session_title"
+
+    def test_skips_span_without_match(self):
+        payload = _llm_span([{"key": "request_id", "value": {"stringValue": "req-unknown"}}])
+        _add_query_source([payload], {"req-2": "sdk"})
+        assert "query_source" not in _span_attrs(payload)
+
+    def test_does_not_override_existing(self):
+        payload = _llm_span(
+            [
+                {"key": "request_id", "value": {"stringValue": "req-2"}},
+                {"key": "query_source", "value": {"stringValue": "keep"}},
+            ]
+        )
+        _add_query_source([payload], {"req-2": "sdk"})
+        assert _span_attrs(payload)["query_source"]["stringValue"] == "keep"
+
+    def test_noop_without_logs(self):
+        payload = _llm_span([{"key": "request_id", "value": {"stringValue": "req-2"}}])
+        _add_query_source([payload], {})
+        assert "query_source" not in _span_attrs(payload)
 
 
 class TestPushTraces:


### PR DESCRIPTION
Follow-up to #180/#186. Makes each LLM call's **origin** visible in MLflow.

## Why
Claude tags every call with a `query_source` (`sdk` = main loop, `agent:custom` = subagents, `generate_session_title` = the standalone title call, …) — but **only in the `/v1/logs` `api_request` events**, which `mlflow-push` doesn't push. So in the MLflow UI you can't tell what a trace/span is for; notably the standalone **session-title** call shows up as a small peer trace per run with no indication of its purpose.

## Change
`_query_source_by_request` builds `request_id → query_source` from the `/v1/logs` records; `_add_query_source` copies it onto each LLM span (joined by the `request_id` attribute both carry). Existing values are left untouched.

## Verified
- Join is 100% on a real run's JSONL (26/26 spans↔logs by `request_id`); values `sdk` / `agent:custom` / `generate_session_title`.
- End-to-end on live MLflow 3.12: a pushed span carries `query_source = generate_session_title`.

## Tests
`TestQuerySource` (map build, tag-by-request-id, skip-no-match, no-override, no-op). Full `test_mlflow.py` passes (32); ruff clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trace uploads now capture additional log information and enrich spans with a new source-related attribute when available.
  * Spans can now be linked to their originating request metadata for better trace context.

* **Bug Fixes**
  * Preserves any existing span source information instead of overwriting it.
  * Handles incomplete or unmatched log entries gracefully without affecting trace processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->