### PR TITLE
AIPCC-20128: Fix trace finalization API and restore OTEL flush wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,14 @@ jobs:
       matrix:
         tox_env: [py310, py311, py312, py313, lint, check-format, typecheck]
     runs-on: ubuntu-latest
+
+  mlflow-e2e:
+    name: MLflow E2E
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+      - name: Run MLflow E2E tests
+        run: pip install tox && tox -e mlflow-e2e
+    runs-on: ubuntu-latest

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -6,6 +6,7 @@ import os
 import subprocess
 import sys
 import threading
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -156,8 +157,12 @@ class Backend(ABC):
         return "".join(filtered).encode("utf-8") if filtered else b""
 
     def _wait_for_otel_flush(self, otel_port):
-        """Legacy hook kept for backend subclass compatibility.
+        """Wait for OTEL metrics to flush after the agent stream ends.
 
-        OTEL flush is now handled in _process_stream by waiting for the
-        process to exit naturally after stream completion.
+        For containerized backends (OpenShell), _process_stream terminates
+        the local exec wrapper, not the remote Claude Code process.  The
+        OTEL batch exporter inside the container may still be flushing to
+        the host collector, so we give it time.
         """
+        if otel_port:
+            time.sleep(7)

--- a/src/agentic_ci/mlflow.py
+++ b/src/agentic_ci/mlflow.py
@@ -341,16 +341,17 @@ def _finalize_traces(endpoint, headers, trace_ids):
     # Batch-fetch trace info for all pushed trace IDs.
     in_progress = []
     try:
-        resp = requests.get(
-            f"{endpoint}/api/2.0/mlflow/traces",
-            params=[("request_ids", tid) for tid in trace_ids],
+        resp = requests.post(
+            f"{endpoint}/api/3.0/mlflow/traces/batchGetInfos",
+            json={"trace_ids": trace_ids},
             headers=headers,
             timeout=10,
         )
         resp.raise_for_status()
-        for trace in resp.json().get("traces", []):
-            if trace.get("status") == "IN_PROGRESS":
-                in_progress.append(trace["request_id"])
+        for trace in resp.json().get("trace_infos", []):
+            tid = trace.get("trace_id")
+            if tid and trace.get("state") == "IN_PROGRESS":
+                in_progress.append(tid)
     except requests.RequestException as e:
         print(f"Trace status lookup failed: {e}", file=sys.stderr)
         return 0

--- a/tests/e2e/test_mlflow_e2e.py
+++ b/tests/e2e/test_mlflow_e2e.py
@@ -1,0 +1,429 @@
+"""E2E tests for mlflow-push against a real MLflow server.
+
+Starts a local MLflow server, generates synthetic OTEL JSONL data, pushes
+it through push_traces(), and verifies the results via the MLflow Python
+client.  Catches API contract mismatches (field names, endpoint versions)
+that unit tests with mocked HTTP cannot detect.
+
+Run with: tox -e mlflow-e2e
+"""
+
+import json
+import signal
+import subprocess
+import sys
+import time
+
+import mlflow
+import pytest
+
+from agentic_ci.mlflow import push_traces
+
+_EXPERIMENT = "mlflow-e2e-test"
+
+
+def _wait_for_server(port, timeout=15):
+    """Poll until the MLflow server responds."""
+    import requests
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            resp = requests.get(
+                f"http://127.0.0.1:{port}/api/2.0/mlflow/experiments/search",
+                json={"filter": "", "max_results": 1},
+                timeout=2,
+            )
+            if resp.status_code == 200:
+                return
+        except requests.ConnectionError:
+            pass
+        time.sleep(0.5)
+    raise RuntimeError(f"MLflow server on port {port} did not start within {timeout}s")
+
+
+@pytest.fixture(scope="module")
+def mlflow_server(tmp_path_factory):
+    """Start a local MLflow server for the test session."""
+    tmp = tmp_path_factory.mktemp("mlflow")
+    db_path = tmp / "mlflow.db"
+    artifacts = tmp / "artifacts"
+    artifacts.mkdir()
+
+    port = 15555
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--backend-store-uri",
+            f"sqlite:///{db_path}",
+            "--artifacts-destination",
+            str(artifacts),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_server(port)
+        endpoint = f"http://127.0.0.1:{port}"
+        mlflow.set_tracking_uri(endpoint)
+        mlflow.create_experiment(_EXPERIMENT)
+        yield endpoint
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+@pytest.fixture()
+def client():
+    return mlflow.MlflowClient()
+
+
+def _write_jsonl(tmp_path, records):
+    path = tmp_path / "claude-otel.jsonl"
+    with open(path, "w") as f:
+        for rec in records:
+            f.write(json.dumps(rec) + "\n")
+    return str(path)
+
+
+def _trace_record(spans, trace_id="aabb112233445566aabb112233445566"):
+    """Build an OTLP trace JSONL record."""
+    for s in spans:
+        s.setdefault("traceId", trace_id)
+        s.setdefault("kind", 1)
+        s.setdefault("startTimeUnixNano", "1000000000")
+        s.setdefault("endTimeUnixNano", "2000000000")
+        s.setdefault("status", {"code": 0})
+        s.setdefault("attributes", [])
+    return {
+        "path": "/v1/traces",
+        "payload": {"resourceSpans": [{"scopeSpans": [{"spans": spans}]}]},
+    }
+
+
+def _metric_record(session_id, cost):
+    """Build an OTLP metrics JSONL record with a cost data point."""
+    return {
+        "path": "/v1/metrics",
+        "payload": {
+            "resourceMetrics": [
+                {
+                    "scopeMetrics": [
+                        {
+                            "metrics": [
+                                {
+                                    "name": "claude_code.cost.usage",
+                                    "sum": {
+                                        "aggregationTemporality": 1,
+                                        "dataPoints": [
+                                            {
+                                                "asDouble": cost,
+                                                "attributes": [
+                                                    {
+                                                        "key": "session.id",
+                                                        "value": {
+                                                            "stringValue": session_id,
+                                                        },
+                                                    }
+                                                ],
+                                            }
+                                        ],
+                                    },
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+
+
+def _log_record(request_id, query_source):
+    """Build an OTLP logs JSONL record with a query_source event."""
+    return {
+        "path": "/v1/logs",
+        "payload": {
+            "resourceLogs": [
+                {
+                    "scopeLogs": [
+                        {
+                            "logRecords": [
+                                {
+                                    "attributes": [
+                                        {
+                                            "key": "event.name",
+                                            "value": {
+                                                "stringValue": "claude_code.api_request",
+                                            },
+                                        },
+                                        {
+                                            "key": "request_id",
+                                            "value": {"stringValue": request_id},
+                                        },
+                                        {
+                                            "key": "query_source",
+                                            "value": {"stringValue": query_source},
+                                        },
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+    }
+
+
+class TestTraceWithRoot:
+    """Trace that has a root span should land as OK."""
+
+    def test_ok_trace(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000010000000000000001"
+        root = {
+            "spanId": "0000000000000001",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        child = {
+            "spanId": "0000000000000002",
+            "parentSpanId": "0000000000000001",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+            "attributes": [
+                {"key": "input_tokens", "value": {"intValue": "100"}},
+                {"key": "output_tokens", "value": {"intValue": "50"}},
+            ],
+        }
+        path = _write_jsonl(tmp_path, [_trace_record([root, child], trace_id=tid)])
+        result = push_traces(path, mlflow_server, _EXPERIMENT)
+
+        assert result.ok == 1
+        assert result.err == 0
+        assert f"tr-{tid}" in result.trace_ids
+
+        trace = client.get_trace(f"tr-{tid}")
+        assert str(trace.info.status) == "TraceStatus.OK"
+        assert len(trace.data.spans) == 2
+
+
+class TestTraceWithoutRoot:
+    """Trace with missing root span should be finalized to ERROR."""
+
+    def test_finalized_to_error(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000020000000000000002"
+        child1 = {
+            "spanId": "0000000000000003",
+            "parentSpanId": "aaaa000000000000",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+        }
+        child2 = {
+            "spanId": "0000000000000004",
+            "parentSpanId": "aaaa000000000000",
+            "name": "claude_code.tool",
+            "traceId": tid,
+        }
+        path = _write_jsonl(tmp_path, [_trace_record([child1, child2], trace_id=tid)])
+        result = push_traces(path, mlflow_server, _EXPERIMENT)
+
+        assert result.ok == 1
+        assert result.err == 0
+
+        trace = client.get_trace(f"tr-{tid}")
+        assert str(trace.info.status) == "TraceStatus.ERROR"
+
+
+class TestTokenUsage:
+    """Token usage attributes should be mapped to MLflow conventions."""
+
+    def test_token_and_genai_attrs(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000030000000000000003"
+        root = {
+            "spanId": "0000000000000005",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        llm = {
+            "spanId": "0000000000000006",
+            "parentSpanId": "0000000000000005",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+            "attributes": [
+                {"key": "input_tokens", "value": {"intValue": "10"}},
+                {"key": "output_tokens", "value": {"intValue": "200"}},
+                {"key": "cache_read_tokens", "value": {"intValue": "5000"}},
+                {"key": "cache_creation_tokens", "value": {"intValue": "1000"}},
+            ],
+        }
+        path = _write_jsonl(tmp_path, [_trace_record([root, llm], trace_id=tid)])
+        push_traces(path, mlflow_server, _EXPERIMENT)
+
+        trace = client.get_trace(f"tr-{tid}")
+        llm_span = next(s for s in trace.data.spans if s.name == "claude_code.llm_request")
+
+        usage = llm_span.attributes.get("mlflow.chat.tokenUsage")
+        assert usage is not None
+        if isinstance(usage, str):
+            usage = json.loads(usage)
+        assert usage["input_tokens"] == 10
+        assert usage["output_tokens"] == 200
+        assert usage["total_tokens"] == 210
+        assert usage["cache_read_input_tokens"] == 5000
+        assert usage["cache_creation_input_tokens"] == 1000
+
+        assert int(llm_span.attributes["gen_ai.usage.input_tokens"]) == 10
+        assert int(llm_span.attributes["gen_ai.usage.output_tokens"]) == 200
+
+
+class TestCostAttribution:
+    """Cost from /v1/metrics should be distributed across spans."""
+
+    def test_cost_distributed(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000040000000000000004"
+        sid = "cost-test-session-1"
+        root = {
+            "spanId": "0000000000000007",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        llm1 = {
+            "spanId": "0000000000000008",
+            "parentSpanId": "0000000000000007",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+            "attributes": [
+                {"key": "session.id", "value": {"stringValue": sid}},
+                {"key": "input_tokens", "value": {"intValue": "100"}},
+                {"key": "output_tokens", "value": {"intValue": "0"}},
+            ],
+        }
+        llm2 = {
+            "spanId": "0000000000000009",
+            "parentSpanId": "0000000000000007",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+            "attributes": [
+                {"key": "session.id", "value": {"stringValue": sid}},
+                {"key": "input_tokens", "value": {"intValue": "0"}},
+                {"key": "output_tokens", "value": {"intValue": "300"}},
+            ],
+        }
+        records = [
+            _trace_record([root, llm1, llm2], trace_id=tid),
+            _metric_record(sid, 0.40),
+        ]
+        path = _write_jsonl(tmp_path, records)
+        push_traces(path, mlflow_server, _EXPERIMENT)
+
+        trace = client.get_trace(f"tr-{tid}")
+        llm_spans = [s for s in trace.data.spans if s.name == "claude_code.llm_request"]
+        costs = []
+        for s in llm_spans:
+            raw = s.attributes.get("mlflow.llm.cost")
+            assert raw is not None, f"span {s.span_id} missing mlflow.llm.cost"
+            cost_data = json.loads(raw) if isinstance(raw, str) else raw
+            costs.append(cost_data["total_cost"])
+
+        assert abs(sum(costs) - 0.40) < 1e-9
+
+
+class TestQuerySource:
+    """query_source from /v1/logs should be joined to spans by request_id."""
+
+    def test_source_tagged(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000050000000000000005"
+        root = {
+            "spanId": "000000000000000a",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        llm = {
+            "spanId": "000000000000000b",
+            "parentSpanId": "000000000000000a",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+            "attributes": [
+                {"key": "request_id", "value": {"stringValue": "req-42"}},
+            ],
+        }
+        records = [
+            _trace_record([root, llm], trace_id=tid),
+            _log_record("req-42", "generate_session_title"),
+        ]
+        path = _write_jsonl(tmp_path, records)
+        push_traces(path, mlflow_server, _EXPERIMENT)
+
+        trace = client.get_trace(f"tr-{tid}")
+        llm_span = next(s for s in trace.data.spans if s.name == "claude_code.llm_request")
+        assert llm_span.attributes.get("query_source") == "generate_session_title"
+
+
+class TestMultiPayloadTrace:
+    """Spans for the same trace split across multiple OTLP payloads
+    should be merged into one trace by MLflow."""
+
+    def test_merged(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000060000000000000006"
+        root = {
+            "spanId": "000000000000000c",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        child1 = {
+            "spanId": "000000000000000d",
+            "parentSpanId": "000000000000000c",
+            "name": "claude_code.llm_request",
+            "traceId": tid,
+        }
+        child2 = {
+            "spanId": "000000000000000e",
+            "parentSpanId": "000000000000000c",
+            "name": "claude_code.tool",
+            "traceId": tid,
+            "startTimeUnixNano": "3000000000",
+            "endTimeUnixNano": "4000000000",
+        }
+        records = [
+            _trace_record([root, child1], trace_id=tid),
+            _trace_record([child2], trace_id=tid),
+        ]
+        path = _write_jsonl(tmp_path, records)
+        result = push_traces(path, mlflow_server, _EXPERIMENT)
+
+        assert result.ok == 2
+
+        trace = client.get_trace(f"tr-{tid}")
+        assert str(trace.info.status) == "TraceStatus.OK"
+        assert len(trace.data.spans) == 3
+
+
+class TestOTLPJsonAccepted:
+    """Verify payloads are sent as JSON (not protobuf)."""
+
+    def test_hex_ids_preserved(self, mlflow_server, client, tmp_path):
+        tid = "00000000000000070000000000000007"
+        span = {
+            "spanId": "000000000000000f",
+            "name": "claude_code.session",
+            "traceId": tid,
+        }
+        path = _write_jsonl(tmp_path, [_trace_record([span], trace_id=tid)])
+        result = push_traces(path, mlflow_server, _EXPERIMENT)
+
+        assert result.ok == 1
+        trace = client.get_trace(f"tr-{tid}")
+        assert trace is not None
+        assert len(trace.data.spans) == 1

--- a/tests/test_mlflow.py
+++ b/tests/test_mlflow.py
@@ -409,17 +409,12 @@ class TestPushTraces:
         finally:
             os.unlink(path)
 
-    @patch("agentic_ci.mlflow.requests.get")
     @patch("agentic_ci.mlflow.requests.post")
-    def test_sends_json_content_type(self, mock_post, mock_get):
+    def test_sends_json_content_type(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {"experiments": [{"experiment_id": "123"}]}
         mock_post.return_value = mock_resp
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {"traces": []}
-        mock_get.return_value = mock_get_resp
 
         path = self._write_jsonl([{"path": "/v1/traces", "payload": copy.deepcopy(TRACE_PAYLOAD)}])
         try:
@@ -435,17 +430,12 @@ class TestPushTraces:
         assert "json" in trace_call.kwargs
         assert "data" not in trace_call.kwargs
 
-    @patch("agentic_ci.mlflow.requests.get")
     @patch("agentic_ci.mlflow.requests.post")
-    def test_sends_valid_json_body(self, mock_post, mock_get):
+    def test_sends_valid_json_body(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {"experiments": [{"experiment_id": "42"}]}
         mock_post.return_value = mock_resp
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {"traces": []}
-        mock_get.return_value = mock_get_resp
 
         path = self._write_jsonl([{"path": "/v1/traces", "payload": copy.deepcopy(TRACE_PAYLOAD)}])
         try:
@@ -460,17 +450,12 @@ class TestPushTraces:
         assert span["name"] == "test-span"
         assert span["traceId"] == "0af7651916cd43dd8448eb211c80319c"
 
-    @patch("agentic_ci.mlflow.requests.get")
     @patch("agentic_ci.mlflow.requests.post")
-    def test_returns_trace_and_session_ids(self, mock_post, mock_get):
+    def test_returns_trace_and_session_ids(self, mock_post):
         mock_resp = MagicMock()
         mock_resp.raise_for_status = MagicMock()
         mock_resp.json.return_value = {"experiments": [{"experiment_id": "1"}]}
         mock_post.return_value = mock_resp
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {"traces": []}
-        mock_get.return_value = mock_get_resp
 
         payload = copy.deepcopy(TRACE_PAYLOAD)
         payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"].append(
@@ -498,14 +483,14 @@ class TestPushTraces:
 
 class TestFinalizeTraces:
     @patch("agentic_ci.mlflow.requests.patch")
-    @patch("agentic_ci.mlflow.requests.get")
-    def test_finalizes_in_progress_trace(self, mock_get, mock_patch):
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {
-            "traces": [{"request_id": "tr-abc", "status": "IN_PROGRESS"}]
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_finalizes_in_progress_trace(self, mock_post, mock_patch):
+        mock_post_resp = MagicMock()
+        mock_post_resp.raise_for_status = MagicMock()
+        mock_post_resp.json.return_value = {
+            "trace_infos": [{"trace_id": "tr-abc", "state": "IN_PROGRESS"}]
         }
-        mock_get.return_value = mock_get_resp
+        mock_post.return_value = mock_post_resp
         mock_patch_resp = MagicMock()
         mock_patch_resp.raise_for_status = MagicMock()
         mock_patch.return_value = mock_patch_resp
@@ -516,29 +501,29 @@ class TestFinalizeTraces:
         call_json = mock_patch.call_args.kwargs["json"]
         assert call_json["status"] == "ERROR"
 
-    @patch("agentic_ci.mlflow.requests.get")
-    def test_skips_ok_trace(self, mock_get):
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {"traces": [{"request_id": "tr-abc", "status": "OK"}]}
-        mock_get.return_value = mock_get_resp
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_skips_ok_trace(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"trace_infos": [{"trace_id": "tr-abc", "state": "OK"}]}
+        mock_post.return_value = mock_resp
 
         count = _finalize_traces("http://mlflow:5000", {}, ["tr-abc"])
         assert count == 0
 
-    @patch("agentic_ci.mlflow.requests.get")
-    def test_skips_missing_trace(self, mock_get):
-        mock_get_resp = MagicMock()
-        mock_get_resp.raise_for_status = MagicMock()
-        mock_get_resp.json.return_value = {"traces": []}
-        mock_get.return_value = mock_get_resp
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_skips_missing_trace(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"trace_infos": []}
+        mock_post.return_value = mock_resp
 
         count = _finalize_traces("http://mlflow:5000", {}, ["tr-abc"])
         assert count == 0
 
-    @patch("agentic_ci.mlflow.requests.get")
-    def test_handles_request_error(self, mock_get):
-        mock_get.side_effect = requests.RequestException("timeout")
+    @patch("agentic_ci.mlflow.requests.post")
+    def test_handles_request_error(self, mock_post):
+        mock_post.side_effect = requests.RequestException("timeout")
         count = _finalize_traces("http://mlflow:5000", {}, ["tr-abc"])
         assert count == 0
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ description = Run tests
 deps =
     pytest
     pyyaml
-commands = pytest {posargs:tests/}
+commands = pytest {posargs:tests/ --ignore=tests/e2e/test_mlflow_e2e.py}
 
 [testenv:lint]
 description = Run code linter
@@ -35,6 +35,14 @@ commands = mypy src/
 description = Format code
 deps = ruff
 commands = ruff format .
+
+[testenv:mlflow-e2e]
+description = MLflow integration e2e tests (starts a real MLflow server)
+basepython = python3.12
+deps =
+    pytest
+    mlflow
+commands = pytest tests/e2e/test_mlflow_e2e.py {posargs}
 
 [testenv:docs]
 description = Build documentation


### PR DESCRIPTION
## Summary

### Commit 1: Fix trace finalization API and restore OTEL flush wait
- **Fix finalization API:** Switch from `GET /api/2.0/mlflow/traces?request_ids=` (returns 400 on production MLflow) to `POST /api/3.0/mlflow/traces/batchGetInfos`. Fixed field name mismatch: v3 API uses `state`/`trace_id` not `status`/`request_id`. Guard against missing `trace_id` in response (CodeRabbit fix).
- **Restore OTEL flush wait:** For OpenShell (containerized) backends, `_process_stream` terminates the local exec wrapper, not the remote Claude Code process. The OTEL batch exporter inside the container may still be flushing to the host collector, so the 7s sleep is still needed.
- **URL-encode trace IDs** in the PATCH finalization path.

### Commit 2: Add MLflow integration e2e test suite (AIPCC-21323)
- Starts a real MLflow server, generates synthetic OTEL data, pushes through `push_traces()`, and verifies via the MLflow Python client.
- 7 test scenarios: OK trace, missing-root finalization, token usage mapping, cost distribution, query_source join, multi-payload merging, OTLP JSON acceptance.
- Runs as a separate tox env (`mlflow-e2e`) and CI job to avoid adding MLflow as a dependency for the main test suite.
- Catches API contract mismatches (field names, endpoint versions) that unit tests with mocked HTTP cannot detect.

## Test plan

- [x] All 694 unit tests pass (py312), lint/format/mypy clean
- [x] All 7 MLflow e2e tests pass (`tox -e mlflow-e2e`)
- [x] E2E verified: pushed real CI OTEL data to local MLflow 3.14.0, confirmed `batchGetInfos` lookup + PATCH finalization works end-to-end
- [x] Tested with the exact OTEL artifact from the failing job (RHOAIENG-69237)

🤖 Generated with [Claude Code](https://claude.com/claude-code)