### PR TITLE
RHAIFIRST-214: Include updated field in _fetch_comments

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -290,6 +290,7 @@ class JiraClient:
                     "author_email": c.get("author", {}).get("emailAddress", ""),
                     "body": body,
                     "created": c.get("created", ""),
+                    "updated": c.get("updated", ""),
                     "visibility": c.get("visibility"),
                 }
             )
@@ -339,6 +340,7 @@ class JiraClient:
                             "author_email": c.get("author", {}).get("emailAddress", ""),
                             "body": body,
                             "created": c.get("created", ""),
+                            "updated": c.get("updated", ""),
                             "visibility": c.get("visibility"),
                         }
                     )

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -78,6 +78,45 @@ class TestGetIssue:
         assert result["reporter_email"] == "j@test.com"
         assert result["labels"] == ["autofix"]
 
+    @patch("agentic_ci.jira.client.requests")
+    def test_fetch_comments_includes_updated(self, mock_requests, client):
+        issue_resp = MagicMock()
+        issue_resp.status_code = 200
+        issue_resp.json.return_value = {
+            "key": "TEST-1",
+            "fields": {
+                "summary": "s",
+                "description": "",
+                "issuetype": {"name": "Bug"},
+                "labels": [],
+                "status": {"name": "Open"},
+                "reporter": {},
+                "components": [],
+                "project": {"key": "TEST"},
+            },
+        }
+
+        comment_resp = MagicMock()
+        comment_resp.status_code = 200
+        comment_resp.json.return_value = {
+            "comments": [
+                {
+                    "id": "100",
+                    "author": {"displayName": "Bot", "emailAddress": "bot@test.com"},
+                    "body": "initial comment",
+                    "created": "2026-07-06T18:00:00.000+0000",
+                    "updated": "2026-07-06T22:43:38.000+0000",
+                }
+            ]
+        }
+
+        mock_requests.get.side_effect = [issue_resp, comment_resp]
+
+        result = client.get_issue("TEST-1")
+        assert len(result["comments"]) == 1
+        assert result["comments"][0]["created"] == "2026-07-06T18:00:00.000+0000"
+        assert result["comments"][0]["updated"] == "2026-07-06T22:43:38.000+0000"
+
 
 class TestSearch:
     @patch("agentic_ci.jira.client.requests")


### PR DESCRIPTION
## Summary

`_fetch_comments()` omitted the Jira comment `updated` timestamp. Downstream `get_last_bot_comment_epoch()` (autofix MR 909) tries `c.get("updated", "")` which always returned `""`, freezing the iterate pipeline's `since` filter at the comment creation time. Old MR comments were re-processed as "new feedback" every cycle.

## Changes

1. **`src/agentic_ci/jira/client.py`**: Add `"updated": c.get("updated", "")` to comment dicts in both `_fetch_comments()` and `search()`.
2. **`tests/test_jira_client.py`**: Add test verifying `updated` field is present in fetched comments.

## Test plan

- [x] All 660 existing tests pass
- [x] New test `test_fetch_comments_includes_updated` verifies the `updated` field is included
- [x] `ruff check` and `ruff format --check` pass

Closes RHAIFIRST-214

🤖 Generated with [Claude Code](https://claude.com/claude-code)