### PR TITLE
Add setup steps for pre-sandbox dependency installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ src/agentic_ci/
             gateway.py  # OpenShell gateway lifecycle
             sandbox.py  # OpenShell sandbox lifecycle
             policy.py   # Policy resolution + built-in default
+    config.py           # Project config loader (.agentic-ci/config.yml)
     plugins.py          # Plugin/skill install (build-time) and filtering (runtime)
     stream.py           # Stream parsers for Claude Code and OpenCode output
     otel.py             # OTLP collector + token/cost summary
@@ -42,7 +43,9 @@ src/agentic_ci/
 
 - **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Bind-mounts the workdir into the container at `/workspace`, so changes are visible on the host immediately. Mounts gcloud credentials as read-only volumes. Uses `--network host` when OTEL is enabled.
 
-- **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Uploads the workdir into the sandbox on `setup()` and downloads it back after `run()` completes. Only changes inside the workdir are reflected back to the host; files written elsewhere in the sandbox are not retrieved. Manages gateway lifecycle, sandbox creation with network policy, and credential injection. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
+- **`config.py`**: Loads project configuration from `.agentic-ci/config.yml` in the workdir. Currently supports a `setup` key with a list of commands (bare strings or `{name, run}` objects) that run on the host before sandbox upload, enabling dependency installation for repos whose agents need it.
+
+- **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Uploads the workdir into the sandbox on `setup()` and downloads it back after `run()` completes. Only changes inside the workdir are reflected back to the host; files written elsewhere in the sandbox are not retrieved. Manages gateway lifecycle, sandbox creation with network policy, credential injection, and setup steps. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
 
 - **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. Both produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
 

--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -222,18 +222,9 @@ The default endpoints cover:
 ### Project-specific endpoints
 
 Projects can declare additional endpoints in
-`.agentic-ci/openshell-policy.yml` at the repository root. These are
-merged with the built-in defaults (duplicates are ignored).
-
-```yaml
-# .agentic-ci/openshell-policy.yml
-endpoints:
-  - "redhat.atlassian.net:443:read-only"
-  - "*.example.com:443:full"
-```
-
-The `--policy` CLI flag takes precedence: if a flag path is provided
-and the file exists, the repo-level file is ignored.
+`.agentic-ci/openshell-policy.yml`. See
+[Project Configuration](../configuration.md#network-policy-openshell)
+for details.
 
 ## Supervisor Image
 

--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -15,9 +15,11 @@ environment). On each `agentic-ci run --backend openshell`, it:
 2. Creates a GCP or Anthropic credential provider
 3. Creates a sandbox container from the specified image
 4. Applies a network policy and waits for it to activate
-5. Uploads an env script with agent configuration
-6. Executes the agent inside the sandbox
-7. Tears everything down on completion
+5. Runs setup steps on the host (if configured in `.agentic-ci/config.yml`)
+6. Uploads the workdir (including setup step outputs) into the sandbox
+7. Uploads an env script with agent configuration
+8. Executes the agent inside the sandbox
+9. Tears everything down on completion
 
 ## OpenShell Commands
 
@@ -174,6 +176,21 @@ openshell sandbox get ci                         # check if exists
 openshell sandbox delete ci
 openshell gateway remove ci                      # deregister from CLI
 # Gateway and podman service processes are killed by PID
+```
+
+## Setup Steps
+
+Because the sandbox has no internet access by default, repositories that
+need dependency installation (e.g. `npm ci` for Node.js projects) can
+define **setup steps** that run on the host before the workdir is
+uploaded. See [Project Configuration](../configuration.md#setup-steps)
+for full details.
+
+```yaml
+# .agentic-ci/config.yml
+setup:
+  - name: Install dependencies
+    run: npm ci
 ```
 
 ## Network Policy

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,8 +16,10 @@ them ideal for dependency installation that the sandboxed agent cannot
 perform itself.
 
 This is primarily useful for the **OpenShell backend**, where the sandbox
-has no internet access by default. The Podman and Local backends already
-have network access, so setup steps are not needed there.
+restricts network access to a small set of allowed endpoints (GitHub,
+GitLab, Vertex AI, etc.) and does not permit general-purpose package
+registry access. The Podman and Local backends already have full network
+access, so setup steps are not needed there.
 
 ### Configuration
 
@@ -60,7 +62,7 @@ Each step object accepts:
    uploaded into the sandbox
 4. The agent starts inside the sandbox
 
-```
+```text
 Host (internet access)          Sandbox (isolated)
 ─────────────────────           ──────────────────
 1. sandbox.create()
@@ -94,4 +96,27 @@ setup:
 ```
 
 This ensures `node_modules/` is present inside the sandbox so the agent
