### PR TITLE
fix(otel): handle chunked transfer encoding in OTLP collector

### DIFF
--- a/src/agentic_ci/otel.py
+++ b/src/agentic_ci/otel.py
@@ -22,16 +22,50 @@ MAX_BODY_SIZE = 1_048_576
 
 
 class OTLPHandler(BaseHTTPRequestHandler):
+    def _read_chunked(self):
+        chunks = []
+        total = 0
+        while True:
+            line = self.rfile.readline()
+            if not line:
+                break
+            try:
+                chunk_size = int(line.split(b";")[0].strip(), 16)
+            except ValueError:
+                break
+            if chunk_size == 0:
+                # Drain trailers until empty line
+                while True:
+                    trailer = self.rfile.readline()
+                    if not trailer or trailer in (b"\r\n", b"\n"):
+                        break
+                break
+            if chunk_size > MAX_BODY_SIZE:
+                return None
+            chunk = self.rfile.read(chunk_size)
+            self.rfile.readline()
+            total += len(chunk)
+            if total > MAX_BODY_SIZE:
+                return None
+            chunks.append(chunk)
+        return b"".join(chunks)
+
     def do_POST(self):
-        try:
-            length = int(self.headers.get("Content-Length", 0))
-        except ValueError:
-            self.send_error(400, "Invalid Content-Length")
-            return
-        if length > MAX_BODY_SIZE:
-            self.send_error(413, "Payload Too Large")
-            return
-        body = self.rfile.read(length) if length else b""
+        if self.headers.get("Transfer-Encoding", "").lower() == "chunked":
+            body = self._read_chunked()
+            if body is None:
+                self.send_error(413, "Payload Too Large")
+                return
+        else:
+            try:
+                length = int(self.headers.get("Content-Length", 0))
+            except ValueError:
+                self.send_error(400, "Invalid Content-Length")
+                return
+            if length > MAX_BODY_SIZE:
+                self.send_error(413, "Payload Too Large")
+                return
+            body = self.rfile.read(length) if length else b""
         try:
             payload = json.loads(body) if body else {}
         except json.JSONDecodeError:

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -1,0 +1,166 @@
+"""Tests for the OTLP HTTP/JSON collector."""
+
+import json
+import urllib.request
+
+import pytest
+
+from agentic_ci.otel import start_collector, stop_collector
+
+
+@pytest.fixture()
+def collector(tmp_path):
+    proc, port, log, _rate = start_collector(str(tmp_path))
+    yield port, log
+    stop_collector(proc)
+
+
+def _post(port, path, body, chunked=False):
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    if chunked:
+        req.remove_header("Content-length")
+        req.add_header("Transfer-Encoding", "chunked")
+    with urllib.request.urlopen(req) as resp:
+        return resp.status
+
+
+def _read_log(log_path):
+    records = []
+    with open(log_path) as f:
+        for line in f:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+class TestOTLPCollector:
+    def test_content_length_metrics(self, collector):
+        port, log = collector
+        payload = {
+            "resourceMetrics": [
+                {
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "claude_code.token.usage",
+                                    "sum": {
+                                        "dataPoints": [
+                                            {
+                                                "asInt": 500,
+                                                "attributes": [
+                                                    {
+                                                        "key": "model",
+                                                        "value": {"stringValue": "test-model"},
+                                                    },
+                                                    {
+                                                        "key": "type",
+                                                        "value": {"stringValue": "input"},
+                                                    },
+                                                ],
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        status = _post(port, "/v1/metrics", payload)
+        assert status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert records[0]["path"] == "/v1/metrics"
+        assert "resourceMetrics" in records[0]["payload"]
+
+    def test_content_length_logs(self, collector):
+        port, log = collector
+        payload = {"resourceLogs": [{"scopeLogs": [{"logRecords": []}]}]}
+        status = _post(port, "/v1/logs", payload)
+        assert status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert "resourceLogs" in records[0]["payload"]
+
+    def test_chunked_metrics(self, collector):
+        port, log = collector
+        payload = {
+            "resourceMetrics": [
+                {
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "claude_code.token.usage",
+                                    "sum": {"dataPoints": [{"asInt": 1000}]},
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+        status = _post(port, "/v1/metrics", payload, chunked=True)
+        assert status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert records[0]["path"] == "/v1/metrics"
+        assert "resourceMetrics" in records[0]["payload"]
+
+    def test_chunked_logs(self, collector):
+        port, log = collector
+        payload = {"resourceLogs": [{"scopeLogs": [{"logRecords": []}]}]}
+        status = _post(port, "/v1/logs", payload, chunked=True)
+        assert status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert "resourceLogs" in records[0]["payload"]
+
+    def test_chunked_traces(self, collector):
+        port, log = collector
+        payload = {"resourceSpans": [{"scopeSpans": []}]}
+        status = _post(port, "/v1/traces", payload, chunked=True)
+        assert status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert "resourceSpans" in records[0]["payload"]
+
+    def test_empty_body(self, collector):
+        port, log = collector
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/metrics",
+            data=b"",
+            headers={"Content-Type": "application/json", "Content-Length": "0"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req) as resp:
+            assert resp.status == 200
+
+        records = _read_log(log)
+        assert len(records) == 1
+        assert records[0]["payload"] == {}
+
+    def test_multiple_requests_mixed_encoding(self, collector):
+        port, log = collector
+        _post(port, "/v1/metrics", {"resourceMetrics": [{"mode": "content-length"}]})
+        _post(port, "/v1/logs", {"resourceLogs": [{"mode": "chunked"}]}, chunked=True)
+        _post(port, "/v1/metrics", {"resourceMetrics": [{"mode": "content-length-2"}]})
+
+        records = _read_log(log)
+        assert len(records) == 3
+        assert records[0]["payload"]["resourceMetrics"][0]["mode"] == "content-length"
+        assert records[1]["payload"]["resourceLogs"][0]["mode"] == "chunked"
+        assert records[2]["payload"]["resourceMetrics"][0]["mode"] == "content-length-2"


### PR DESCRIPTION
## Summary

This adds `_read_chunked()` to decode chunked bodies. The collector now handles both `Content-Length` and chunked requests.

## Evidence

All recent CI runs produce empty OTEL payloads and zero session metrics:

- **Payload agent**: [claude-session-metrics-autodl.json](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-main-claude-payload-agent/2073939627877601280/artifacts/claude-payload-agent/openshift-claude-payload-agent/artifacts/claude-session-metrics-autodl.json) — all zeros
- **Jira agent (CNTRLPLANE-3698)**: [solve session metrics](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-jira-agent/2074036323613675520/artifacts/periodic-jira-agent/hypershift-jira-agent-process/artifacts/claude-CNTRLPLANE-3698-solve-session-metrics-autodl.json) — all zeros
- **Review agent (PR #8319)**: [session metrics](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-hypershift-main-periodic-review-agent/2074052439379546112/artifacts/periodic-review-agent/hypershift-review-agent-process/artifacts/claude-8319-address-review-session-metrics-autodl.json) — all zeros

For comparison, runs from July 3rd (Claude Code v2.1.187) produced real data with cost, tokens, and duration.

## Root cause

**Hypothesis:** A recent Claude Code update (likely around v2.1.190, June 24) changed the OTLP exporter's HTTP transfer encoding. This is not documented in the Claude Code changelog — we identified it empirically by comparing what two versions actually send on the wire.

Observed behavior:
```
v2.1.187:  Content-Length: 4772, Transfer-Encoding: (none)    → payloads captured
v2.1.201:  Content-Length: (none), Transfer-Encoding: chunked  → payloads empty
```

The collector code that breaks:
```python
length = int(self.headers.get("Content-Length", 0))  # → 0 (header missing)
body = self.rfile.read(length) if length else b""     # → b""
payload = json.loads(body) if body else {}             # → {}
```

Python's `BaseHTTPRequestHandler` does not decode chunked bodies automatically — you must read and parse chunks manually.

## Local verification

Tested on macOS with Claude Code v2.1.201:

| Version | Payloads captured | Empty |
|---|---|---|
| **Unfixed** (0.3.14) | 0 | 3 |
| **Fixed** (this PR) | 4 | 0 |

## Test plan

- [x] 7 new unit tests covering Content-Length, chunked, empty body, traces, and mixed encoding
- [x] 648 total tests pass (641 existing + 7 new)
- [x] End-to-end verified with Claude Code v2.1.201 (chunked) and v2.1.187 (Content-Length)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of changes

* **Bug Fixes**
  * Improved handling of OTLP HTTP requests that use `Transfer-Encoding: chunked`.
  * Added clearer responses for malformed or oversized bodies (`400 Invalid Content-Length`, `413 Payload Too Large`).
  * Continued correct processing of valid submissions for metrics, logs, and traces, including mixed request formats.

* **Tests**
  * Added end-to-end pytest coverage for OTLP HTTP/JSON collection across metrics, logs, and traces, including chunked uploads, empty metrics (`Content-Length: 0`), and ordered log validation with preserved payload content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->