### PR TITLE
feat: change thinking output color from red to cyan

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The **openshell** backend uploads the local ADC file
 
 By default, agent output is parsed into human-readable CI logs with:
 
-- Colored ANSI output (thinking in red, tool calls in gray)
+- Colored ANSI output (thinking in cyan, tool calls in gray)
 - Tool call summaries (bash commands, file paths, agent dispatches)
 - Token count display with throughput rate
 - OTEL token/cost summary at completion

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -81,7 +81,7 @@ class ClaudeCodeStreamProcessor:
         self.claude_pid = claude_pid
 
         if color:
-            self.THINK = "\033[3;31m"
+            self.THINK = "\033[3;36m"
             self.TOOL = "\033[1;90m"
             self.CLAUDE = ""
             self.RED = "\033[31m"
@@ -374,7 +374,7 @@ class OpenCodeStreamProcessor:
         self.agent_pid = agent_pid
 
         if color:
-            self.THINK = "\033[3;31m"
+            self.THINK = "\033[3;36m"
             self.TOOL = "\033[1;90m"
             self.AGENT = ""
             self.RED = "\033[31m"


### PR DESCRIPTION
## Problem

`ClaudeCodeStreamProcessor` and `OpenCodeStreamProcessor` (`src/agentic_ci/stream.py`) both color the agent's "thinking" block using `self.THINK = "\033[3;31m"` — italic red. That's the same base color (`31`) used for `self.RED`, which marks actual errors (`❌ Error: ...`). In a CI log, thinking output and error output end up looking like the same color family, which makes it easy to mistake reasoning output for an error at a glance, or vice versa.

Also, `color` is never actually threaded through from any CLI flag or env var — `harness.py` always constructs `ClaudeCodeStreamProcessor(claude_pid=pid)` with no `color=` argument, so this hardcoded red is what every run gets; there's no way to opt out short of `--no-streaming` (which drops all the pretty-printing, not just the color).

## Fix

Changed `THINK` from italic red (`\033[3;31m`) to italic cyan (`\033[3;36m`) in both stream processors, per the harness-parity convention in CONTRIBUTING.md. Cyan doesn't collide with any other color currently in use:

- `RED` (`31`) -- errors
- `YELLOW` (`33`) -- retries (Claude processor only)
- `TOOL` (`1;90`, bold gray) -- tool calls / token counts
- `CLAUDE`/`AGENT` -- unstyled (default terminal foreground)

Cyan is also a conventional choice for reasoning/meta output in other CLI agent tools, and reads clearly on both light and dark terminal themes.

Updated the one doc reference in README.md's Streaming Output section to match.

## Test plan

- Ran the full test suite: `uv run pytest tests/ --ignore=tests/e2e/test_mlflow_e2e.py` -- 740 passed.
- `uv run ruff check .` -- all checks passed.
- `uv run ruff format --check --diff .` -- no diff.
- `uv run mypy src/` -- same single pre-existing, unrelated error in `forge/github.py` present on unmodified `main` too (confirmed via `git stash`); no new errors introduced.
- No test asserts on the specific ANSI color code, so no test changes were needed.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the color of “Thinking” indicators in streaming output from red to cyan.
  * Tool-call text and other output formatting remain unchanged.
* **Documentation**
  * Updated the streaming output documentation to reflect the new cyan “Thinking” text color.
  * Streaming and telemetry disabling behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->