-can run tests, linting, and type checks without needing internet access.
+can run tests, linting, and type checks without needing general internet
+access.
+
+## Network Policy (OpenShell)
+
+Projects can declare additional network endpoints for the OpenShell
+sandbox in `.agentic-ci/openshell-policy.yml`. These are merged with
+the built-in defaults (duplicates are ignored).
+
+```yaml
+# .agentic-ci/openshell-policy.yml
+endpoints:
+  - "redhat.atlassian.net:443:read-only"
+  - "*.example.com:443:full"
+```
+
+Each endpoint uses the format `host:port:access` where access is one of
+`full`, `read-only`, or `read-write`.
+
+The `--policy` CLI flag takes precedence: if a flag path is provided and
+the file exists, the repo-level file is ignored.
+
+See [OpenShell Backend](backends/openshell.md) for the full list of
+built-in default endpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,97 @@
+# Project Configuration
+
+Repositories can configure agentic-ci behavior by placing files in a
+`.agentic-ci/` directory at the repository root.
+
+| File | Purpose |
+|------|---------|
+| `config.yml` | General project configuration (setup steps, etc.) |
+| `openshell-policy.yml` | Additional network endpoints for the OpenShell sandbox |
+
+## Setup Steps
+
+Setup steps are commands that run on the host **before** the workdir is
+uploaded into the sandbox. They execute with full network access, making
+them ideal for dependency installation that the sandboxed agent cannot
+perform itself.
+
+This is primarily useful for the **OpenShell backend**, where the sandbox
+has no internet access by default. The Podman and Local backends already
+have network access, so setup steps are not needed there.
+
+### Configuration
+
+Add a `setup` key to `.agentic-ci/config.yml`:
+
+```yaml
+# .agentic-ci/config.yml
+setup:
+  - name: Install dependencies
+    run: npm ci
+  - name: Build project
+    run: npm run build
+```
+
+Both object form and bare-string shorthand are supported:
+
+```yaml
+# Object form (recommended for clarity)
+setup:
+  - name: Install dependencies
+    run: npm ci
+
+# Bare-string shorthand
+setup:
+  - npm ci
+```
+
+Each step object accepts:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `run` | yes | Shell command to execute |
+| `name` | no | Human-readable label for log output |
+
+### How It Works
+
+1. The sandbox is created and the network policy is applied
+2. Setup steps run sequentially on the host in the workdir
+3. The workdir (now including setup step outputs like `node_modules/`) is
+   uploaded into the sandbox
+4. The agent starts inside the sandbox
+
+```
+Host (internet access)          Sandbox (isolated)
+─────────────────────           ──────────────────
+1. sandbox.create()
+2. npm ci  ─────────────┐
+   (setup step)         │
+3. sandbox.upload() ────┼──→  /sandbox/repo/
+                        │     ├── node_modules/  ✓
+                        │     ├── src/
+                        │     └── ...
+4.                      └──→  agent starts
+```
+
+### Behavior
+
+- Steps run with `shell=True`, so pipes, redirects, and shell builtins
+  work as expected.
+- Steps run sequentially in the order they appear in the config.
+- If a step fails (non-zero exit code), the run aborts with an error.
+- Each step has a 10-minute timeout to prevent hanging commands from
+  blocking CI indefinitely.
+- Malformed entries (e.g. missing `run` key, non-string `run` value) are
+  skipped with a warning.
+
+### Example: Node.js Project
+
+```yaml
+# .agentic-ci/config.yml
+setup:
+  - name: Install dependencies
+    run: npm ci
+```
+
+This ensures `node_modules/` is present inside the sandbox so the agent
+can run tests, linting, and type checks without needing internet access.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ simplicity and security.
 
 - **Multiple backends**: Local (direct execution), Podman containers, or OpenShell sandboxes with network policy enforcement
 - **Multiple harnesses**: Claude Code and OpenCode agent CLIs
+- **Setup steps**: Pre-sandbox dependency installation for repos that need it
 - **Streaming output**: Colored, parsed CI logs with tool call summaries and token tracking
 - **OTEL telemetry**: Token usage, cost tracking, and metrics collection
 - **Gates**: Pre- and post-agent validation (sensitive files, commit checks, secret scanning)
