### PR TITLE
feat: add retry_job() to GitLabForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ from agentic_ci.harness import create_harness
 harness = create_harness("claude-code")
 
 # Podman backend
-backend = create_backend("podman", harness=harness, workdir="/path/to/repo", image="my-image:latest")
+backend = create_backend(
+    "podman", harness=harness, workdir="/path/to/repo", image="my-image:latest"
+)
 backend.setup()
 rc = backend.run(prompt="Fix the bug", model="claude-sonnet-4-6")
 backend.stop()
@@ -310,12 +312,8 @@ config = SkillConfig(
     prompt_builder=lambda ticket_key, mode, skill_name, **kw: (
         f"Use the /{skill_name} skill to review ticket {ticket_key}."
     ),
-    verdict_loader=lambda work_dir: json.loads(
-        (work_dir / "verdict.json").read_text()
-    ),
-    label_applier=lambda ticket_key, verdict, **kw: (
-        print(f"[{ticket_key}] verdict: {verdict}")
-    ),
+    verdict_loader=lambda work_dir: json.loads((work_dir / "verdict.json").read_text()),
+    label_applier=lambda ticket_key, verdict, **kw: print(f"[{ticket_key}] verdict: {verdict}"),
 )
 
 rc = run_skill(
@@ -402,12 +400,12 @@ project uses this framework to build an automated Jira bug-fix pipeline:
 ```python
 config = SkillConfig(
     skill_name="autofix-resolve",
-    prompt_builder=_build_prompt,         # Jira-specific prompt
-    context_writer=_write_context,        # Writes ticket.json to .autofix-context/
-    verdict_loader=_load_verdict,          # Reads .autofix-verdict.json
-    label_applier=_apply_labels,          # Manages jira-autofix-* labels
-    cost_formatter=_format_otel_cost,     # Formats cost for Jira comments
-    post_gates=[_autofix_post_gate],      # Commit author check, sensitive files, gitleaks
+    prompt_builder=_build_prompt,  # Jira-specific prompt
+    context_writer=_write_context,  # Writes ticket.json to .autofix-context/
+    verdict_loader=_load_verdict,  # Reads .autofix-verdict.json
+    label_applier=_apply_labels,  # Manages jira-autofix-* labels
+    cost_formatter=_format_otel_cost,  # Formats cost for Jira comments
+    post_gates=[_autofix_post_gate],  # Commit author check, sensitive files, gitleaks
 )
 ```
 

--- a/docs/otel-architecture.md
+++ b/docs/otel-architecture.md
@@ -134,7 +134,10 @@ the orchestrator's root span.
 
 ```python
 otel.inject_root_spans(
-    otel_log, start_ns, end_ns, rc,
+    otel_log,
+    start_ns,
+    end_ns,
+    rc,
     fallback_trace_id=trace_id,
     fallback_span_id=span_id,
     attributes={...},

--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -22,6 +22,16 @@ from agentic_ci.forge.session import GitLabHTTPAdapter, build_session, extract_a
 
 log = logging.getLogger(__name__)
 
+_MAX_ERROR_TEXT_LEN = 200
+
+
+def _sanitize_resp_text(text: str) -> str:
+    """Strip control characters and truncate response text for error messages."""
+    cleaned = re.sub(r"[\r\n\x00-\x1f]+", " ", text).strip()
+    if len(cleaned) > _MAX_ERROR_TEXT_LEN:
+        return cleaned[:_MAX_ERROR_TEXT_LEN] + "..."
+    return cleaned
+
 
 class GitLabForge(Forge):
     """GitLab REST API implementation of the ``Forge`` interface."""
@@ -328,6 +338,36 @@ class GitLabForge(Forge):
         if resp.status_code != 200:
             raise ForgeError(f"HTTP {resp.status_code}: {resp.text}")
         return resp.text
+
+    def retry_job(self, project_path: str, job_id: int) -> dict:
+        """Retry a failed or canceled GitLab CI job.
+
+        Args:
+            project_path: GitLab project path (e.g. ``"org/repo"``).
+            job_id: Numeric job ID to retry.
+
+        Returns the new job dict from the API response (includes the
+        retried job's ``id``, ``web_url``, and ``status``).
+
+        Raises:
+            ForgeError: On API failure. A 401/403 response raises an
+                actionable error indicating the token needs the ``api``
+                or ``write_build`` scope to retry jobs.
+        """
+        job_id = int(job_id)
+        pid = self.project_id(project_path)
+        resp = self._session.post(
+            f"https://gitlab.com/api/v4/projects/{pid}/jobs/{job_id}/retry",
+        )
+        if resp.status_code in (401, 403):
+            raise ForgeError(
+                f"GitLab API returned {resp.status_code}: token does not have "
+                "permission to retry jobs. Ensure BOT_PAT has the 'api' or "
+                "'write_build' scope."
+            )
+        if resp.status_code not in (200, 201):
+            raise ForgeError(f"HTTP {resp.status_code}: {_sanitize_resp_text(resp.text)}")
+        return resp.json()
 
     def pipeline_schedules(self, project_path: str) -> list[dict]:
         """List all pipeline schedules for a project (paginated).

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agentic_ci.forge import ForgeError
-from agentic_ci.forge.gitlab import GitLabForge, _find_first_added_line
+from agentic_ci.forge.gitlab import GitLabForge, _find_first_added_line, _sanitize_resp_text
 
 
 @pytest.fixture()
@@ -619,6 +619,63 @@ class TestJobTrace:
             forge.job_trace("org/repo", 501)
 
 
+class TestRetryJob:
+    def test_returns_new_job(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(
+            201,
+            {
+                "id": 999,
+                "web_url": "https://gitlab.com/org/repo/-/jobs/999",
+                "status": "pending",
+            },
+        )
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        result = forge.retry_job("org/repo", 501)
+        assert result["id"] == 999
+        assert result["status"] == "pending"
+        mock_session.post.assert_called_once()
+        assert "/jobs/501/retry" in mock_session.post.call_args[0][0]
+
+    def test_401_raises_actionable_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(401, text="Unauthorized")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="BOT_PAT"):
+            forge.retry_job("org/repo", 501)
+
+    def test_403_raises_actionable_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(403, text="Forbidden")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="does not have permission to retry jobs"):
+            forge.retry_job("org/repo", 501)
+
+    def test_other_error_raises_generic_forge_error(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(404, text="Job not found")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="HTTP 404"):
+            forge.retry_job("org/repo", 501)
+
+    def test_error_text_sanitized(self, forge, mock_session):
+        project_resp = _make_response(200, {"id": 1})
+        retry_resp = _make_response(500, text="line1\r\nline2\x00line3")
+        mock_session.get.return_value = project_resp
+        mock_session.post.return_value = retry_resp
+
+        with pytest.raises(ForgeError, match="line1 line2 line3"):
+            forge.retry_job("org/repo", 501)
+
+
 class TestPipelineSchedules:
     def test_returns_schedules(self, forge, mock_session):
         project_resp = _make_response(200, {"id": 1})
@@ -777,3 +834,17 @@ class TestFindFirstAddedLine:
     def test_no_newline_metadata_does_not_shift_line(self):
         diff = "@@ -1,2 +1,3 @@\n existing\n\\ No newline at end of file\n+added line"
         assert _find_first_added_line(diff) == 2
+
+
+class TestSanitizeRespText:
+    def test_strips_control_characters(self):
+        assert _sanitize_resp_text("a\r\nb\nc") == "a b c"
+
+    def test_truncates_long_text(self):
+        long_text = "x" * 300
+        result = _sanitize_resp_text(long_text)
+        assert len(result) == 203
+        assert result.endswith("...")
+
+    def test_passthrough_short_clean_text(self):
+        assert _sanitize_resp_text("Not found") == "Not found"


### PR DESCRIPTION
Enable programmatic retry of failed GitLab CI jobs via the POST /projects/:id/jobs/:job_id/retry API endpoint. Returns the new job object on success and raises actionable errors on 401/403 indicating the required BOT_PAT token scopes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retry failed or canceled GitLab CI jobs.
  * Successful retries return the updated job details.

* **Bug Fixes**
  * Improved error handling and messaging for authentication/permission issues during job retries.
  * Enhanced retry failure errors by sanitizing and truncating GitLab error text for clearer reporting.

* **Tests**
  * Expanded unit tests to cover successful retries, HTTP error cases, and response-text sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->