### PR TITLE
Fix stream processor treating error results as successful completion

### DIFF
--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -188,12 +188,15 @@ class ClaudeCodeStreamProcessor:
     def _format_result(self, msg):
         subtype = msg.get("subtype", "unknown")
         stop = msg.get("stop_reason", "")
+        is_error = msg.get("is_error", False)
         duration_ms = msg.get("duration_ms", 0)
         api_ms = msg.get("duration_api_ms", 0)
         ttft_ms = msg.get("ttft_ms", 0)
         turns = msg.get("num_turns", 0)
         cost = msg.get("total_cost_usd", 0)
         label = f"{subtype} ({stop})" if stop else subtype
+        if is_error:
+            label = f"ERROR: {label}"
         log.section(f"Result: {label}")
         log.detail(
             "Duration",
@@ -201,6 +204,10 @@ class ClaudeCodeStreamProcessor:
         )
         log.detail("Turns", str(turns))
         log.detail("Cost", f"${cost:.4f}")
+        if is_error:
+            error_text = msg.get("result", "")
+            if error_text:
+                log.detail("Error", error_text)
 
     def flush_errors(self):
         # Claude Code reports errors inline; nothing to flush.
@@ -254,6 +261,8 @@ class ClaudeCodeStreamProcessor:
         if msg_type == "result":
             self._end_block()
             self._format_result(msg)
+            if msg.get("is_error"):
+                return False
             return True
 
         if msg_type != "stream_event":

--- a/tests/test_stream_claude.py
+++ b/tests/test_stream_claude.py
@@ -1,0 +1,58 @@
+"""Tests for ClaudeCodeStreamProcessor."""
+
+import json
+
+from agentic_ci.stream import ClaudeCodeStreamProcessor
+
+
+def _make_result(is_error=False, **kwargs):
+    msg = {
+        "type": "result",
+        "subtype": "success",
+        "stop_reason": "stop_sequence",
+        "duration_ms": 400,
+        "duration_api_ms": 0,
+        "ttft_ms": 0,
+        "num_turns": 1,
+        "total_cost_usd": 0.0,
+        "result": "",
+        **kwargs,
+    }
+    if is_error:
+        msg["is_error"] = True
+    return json.dumps(msg)
+
+
+class TestProcessLineResult:
+    def test_successful_result_completes_stream(self):
+        proc = ClaudeCodeStreamProcessor(color=False)
+        assert proc.process_line(_make_result()) is True
+
+    def test_error_result_does_not_complete_stream(self):
+        proc = ClaudeCodeStreamProcessor(color=False)
+        line = _make_result(
+            is_error=True,
+            api_error_status=403,
+            result="Permission denied",
+        )
+        assert proc.process_line(line) is False
+
+    def test_error_result_is_error_false_completes_stream(self):
+        proc = ClaudeCodeStreamProcessor(color=False)
+        line = _make_result(is_error=False)
+        assert proc.process_line(line) is True
+
+
+class TestFormatResultError:
+    def test_error_result_prints_error_label(self, capsys):
+        proc = ClaudeCodeStreamProcessor(color=False)
+        proc.process_line(_make_result(is_error=True, result="Permission denied"))
+        out = capsys.readouterr().out
+        assert "ERROR:" in out
+        assert "Permission denied" in out
+
+    def test_successful_result_no_error_label(self, capsys):
+        proc = ClaudeCodeStreamProcessor(color=False)
+        proc.process_line(_make_result())
+        out = capsys.readouterr().out
+        assert "ERROR:" not in out


### PR DESCRIPTION
When Claude Code returns a result with is_error=true (e.g. a 403 permission denied from Vertex AI), the stream processor was marking stream_complete=True. This caused _resolve_exit_code to override the non-zero exit code to 0, hiding the error and making the CI job green.

Now process_line returns False for error results so the original exit code is preserved. Also surface the error message in _format_result so it's visible in streaming mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved result reporting to clearly mark error outcomes with an `ERROR:` label and include the error message when available.
  * Error results now use a distinct completion flow so they aren’t treated as successful run completions.

* **Tests**
  * Added test coverage for success vs. error handling in result processing.
  * Added assertions for console output to confirm the new `ERROR:` label behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->