@@ -56,6 +57,7 @@ backend.stop()
 
 ## Learn more
 
+- [Project Configuration](configuration.md) -- setup steps and per-repo config
 - [OTEL Architecture](otel-architecture.md) -- collector, trace completeness, MLflow pipeline
 - [OTEL Configuration](otel-configuration.md) -- per-harness env var reference
 - [MLflow Trace Export](mlflow-traces.md) -- CI setup and enrichment details

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentic_ci import log
+from agentic_ci.config import load_config
 
 if TYPE_CHECKING:
     from agentic_ci.harness import Harness
@@ -156,6 +157,22 @@ class Backend(ABC):
         lines = buf.decode("utf-8", errors="replace").splitlines(keepends=True)
         filtered = [line for line in lines if not any(p in line for p in cls._STDERR_NOISE)]
         return "".join(filtered).encode("utf-8") if filtered else b""
+
+    def _run_setup_steps(self):
+        """Run repo-defined setup commands on the host before the agent starts.
+
+        Setup steps execute with full network access outside any sandbox,
+        allowing dependency installation (e.g. ``npm ci``) whose outputs
+        are available to the agent at runtime.
+        """
+        config = load_config(self.workdir)
+        if not config.setup:
+            return
+
+        log.section("Running setup steps")
+        for step in config.setup:
+            log.info(f"  {step.name}: {step.run}")
+            subprocess.run(step.run, shell=True, cwd=self.workdir, check=True, timeout=600)
 
     def _wait_for_otel_flush(self, otel_port):
         """Wait for OTEL metrics to flush after the agent stream ends.

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -28,6 +28,7 @@ class LocalBackend(Backend):
 
     def setup(self, otel_port=None):
         log.section("Local backend (direct execution)")
+        self._run_setup_steps()
 
     def stop(self):
         pass

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 from agentic_ci import log
 from agentic_ci.backend import Backend
 from agentic_ci.backends.openshell import gateway, provider, sandbox
+from agentic_ci.config import load_config
 
 if TYPE_CHECKING:
     from agentic_ci.harness import Harness
@@ -124,6 +125,8 @@ class OpenShellBackend(Backend):
             approval_mode=self.approval_mode,
         )
 
+        self._run_setup_steps()
+
         log.section("Uploading workdir")
         sandbox.upload(self.workdir)
 
@@ -142,6 +145,22 @@ class OpenShellBackend(Backend):
                 sandbox.exec_cmd(["mv", fname, container_path])
         finally:
             shutil.rmtree(config_dir, ignore_errors=True)
+
+    def _run_setup_steps(self):
+        """Run repo-defined setup commands on the host before uploading the workdir.
+
+        Setup steps execute with full network access outside the sandbox,
+        allowing dependency installation (e.g. ``npm ci``) whose outputs
+        are then included in the workdir upload.
+        """
+        config = load_config(self.workdir)
+        if not config.setup:
+            return
+
+        log.section("Running setup steps")
+        for step in config.setup:
+            log.info(f"  {step.name}: {step.run}")
+            subprocess.run(step.run, shell=True, cwd=self.workdir, check=True)
 
     def stop(self):
         try:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -13,7 +13,6 @@ from typing import TYPE_CHECKING
 from agentic_ci import log
 from agentic_ci.backend import Backend
 from agentic_ci.backends.openshell import gateway, provider, sandbox
-from agentic_ci.config import load_config
 
 if TYPE_CHECKING:
     from agentic_ci.harness import Harness
@@ -145,22 +144,6 @@ class OpenShellBackend(Backend):
                 sandbox.exec_cmd(["mv", fname, container_path])
         finally:
             shutil.rmtree(config_dir, ignore_errors=True)
-
-    def _run_setup_steps(self):
-        """Run repo-defined setup commands on the host before uploading the workdir.
-
-        Setup steps execute with full network access outside the sandbox,
-        allowing dependency installation (e.g. ``npm ci``) whose outputs
-        are then included in the workdir upload.
-        """
-        config = load_config(self.workdir)
-        if not config.setup:
-            return
-
-        log.section("Running setup steps")
-        for step in config.setup:
-            log.info(f"  {step.name}: {step.run}")
-            subprocess.run(step.run, shell=True, cwd=self.workdir, check=True, timeout=600)
 
     def stop(self):
         try:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -160,7 +160,7 @@ class OpenShellBackend(Backend):
         log.section("Running setup steps")
         for step in config.setup:
             log.info(f"  {step.name}: {step.run}")
-            subprocess.run(step.run, shell=True, cwd=self.workdir, check=True)
+            subprocess.run(step.run, shell=True, cwd=self.workdir, check=True, timeout=600)
 
     def stop(self):
         try:

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -45,6 +45,7 @@ class PodmanBackend(Backend):
         if self.harness.auth_mode == "vertex":
             self._resolve_credentials()
         self._resolve_sandbox_config(otel_enabled=otel_port is not None)
+        self._run_setup_steps()
 
         if self.is_running():
             log.section("Podman container already running")

--- a/src/agentic_ci/config.py
+++ b/src/agentic_ci/config.py
@@ -58,7 +58,11 @@ def load_config(workdir: str = ".") -> Config:
         return Config()
 
     with open(path) as fh:
-        data = yaml.safe_load(fh)
+        try:
+            data = yaml.safe_load(fh)
+        except yaml.YAMLError:
+            log.warning("Failed to parse %s, skipping", path)
+            return Config()
 
     if not isinstance(data, dict):
         return Config()

--- a/src/agentic_ci/config.py
+++ b/src/agentic_ci/config.py
@@ -1,0 +1,65 @@
+"""Project-level configuration for agentic-ci.
+
+Loads ``.agentic-ci/config.yml`` from the target repository's workdir.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+
+import yaml
+
+REPO_CONFIG_PATH = ".agentic-ci/config.yml"
+
+
+@dataclass
+class SetupStep:
+    """A single setup command to run before the agent starts."""
+
+    name: str
+    run: str
+
+
+@dataclass
+class Config:
+    """Parsed project configuration."""
+
+    setup: list[SetupStep] = field(default_factory=list)
+
+
+def _parse_setup_steps(raw: list) -> list[SetupStep]:
+    """Parse a list of setup step entries.
+
+    Accepts both short-form (bare string) and long-form (object with
+    ``name`` and ``run`` keys), matching the GitHub Actions convention.
+    """
+    steps: list[SetupStep] = []
+    for i, entry in enumerate(raw):
+        if isinstance(entry, str):
+            steps.append(SetupStep(name=f"step-{i}", run=entry))
+        elif isinstance(entry, dict) and "run" in entry:
+            steps.append(SetupStep(name=entry.get("name", f"step-{i}"), run=entry["run"]))
+    return steps
+
+
+def load_config(workdir: str = ".") -> Config:
+    """Load project config from ``.agentic-ci/config.yml`` in *workdir*.
+
+    Returns a default (empty) Config if the file does not exist.
+    """
+    path = os.path.join(workdir, REPO_CONFIG_PATH)
+    if not os.path.isfile(path):
+        return Config()
+
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+
+    if not isinstance(data, dict):
+        return Config()
+
+    setup_raw = data.get("setup", [])
+    if not isinstance(setup_raw, list):
+        return Config()
+
+    return Config(setup=_parse_setup_steps(setup_raw))

