### PR TITLE
Add AGENTIC_CI_SKIP_SETUP env var to opt out of setup steps

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -85,6 +85,8 @@ Host (internet access)          Sandbox (isolated)
   blocking CI indefinitely.
 - Malformed entries (e.g. missing `run` key, non-string `run` value) are
   skipped with a warning.
+- Set `AGENTIC_CI_SKIP_SETUP=1` to skip all setup steps (useful for
+  lightweight jobs like triage that don't need dependencies).
 
 ### Example: Node.js Project
 

--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -164,7 +164,13 @@ class Backend(ABC):
         Setup steps execute with full network access outside any sandbox,
         allowing dependency installation (e.g. ``npm ci``) whose outputs
         are available to the agent at runtime.
+
+        Skipped when ``AGENTIC_CI_SKIP_SETUP=1`` is set, allowing
+        lightweight consumers (e.g. triage) to opt out.
         """
+        if os.environ.get("AGENTIC_CI_SKIP_SETUP") == "1":
+            return
+
         config = load_config(self.workdir)
         if not config.setup:
             return

--- a/tests/e2e/e2e-claude-runner.sh
+++ b/tests/e2e/e2e-claude-runner.sh
@@ -172,6 +172,36 @@ assert_contains "setup-steps: marker file found by agent" "$OUTPUT" "pong"
 
 agentic-ci stop --harness claude-code 2>/dev/null || true
 
+# -- AGENTIC_CI_SKIP_SETUP test -----------------------------------------------
+print_header "=== agentic-ci run: AGENTIC_CI_SKIP_SETUP (podman) ==="
+
+WORKDIR="$TMPDIR_E2E/skip-setup"
+mkdir -p "$WORKDIR/.agentic-ci"
+cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+print_step "Running Claude Code with AGENTIC_CI_SKIP_SETUP=1 (podman)..."
+SKIP_LOG="$TMPDIR_E2E/skip-setup-out.txt"
+RC=0
+AGENTIC_CI_SKIP_SETUP=1 \
+agentic-ci run \
+    "Check if the file .setup-marker exists. If yes, reply with only the word fail. If not, reply with only the word pong." \
+    --image "$IMAGE" \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$SKIP_LOG" 2>&1 || RC=$?
+
+OUTPUT="$(cat "$SKIP_LOG")"
+assert_ok "skip-setup run exited successfully" test "$RC" -eq 0
+assert_contains "skip-setup: marker file NOT created" "$OUTPUT" "pong"
+
+agentic-ci stop --harness claude-code 2>/dev/null || true
+
 # -- AGENT_ENABLED_PLUGINS test -----------------------------------------------
 print_header "=== agentic-ci run: AGENT_ENABLED_PLUGINS ==="
 

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -181,5 +181,31 @@ assert_ok "setup-steps local run exited successfully" test "$RC" -eq 0
 assert_contains "setup-steps: marker file found by agent" \
     "$(cat "$TMPDIR_E2E/setup-out.txt")" "pong"
 
+# -- AGENTIC_CI_SKIP_SETUP test -----------------------------------------------
+print_header "=== agentic-ci run --backend local: AGENTIC_CI_SKIP_SETUP ==="
+
+WORKDIR="$TMPDIR_E2E/skip-setup"
+mkdir -p "$WORKDIR/.agentic-ci"
+cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+print_step "Running Claude Code with AGENTIC_CI_SKIP_SETUP=1 (local)..."
+RC=0
+AGENTIC_CI_SKIP_SETUP=1 \
+agentic-ci run --backend local \
+    "Check if the file .setup-marker exists. If yes, reply with only the word fail. If not, reply with only the word pong." \
+    --harness claude-code \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    --no-streaming \
+    > "$TMPDIR_E2E/skip-setup-out.txt" 2>"$TMPDIR_E2E/skip-setup-err.txt" || RC=$?
+
+assert_ok "skip-setup local run exited successfully" test "$RC" -eq 0
+assert_contains "skip-setup: marker file NOT created" \
+    "$(cat "$TMPDIR_E2E/skip-setup-out.txt")" "pong"
+
 echo ""
 print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -386,6 +386,38 @@ CONFIG
 
     agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
 
+    # --- AGENTIC_CI_SKIP_SETUP test ---
+    # Verifies that AGENTIC_CI_SKIP_SETUP=1 skips setup steps entirely.
+    # Uses the same config as above but the marker file should NOT exist.
+    print_header "=== agentic-ci run: AGENTIC_CI_SKIP_SETUP ==="
+
+    WORKDIR="$TMPDIR_E2E/skip-setup"
+    mkdir -p "$WORKDIR/.agentic-ci"
+    cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+    print_step "Running Claude Code with AGENTIC_CI_SKIP_SETUP=1..."
+    SKIP_LOG="$TMPDIR_E2E/skip-setup.log"
+    RC=0
+    AGENTIC_CI_SKIP_SETUP=1 \
+    agentic-ci run \
+        "Check if the file .setup-marker exists. If yes, reply with only the word fail. If not, reply with only the word pong." \
+        --backend openshell \
+        --image "$CLAUDE_SANDBOX" \
+        --harness claude-code \
+        --workdir "$WORKDIR" \
+        --no-otel 2>&1 | tee "$SKIP_LOG" || RC=$?
+
+    OUTPUT="$(cat "$SKIP_LOG")"
+    assert_ok "skip-setup run exited successfully" test "$RC" -eq 0
+    assert_contains "skip-setup: marker file NOT created" "$OUTPUT" "pong"
+    dump_gateway_log
+
+    agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
+
     # --- Verdict file download test ---
     # Verifies that files written to gitignored directories inside the
     # sandbox (like autofix-output/) are downloaded back to the host.


### PR DESCRIPTION
## Summary
- Adds `AGENTIC_CI_SKIP_SETUP=1` env var check to `_run_setup_steps()` in the Backend base class
- When set, all setup steps are skipped entirely

## Motivation

Triage jobs don't need dependency installation — they only read code. But setup steps (e.g. `dnf install nodejs && npm ci`) run unconditionally, wasting time and failing when the runner image lacks the right tools.

This lets the triage runner in the autofix repo set `AGENTIC_CI_SKIP_SETUP=1` to skip setup without coupling agentic-ci to autofix-specific concepts like "triage vs resolve".

Resolves: [RHAIFIRST-285](https://redhat.atlassian.net/browse/RHAIFIRST-285)

## Test plan
- [x] 740 unit tests pass
- [x] Ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHAIFIRST-285]: https://redhat.atlassian.net/browse/RHAIFIRST-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for skipping all setup steps when `AGENTIC_CI_SKIP_SETUP=1` is set.

* **Documentation**
  * Documented the new `AGENTIC_CI_SKIP_SETUP` environment variable and its setup-step execution behavior.

* **Tests**
  * Added end-to-end coverage to verify setup steps are not executed and expected marker files are not created across supported backends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->