### PR TITLE
AIPCC-20128: Add root span injection to skill runner OTEL path

### DIFF
--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -24,13 +24,21 @@ import json
 import logging
 import os
 import shutil
+import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, TypedDict
 
 from agentic_ci.backends import create_backend
 from agentic_ci.harness import create_harness
-from agentic_ci.otel import parse_metrics, start_collector, stop_collector
+from agentic_ci.otel import (
+    generate_trace_context,
+    inject_root_spans,
+    parse_metrics,
+    start_collector,
+    stop_collector,
+)
 
 log = logging.getLogger(__name__)
 
@@ -146,22 +154,55 @@ def _default_run_container(
 
     otel_proc = None
     otel_port = None
+    otel_log = None
+    traceparent = None
+    trace_id = None
+    span_id = None
+    start_ns = None
     if harness.supports_otel:
         run_dir = Path(work_dir) / "_run"
         run_dir.mkdir(parents=True, exist_ok=True)
         try:
-            otel_proc, otel_port, _, _ = start_collector(
+            otel_proc, otel_port, otel_log, _ = start_collector(
                 str(run_dir), bind_addr=backend.collector_bind_address
             )
+            trace_id, span_id, traceparent = generate_trace_context()
         except Exception:
             log.warning("Failed to start OTEL collector, continuing without telemetry")
 
+    rc = 1
     try:
         backend.setup(otel_port=otel_port)
-        return backend.run(prompt, model=model, otel_port=otel_port)
+        start_ns = time.time_ns()
+        rc = backend.run(prompt, model=model, otel_port=otel_port, traceparent=traceparent)
+        return rc
     finally:
+        end_ns = time.time_ns()
+
         if otel_proc:
             stop_collector(otel_proc)
+            if start_ns and otel_log:
+                try:
+                    injected = inject_root_spans(
+                        otel_log,
+                        start_ns,
+                        end_ns,
+                        rc,
+                        fallback_trace_id=trace_id,
+                        fallback_span_id=span_id,
+                        attributes={
+                            "agent.backend": backend_name,
+                            "agent.harness": harness_name,
+                            "agent.model": model,
+                        },
+                    )
+                    if injected:
+                        log.info("Injected %d synthetic root span(s)", injected)
+                except Exception as exc:
+                    print(
+                        f"Root span injection failed (non-fatal): {exc}",
+                        file=sys.stderr,
+                    )
         backend.stop()
 
 


### PR DESCRIPTION
## Summary

The skill runner (`skill.py`) has its own OTEL collector lifecycle separate from `cli.py cmd_run()`. It was missing trace context generation, TRACEPARENT propagation, and synthetic root span injection. This caused all skill-based runs (autofix, assessor, etc.) to produce incomplete MLflow traces with garbage execution times and ERROR status on successful runs.

This is the actual path used by production autofix pipelines. The root span injection added in #235 and hardened in #236 only covered `cmd_run()`, which is the `agentic-ci run` CLI entrypoint. Skill runs go through `_default_run_container()` in `skill.py` instead.

### Changes

- Add `generate_trace_context()` and `inject_root_spans()` to the skill runner's `_default_run_container()`
- Pass `traceparent` through to `backend.run()`
- Wrap injection in `try/except` (best-effort, same as cli.py)
- Record `start_ns`/`end_ns` timestamps around the run

### Root cause of the MLflow issues

Without the synthetic root span:
- MLflow receives child spans with no root, marks trace as `IN_PROGRESS`
- `_finalize_traces()` marks it `ERROR` (even on successful runs)
- MLflow computes duration from incomplete span data, producing negative/garbage execution times (e.g. `-1783988289.257s`)

## Test plan

- [x] 727 unit tests pass, lint/format/typecheck clean
- [x] Traced the issue to missing injection by analyzing OTEL JSONL from production pipeline (gitlab.com/redhat/rhel-ai/agentic-ci/autofix, pipeline 2674104019)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved OpenTelemetry tracing for container-based skill runs.
  * Captured additional execution context and timing details in telemetry logs.
  * Preserved execution when telemetry setup or trace enrichment encounters errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->