--- a/src/agentic_ci/config.py
+++ b/src/agentic_ci/config.py
@@ -5,10 +5,13 @@ Loads ``.agentic-ci/config.yml`` from the target repository's workdir.
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass, field
 
 import yaml
+
+log = logging.getLogger(__name__)
 
 REPO_CONFIG_PATH = ".agentic-ci/config.yml"
 
@@ -38,8 +41,10 @@ def _parse_setup_steps(raw: list) -> list[SetupStep]:
     for i, entry in enumerate(raw):
         if isinstance(entry, str):
             steps.append(SetupStep(name=f"step-{i}", run=entry))
-        elif isinstance(entry, dict) and "run" in entry:
+        elif isinstance(entry, dict) and isinstance(entry.get("run"), str):
             steps.append(SetupStep(name=entry.get("name", f"step-{i}"), run=entry["run"]))
+        else:
+            log.warning("setup[%d]: skipping invalid entry (expected string or {run: ...})", i)
     return steps
 
 

--- a/tests/e2e/e2e-claude-runner.sh
+++ b/tests/e2e/e2e-claude-runner.sh
@@ -143,6 +143,35 @@ fi
 # Stop the container before the next test
 agentic-ci stop --harness claude-code 2>/dev/null || true
 
+# -- Setup steps test ---------------------------------------------------------
+print_header "=== agentic-ci run: setup steps (podman) ==="
+
+WORKDIR="$TMPDIR_E2E/setup-steps"
+mkdir -p "$WORKDIR/.agentic-ci"
+cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+print_step "Running Claude Code with setup steps (podman)..."
+SETUP_LOG="$TMPDIR_E2E/setup-steps-out.txt"
+RC=0
+agentic-ci run \
+    "Check if the file .setup-marker exists and contains 'setup-complete'. If yes, reply with only the word pong. If not, reply with only the word fail." \
+    --image "$IMAGE" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$SETUP_LOG" 2>&1 || RC=$?
+
+OUTPUT="$(cat "$SETUP_LOG")"
+assert_ok "setup-steps run exited successfully" test "$RC" -eq 0
+assert_contains "setup-steps: marker file found by agent" "$OUTPUT" "pong"
+
+agentic-ci stop --harness claude-code 2>/dev/null || true
+
 # -- AGENT_ENABLED_PLUGINS test -----------------------------------------------
 print_header "=== agentic-ci run: AGENT_ENABLED_PLUGINS ==="
 

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -156,5 +156,30 @@ assert_ok "extra args output file is non-empty" test -s "$TMPDIR_E2E/extra-args-
 assert_contains "extra args output contains response" \
     "$(cat "$TMPDIR_E2E/extra-args-out.txt")" "pong"
 
