### PR TITLE
Expose session and paginate as public API

### DIFF
--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -39,6 +39,11 @@ class GitLabForge(Forge):
     def __init__(self, *, adapter: GitLabHTTPAdapter | None = None) -> None:
         self._session = build_session(gitlab_adapter=adapter)
 
+    @property
+    def session(self):
+        """The authenticated HTTP session for direct API calls."""
+        return self._session
+
     def project_id(self, project_path: str) -> int:
         """Look up the numeric GitLab project ID from a project path.
 
@@ -467,7 +472,7 @@ class GitLabForge(Forge):
                 break
         return result
 
-    def _paginate(self, url: str, params: dict | None = None) -> list[dict]:
+    def paginate(self, url: str, params: dict | None = None) -> list[dict]:
         """Fetch all pages of a paginated GitLab API endpoint."""
         all_items: list[dict] = []
         page = 1
@@ -486,6 +491,8 @@ class GitLabForge(Forge):
                 break
             page += 1
         return all_items
+
+    _paginate = paginate
 
 
 def _find_first_added_line(diff_text: str) -> int | None:


### PR DESCRIPTION
Let consumers make arbitrary GitLab API calls without adding project-specific methods to the forge.

- Add `session` property for direct authenticated HTTP access
- Rename `_paginate` to `paginate` (keep `_paginate` alias for existing callers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed the authenticated GitLab session for broader integration.
  * Added a public pagination capability for retrieving results across all API pages.

* **Compatibility**
  * Existing internal pagination usage continues to work without changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->