### PR TITLE
feat: add retry_job() to GitLabForge

### DIFF
--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -329,6 +329,36 @@ class GitLabForge(Forge):
             raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
         return resp.text
 
+    def retry_job(self, project_path: str, job_id: int) -> dict:
+        """Retry a failed or canceled GitLab CI job.
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+            job_id: Numeric job ID to retry.
+
+        Returns the new job dict from the API response (includes the
+        retried job's ``id``, ``web_url``, and ``status``).
+
+        Raises:
+            ForgeError: On API failure. A 401/403 response raises an
+                actionable error indicating the token needs the ``api``
+                or ``write_build`` scope to retry jobs.
+        """
+        job_id = int(job_id)
+        pid = self.project_id(project_path)
+        resp = self._session.post(
+            f"https://gitlab.com/api/v4/projects/{pid}/jobs/{job_id}/retry",
+        )
+        if resp.status_code in (401, 403):
+            raise ForgeError(
+                f"GitLab API returned {resp.status_code}: token does not have "
+                "permission to retry jobs. Ensure BOT_PAT has the 'api' or "
+                "'write_build' scope."
+            )
+        if resp.status_code not in (200, 201):
+            raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
+        return resp.json()
+
     def pipeline_schedules(self, project_path: str) -> list[dict]:
         """List all pipeline schedules for a project (paginated).
 

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -619,6 +619,54 @@ class TestJobTrace:
             forge.job_trace("org/repo", 501)
 
 
+class TestRetryJob:
+    def test_returns_new_job(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(
+            201,
+            {
+                "id": 999,
+                "web_url": "https://gitlab.com/org/repo/-/jobs/999",
+                "status": "pending",
+            },
+        )
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        result = forge.retry_job("org/repo", 501)
+        assert result["id"] == 999
+        assert result["status"] == "pending"
+        mock_session.post.assert_called_once()
+        assert "/jobs/501/retry" in mock_session.post.call_args[0][0]
+
+    def test_401_raises_actionable_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(401, text="Unauthorized")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="BOT_PAT"):
+            forge.retry_job("org/repo", 501)
+
+    def test_403_raises_actionable_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(403, text="Forbidden")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="does not have permission to retry jobs"):
+            forge.retry_job("org/repo", 501)
+
+    def test_other_error_raises_generic_forge_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(404, text="Job not found")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="HTTP 404"):
+            forge.retry_job("org/repo", 501)
+
+
 class TestPipelineSchedules:
     def test_returns_schedules(self, forge, mock_session):
         project_resp = _make_response(200, {"id": 1})


### PR DESCRIPTION
Enable programmatic retry of failed GitLab CI jobs via the POST /projects/:id/jobs/:job_id/retry API endpoint. Returns the new job object on success and raises actionable errors on 401/403 indicating the required BOT_PAT token scopes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrying failed or canceled GitLab CI jobs.
  * Retry results now include the newly created job’s status and ID.

* **Bug Fixes**
  * Added clear error messages for missing credentials, insufficient permissions, and other retry failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->