+# -- Setup steps test ---------------------------------------------------------
+print_header "=== agentic-ci run --backend local: setup steps ==="
+
+WORKDIR="$TMPDIR_E2E/setup-steps"
+mkdir -p "$WORKDIR/.agentic-ci"
+cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+print_step "Running Claude Code with setup steps (local)..."
+RC=0
+agentic-ci run --backend local \
+    "Check if the file .setup-marker exists and contains 'setup-complete'. If yes, reply with only the word pong. If not, reply with only the word fail." \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$TMPDIR_E2E/setup-out.txt" 2>"$TMPDIR_E2E/setup-err.txt" || RC=$?
+
+assert_ok "setup-steps local run exited successfully" test "$RC" -eq 0
+assert_contains "setup-steps: marker file found by agent" \
+    "$(cat "$TMPDIR_E2E/setup-out.txt")" "pong"
+
 echo ""
 print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -353,6 +353,39 @@ POLICY
 
     agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
 
+    # --- Setup steps test ---
+    # Verifies that .agentic-ci/config.yml setup steps run on the host
+    # before the workdir is uploaded. The setup step creates a marker file;
+    # the agent checks whether it exists inside the sandbox.
+    print_header "=== agentic-ci run: setup steps ==="
+
+    WORKDIR="$TMPDIR_E2E/setup-steps"
+    mkdir -p "$WORKDIR/.agentic-ci"
+    cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+    print_step "Running Claude Code with setup steps..."
+    SETUP_LOG="$TMPDIR_E2E/setup-steps.log"
+    RC=0
+    agentic-ci run \
+        "Check if the file .setup-marker exists and contains 'setup-complete'. If yes, reply with only the word pong. If not, reply with only the word fail." \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel 2>&1 | tee "$SETUP_LOG" || RC=$?
+
+    OUTPUT="$(cat "$SETUP_LOG")"
+    assert_ok "setup-steps run exited successfully" test "$RC" -eq 0
+    assert_contains "setup-steps: marker file found in sandbox" "$OUTPUT" "pong"
+    assert_contains "setup-steps: setup section logged" "$OUTPUT" "Running setup steps"
+    dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+
     # --- Verdict file download test ---
     # Verifies that files written to gitignored directories inside the
     # sandbox (like autofix-output/) are downloaded back to the host.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,101 @@
