### PR TITLE
chore: Update release skill for dynamic versioning

### DIFF
--- a/.claude/skills/release-agentic-ci/SKILL.md
+++ b/.claude/skills/release-agentic-ci/SKILL.md
@@ -1,18 +1,21 @@
 ---
 name: release-agentic-ci
-description: Cut a new agentic-ci release: bump version, open PR, wait for approval and checks, merge, tag, and push.
+description: Cut a new agentic-ci release by tagging and pushing. Version is derived from git tags automatically.
 disable-model-invocation: true
 argument-hint: "[version]"
 ---
 
 # Release agentic-ci
 
-Orchestrates the full release flow: version bump, PR, approval wait, merge, tag, push.
+Tag a new release. The version is embedded in the build via
+`uv-dynamic-versioning` (reads from git tags), so no pyproject.toml
+changes are needed.
 
 ## Inputs
 
-The skill argument is an optional version string (e.g. `0.3.0`).
-If omitted, bump the patch version of the current version in `pyproject.toml` (e.g. `0.2.24` becomes `0.2.25`).
+The skill argument is an optional version string (e.g. `0.3.26`).
+If omitted, bump the patch version of the latest git tag
+(e.g. `0.3.25` becomes `0.3.26`).
 
 ## Steps
 
@@ -21,94 +24,54 @@ Follow these steps exactly. Stop and report if any step fails.
 ### 1. Determine the new version
 
 ```bash
-# Read current version
-grep '^version' pyproject.toml
+git fetch origin --tags
+git tag -l --sort=-v:refname | head -1
 ```
 
 If the user supplied a version string as the skill argument, use it.
-Otherwise, bump the patch component (e.g. `0.2.24` -> `0.2.25`).
+Otherwise, bump the patch component of the latest tag
+(e.g. `0.3.25` -> `0.3.26`).
 
 Confirm the new version with the user before proceeding.
 
-### 2. Create the release branch and commit
+### 2. Verify main is clean
 
 ```bash
-git checkout -b agentic-ci-<VERSION> main
+git fetch origin main
+git log --oneline origin/main | head -5
 ```
 
-Edit `pyproject.toml` to set `version = "<VERSION>"`.
+Show the user the recent commits that will be included in this release.
+Ask for confirmation before tagging.
 
-Commit:
-```bash
-git commit -s -am "Bump agentic-ci to <VERSION>"
-```
-
-### 3. Push and open PR
+### 3. Tag and push
 
 ```bash
-git push -u origin agentic-ci-<VERSION>
-gh pr create --title "Bump agentic-ci to <VERSION>" --body ""
+# Tag the latest commit on origin/main
+git tag <VERSION> origin/main
+git push origin <VERSION>
 ```
 
-Print the PR URL.
+### 4. Verify the image build started
 
-### 4. Wait for approval and merge
+The tag push triggers the Container Images workflow which builds and
+pushes version-tagged images to quay.io.
 
-Use `CronCreate` to schedule a recurring job that checks PR status every 5 minutes and completes the release automatically when ready.
-
-The cron prompt must be **fully self-contained**.
-Each run is an independent Claude invocation with no memory of prior turns.
-Inline all necessary context: the version, PR number, and the exact commands to run.
-
-```text
-CronCreate:
-  cron: "*/5 * * * *"
-  recurring: true
-  prompt: |
-    You are completing a release of agentic-ci version <VERSION>.
-    PR #<PR_NUMBER> is open at https://github.com/opendatahub-io/agentic-ci/pull/<PR_NUMBER>.
-    The working directory is already the repo root.
-
-    Step 1: Check if the PR is ready.
-
-    Run:
-      gh pr view <PR_NUMBER> --repo opendatahub-io/agentic-ci --json reviewDecision,mergedAt --jq '{reviewDecision, mergedAt}'
-
-    - If mergedAt is non-empty, the PR was already merged. Skip to step 3.
-    - If reviewDecision is not "APPROVED", print "PR #<PR_NUMBER>: waiting for approval" and stop.
-    - If reviewDecision is "APPROVED", check CI:
-        gh pr checks <PR_NUMBER> --repo opendatahub-io/agentic-ci
-      If any required check is failing or pending, print the status and stop.
-      If all checks pass, proceed to step 2.
-
-    Step 2: Merge the PR.
-
-    Run:
-      gh pr merge <PR_NUMBER> --repo opendatahub-io/agentic-ci --merge --delete-branch
-
-    Step 3: Tag and push.
-
-    Run:
-      git checkout main
-      git pull origin main
-      git log --oneline -1
-
-    Verify the HEAD commit message contains "Merge pull request #<PR_NUMBER>".
-
-    Then tag and push:
-      git tag <VERSION>
-      git push origin <VERSION>
-
-    Step 4: Print a summary and clean up.
-
-    Print:
-      - Version: <VERSION>
-      - PR: https://github.com/opendatahub-io/agentic-ci/pull/<PR_NUMBER>
-      - Tag: <VERSION>
-      - Merge commit: (short SHA from git log)
-
-    Then delete this cron job using CronDelete with the job ID from CronList.
+```bash
+gh run list --repo opendatahub-io/agentic-ci --workflow "Container Images" --limit 3
 ```
 
-After creating the cron job, print the PR URL and tell the user the release will complete automatically once the PR is approved and CI passes.
-Print the cron job ID so the user can cancel it manually if needed.
+### 5. Print summary
+
+Print:
+  - Version: `<VERSION>`
+  - Tag: `<VERSION>`
+  - Tagged commit: (short SHA from `git rev-parse --short origin/main`)
+  - Image workflow: (link or status from step 4)
+  - Images will be available at:
+    - `quay.io/aipcc/agentic-ci/claude-runner:<VERSION>`
+    - `quay.io/aipcc/agentic-ci/opencode-runner:<VERSION>`
+    - `quay.io/aipcc/agentic-ci/claude-sandbox:<VERSION>`
+    - `quay.io/aipcc/agentic-ci/opencode-sandbox:<VERSION>`
+    - `quay.io/aipcc/agentic-ci/openshell:<VERSION>`
+    - `quay.io/aipcc/agentic-ci/podman:<VERSION>`


### PR DESCRIPTION
## Summary

Updates the `release-agentic-ci` skill to match the new dynamic versioning flow from #244.

**Before:** Bump `pyproject.toml`, open PR, wait for approval/CI, merge, tag, push. Required a cron job to poll PR status.

**After:** Determine next version from git tags, confirm with user, tag `origin/main`, push tag. Done in one step.

No more bump PRs, no more cron polling, no more `pyproject.toml` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release guidance to use direct version tagging and publishing from the main branch.
  * Clarified how optional version inputs are handled and how new versions are derived.
  * Added verification steps for container image builds and release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->