### PR TITLE
Bump agentic-ci to 0.3.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "agentic-ci"
-version = "0.3.23"
+version = "0.3.24"
 description = "Tooling for running AI coding agents in CI/CD environments"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Version bump to 0.3.24

Includes root span injection in skill runner OTEL path (#242).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package to version 0.3.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->