+"""Tests for project configuration loading."""
+
+from agentic_ci.config import Config, SetupStep, load_config
+
+
+def test_no_config_file_returns_empty(tmp_path):
+    config = load_config(str(tmp_path))
+    assert config == Config()
+    assert config.setup == []
+
+
+def test_empty_config_file(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("")
+    config = load_config(str(tmp_path))
+    assert config.setup == []
+
+
+def test_config_without_setup_key(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("other: true\n")
+    config = load_config(str(tmp_path))
+    assert config.setup == []
+
+
+def test_setup_bare_strings(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup:\n  - npm ci\n  - npm run build\n")
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 2
+    assert config.setup[0] == SetupStep(name="step-0", run="npm ci")
+    assert config.setup[1] == SetupStep(name="step-1", run="npm run build")
+
+
+def test_setup_object_form(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text(
+        "setup:\n"
+        "  - name: Install dependencies\n"
+        "    run: npm ci\n"
+        "  - name: Build\n"
+        "    run: npm run build\n"
+    )
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 2
+    assert config.setup[0] == SetupStep(name="Install dependencies", run="npm ci")
+    assert config.setup[1] == SetupStep(name="Build", run="npm run build")
+
+
+def test_setup_object_without_name(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup:\n  - run: npm ci\n")
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 1
+    assert config.setup[0].name == "step-0"
+    assert config.setup[0].run == "npm ci"
+
+
+def test_setup_mixed_forms(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text(
+        "setup:\n  - npm ci\n  - name: Build\n    run: npm run build\n"
+    )
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 2
+    assert config.setup[0].run == "npm ci"
+    assert config.setup[1] == SetupStep(name="Build", run="npm run build")
+
+
+def test_setup_invalid_entry_skipped(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text(
+        "setup:\n  - npm ci\n  - name: no-run-key\n  - run: valid\n"
+    )
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 2
+    assert config.setup[0].run == "npm ci"
+    assert config.setup[1].run == "valid"
+
+
+def test_setup_not_a_list(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup: npm ci\n")
+    config = load_config(str(tmp_path))
+    assert config.setup == []
+
+
+def test_config_not_a_dict(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("- just a list\n")
+    config = load_config(str(tmp_path))
+    assert config.setup == []

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -99,3 +99,21 @@ def test_config_not_a_dict(tmp_path):
     (config_dir / "config.yml").write_text("- just a list\n")
     config = load_config(str(tmp_path))
     assert config.setup == []
+
+
+def test_setup_run_non_string_skipped(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup:\n  - run: 123\n  - run: npm ci\n")
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 1
+    assert config.setup[0].run == "npm ci"
+
+
+def test_setup_run_null_skipped(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup:\n  - run: null\n  - run: valid\n")
+    config = load_config(str(tmp_path))
+    assert len(config.setup) == 1
+    assert config.setup[0].run == "valid"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -101,6 +101,14 @@ def test_config_not_a_dict(tmp_path):
     assert config.setup == []
 
 
+def test_malformed_yaml_returns_empty(tmp_path):
+    config_dir = tmp_path / ".agentic-ci"
+    config_dir.mkdir()
+    (config_dir / "config.yml").write_text("setup:\n  - run: [\n")
+    config = load_config(str(tmp_path))
+    assert config.setup == []
+
+
 def test_setup_run_non_string_skipped(tmp_path):
     config_dir = tmp_path / ".agentic-ci"
     config_dir.mkdir()


### PR DESCRIPTION
## Summary
- Adds a new `setup` key to `.agentic-ci/config.yml` that defines commands to run on the host before uploading the workdir into the OpenShell sandbox
- Setup steps execute with full internet access, enabling dependency installation (e.g. `npm ci`) whose outputs are then available inside the sandbox
- Supports both GitHub Actions-style objects (`name`/`run`) and bare-string shorthand

## Motivation

Repos with heavy dependency installs (e.g. ODH dashboard needing `npm install`) fail in autofix because the OpenShell sandbox blocks internet access. This feature runs setup commands outside the sandbox so their outputs (e.g. `node_modules/`) are included in the workdir upload.

Slack thread: https://redhat-internal.slack.com/archives/C0ASJ32PJ0N/p1783524952468199
Resolves: [RHAIFIRST-267](https://redhat.atlassian.net/browse/RHAIFIRST-267)

## Config format

```yaml
# .agentic-ci/config.yml
setup:
  - name: Install dependencies
    run: npm ci
  - npm run build  # bare string shorthand
```

## Test plan
- [x] Unit tests for config parsing (10 tests covering all forms, edge cases)
- [x] Full test suite passes (737 tests)
- [x] Ruff lint clean
- [x] Ruff format clean
- [x] Mypy typecheck clean
- [ ] E2E test with ODH dashboard repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIFIRST-267]: https://redhat.atlassian.net/browse/RHAIFIRST-267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added repository configuration loading from `.agentic-ci/config.yml` (optional `setup`).
  - OpenShell now executes configured host-side setup steps before uploading the work directory to the sandbox, so setup outputs are available in the run (fail-fast on errors with per-step time limits).
- **Documentation**
  - Added/expanded guidance on `setup` steps execution flow and OpenShell network/policy configuration references.
- **Tests**
  - Added unit coverage for missing/malformed configs and for skipping invalid `setup` entries.
  - Added an end-to-end OpenShell sandbox test confirming setup steps run on the host before upload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->