### PR TITLE
Add Codex CLI harness

### DIFF
--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -62,6 +62,10 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: Codex was classified as generic `api-key` auth and OpenShell selected its Anthropic provider. Codex must use the `openai` auth mode and the OpenAI network endpoints.
 - **Where to look**: `harness.py` auth mode, `backends/openshell/provider.py`, `backends/openshell/policy.py`
 
+### Codex exits before local or Podman execution with "credentials not found"
+- **Likely cause**: None of `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or `OPENAI_API_KEY` is available. Local runs may instead use `$CODEX_HOME/auth.json`; Podman runs require a forwarded environment credential.
+- **Where to look**: `CodexHarness.validate_credentials()`, backend `setup()`, CI secret injection, and `CODEX_HOME`
+
 ## Jira client
 
 ### Markdown formatting lost in ADF roundtrip

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -54,6 +54,14 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: For OpenShell backend, OTEL host networking wasn't configured. Fixed to set up OTEL endpoint forwarding.
 - **Where to look**: `otel.py` collector setup, `backends/openshell/` network config
 
+### Codex starts but plugins or OTEL data are missing
+- **Likely cause**: Codex was launched with `--ignore-user-config`, which suppresses plugin state and user-level OTel configuration, or the per-run `otel.*` exporter overrides were not passed.
+- **Where to look**: `harness.py` Codex arguments, `plugins.py`, backend `otel_endpoint` argument wiring
+
+### Codex OpenShell setup creates an Anthropic provider
+- **Likely cause**: Codex was classified as generic `api-key` auth and OpenShell selected its Anthropic provider. Codex must use the `openai` auth mode and the OpenAI network endpoints.
+- **Where to look**: `harness.py` auth mode, `backends/openshell/provider.py`, `backends/openshell/policy.py`
+
 ## Jira client
 
 ### Markdown formatting lost in ADF roundtrip

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -62,6 +62,10 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: Codex was classified as generic `api-key` auth and OpenShell selected its Anthropic provider. Codex must use the `openai` auth mode and the OpenAI network endpoints.
 - **Where to look**: `harness.py` auth mode, `backends/openshell/provider.py`, `backends/openshell/policy.py`
 
+### OpenShell harness cannot reach its model API, or can reach another harness's API
+- **Likely cause**: The sandbox policy was resolved without the harness auth mode. Authentication endpoints are scoped to `vertex`, `api-key`, or `openai`; only common forge and package endpoints are shared.
+- **Where to look**: `backends/openshell/policy.py`, `backends/openshell/sandbox.py` auth mode wiring
+
 ### Codex exits before local or Podman execution with "credentials not found"
 - **Likely cause**: None of `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or `OPENAI_API_KEY` is available. Local runs may instead use `$CODEX_HOME/auth.json`; Podman runs require a forwarded environment credential.
 - **Where to look**: `CodexHarness.validate_credentials()`, backend `setup()`, CI secret injection, and `CODEX_HOME`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ Three **backends** provide execution environments:
 - **Podman** (default): Runs the agent in a Podman container. Simple, widely available.
 - **OpenShell**: Runs the agent in an [OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with network policy enforcement and filesystem isolation.
 
-Two **harnesses** define which agent CLI to run:
+Three **harnesses** define which agent CLI to run:
 - **claude-code** (default): [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `stream-json` output format.
 - **opencode**: [OpenCode](https://github.com/anomalyco/opencode) with JSON event output format.
+- **codex**: [OpenAI Codex](https://developers.openai.com/codex/cli) with JSONL event output and native OpenTelemetry export.
 
 ## Architecture
 
@@ -20,7 +21,7 @@ Two **harnesses** define which agent CLI to run:
 src/agentic_ci/
     cli.py              # Entry point, backend/harness selection, OTEL orchestration
     backend.py          # Backend ABC + shared stream processing
-    harness.py          # Harness ABC + ClaudeCode/OpenCode implementations
+    harness.py          # Harness ABC + ClaudeCode/OpenCode/Codex implementations
     backends/
         __init__.py     # Backend factory (create_backend)
         local.py        # LocalBackend — direct execution (no container)
@@ -32,7 +33,7 @@ src/agentic_ci/
             policy.py   # Policy resolution + built-in default
     config.py           # Project config loader (.agentic-ci/config.yml)
     plugins.py          # Plugin/skill install (build-time) and filtering (runtime)
-    stream.py           # Stream parsers for Claude Code and OpenCode output
+    stream.py           # Stream parsers for Claude Code, OpenCode, and Codex output
     otel.py             # OTLP collector + token/cost summary
 ```
 
@@ -40,9 +41,9 @@ src/agentic_ci/
 
 - **`backend.py`**: Abstract `Backend` class with `setup()` and `run()` methods. Shared `_process_stream()` helper reads output from a subprocess through the harness's stream processor.
 
-- **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`.
+- **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`, `CodexHarness`.
 
-- **`plugins.py`**: Build-time plugin installation (`install_claude_plugins`, `install_opencode_skills`) and runtime filtering (`enable_plugins`). At build time, installs skills from the skills-registry marketplace into the container image and writes a plugin-to-skill manifest. At runtime, `AGENT_ENABLED_PLUGINS` controls which plugins are active: Claude Code disables plugins in `settings.json`; OpenCode deletes unwanted skill directories from disk (since `permission.skill.deny` doesn't prevent loading with `--dangerously-skip-permissions`).
+- **`plugins.py`**: Build-time plugin installation (`install_claude_plugins`, `install_opencode_skills`, `install_codex_plugins`) and runtime filtering (`enable_plugins`). At build time, installs plugins or skills from the skills-registry marketplace into the container image and writes a plugin-to-skill manifest. At runtime, `AGENT_ENABLED_PLUGINS` controls which plugins are active: Claude Code disables plugins in `settings.json`; OpenCode deletes unwanted skill directories from disk; Codex removes unwanted native plugins and manifest-managed compatibility skills while preserving unmanaged personal skills.
 
 - **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Bind-mounts the workdir into the container at `/workspace`, so changes are visible on the host immediately. Mounts gcloud credentials as read-only volumes. Uses `--network host` when OTEL is enabled.
 
@@ -50,14 +51,14 @@ src/agentic_ci/
 
 - **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Uploads the workdir into the sandbox on `setup()` and downloads it back after `run()` completes. Only changes inside the workdir are reflected back to the host; files written elsewhere in the sandbox are not retrieved. Manages gateway lifecycle, sandbox creation with network policy, credential injection, and setup steps. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
 
-- **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. Both produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
+- **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. `CodexStreamProcessor` parses Codex JSONL events. All produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
 
 - **`otel.py`**: Lightweight OTLP HTTP/JSON receiver (stdlib `http.server`) that logs payloads to JSONL, tracks token usage over a sliding window, and prints a token/cost summary.
 
 ### Key
 
-- **Authentication** is auto-detected: if `ANTHROPIC_API_KEY` is set, direct API auth is used (no gcloud credentials needed); otherwise Vertex AI with gcloud ADC files.
-- **OTEL collector runs on the host**, not inside the sandbox/container. Currently only Claude Code emits OTEL metrics; OpenCode provides token/cost data via its JSON output.
+- **Authentication** is harness-specific: Claude Code uses `ANTHROPIC_API_KEY` when set and otherwise Vertex AI with gcloud ADC files; Codex uses `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `OPENAI_API_KEY`, or local `$CODEX_HOME/auth.json` login state.
+- **OTEL collector runs on the host**, not inside the sandbox/container. Claude Code and Codex export OTEL data; OpenCode provides token/cost data via its JSON output.
 
 ## Container images
 
@@ -169,7 +170,7 @@ When fixing a bug or adding a feature that changes failure modes, update `.claud
 When investigating this repo specifically, focus on these areas by symptom:
 
 - **Container failed**: Check `backends/podman.py` or `backends/openshell/` for container launch logic. Check `harness.py` for agent CLI argument construction. Check `cli.py` for credential and OTEL setup. Check `stream.py` if output parsing failed.
-- **Skills not found / wrong skills loaded**: Check `plugins.py` for install-time skill discovery (`install_opencode_skills` fallback dirs, manifest generation) and runtime filtering (`enable_plugins` reads `AGENT_ENABLED_PLUGINS`). Check `harness.py` `build_env_args()` and `build_env_script_lines()` for env var forwarding to the container. For OpenCode, filtering deletes unwanted skill directories from disk; for Claude Code, it disables plugins in `settings.json`.
+- **Skills not found / wrong skills loaded**: Check `plugins.py` for install-time skill discovery (`install_opencode_skills` fallback dirs, `install_codex_plugins` native/compatibility paths, manifest generation) and runtime filtering (`enable_plugins` reads `AGENT_ENABLED_PLUGINS`). Check `harness.py` `build_env_args()` and `build_env_script_lines()` for env var forwarding to the container. Claude Code disables unwanted plugins in `settings.json`; OpenCode deletes unwanted skill directories; Codex removes unwanted native plugins and only manifest-managed compatibility skills.
 - **Skill engine failure**: Check `skill.py` for the `run_skill()` flow: pre-gates, container launch, post-gates, verdict loading. Check which phase returned an error.
 - **MR/PR operations failed**: Check `forge.py` and the `forge` CLI subcommands. Check `git.py` for clone/push/branch operations. Check error handling in `ForgeError`.
 - **Gate framework issues**: Check `gates.py` for the gate registry and execution order. Check if a gate was added or changed that altered behavior. Gates run as pre/post hooks around the agent; the wiring is in the calling repo (autofix), but the gate implementations may be here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ src/agentic_ci/
 
 ### Key
 
-- **Authentication** is harness-specific: Claude Code uses `ANTHROPIC_API_KEY` when set and otherwise Vertex AI with gcloud ADC files; Codex uses `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `OPENAI_API_KEY`, or local `$CODEX_HOME/auth.json` login state.
+- **Authentication** is harness-specific: Claude Code uses `ANTHROPIC_API_KEY` when set and otherwise Vertex AI with gcloud ADC files; Codex uses `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `OPENAI_API_KEY`, or local `$CODEX_HOME/auth.json` login state. The OpenShell backend currently supports Codex only with `CODEX_API_KEY` or `OPENAI_API_KEY`.
 - **OTEL collector runs on the host**, not inside the sandbox/container. Claude Code and Codex export OTEL data; OpenCode provides token/cost data via its JSON output.
 
 ## Container images

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ full execution path with real containers and API calls:
 
 - `e2e-claude-runner.sh` -- Claude Code runner (podman backend)
 - `e2e-opencode-runner.sh` -- OpenCode runner (podman backend)
-- `e2e-local-runner.sh` -- Local backend (no container)
+- `e2e-local-runner.sh` -- Local backend, including Codex when credentials are available
 - `e2e-openshell-sandbox.sh` -- OpenShell sandbox backend
 - `test_mlflow_e2e.py` -- MLflow integration
 
@@ -62,7 +62,7 @@ Update the relevant docs when your PR changes user-facing behavior:
 
 ## Harness and Backend Parity
 
-agentic-ci supports multiple harnesses (Claude Code, OpenCode) and
+agentic-ci supports multiple harnesses (Claude Code, OpenCode, Codex) and
 backends (local, podman, OpenShell). When making changes to one, you
 must update the others to keep feature parity:
 
@@ -72,12 +72,14 @@ If you add a feature or fix to one harness, apply the equivalent
 change to all harnesses. For example:
 
 - A new CLI argument added to `ClaudeCodeHarness.build_args()` needs
-  the equivalent in `OpenCodeHarness.build_args()`.
+  the equivalent in `OpenCodeHarness.build_args()` and
+  `CodexHarness.build_args()` when the CLIs support it.
 - A new env var handled in one harness's `build_env_args()` must be
   handled in all.
 - Stream processor changes in `ClaudeCodeStreamProcessor` should have
-  the corresponding update in `OpenCodeStreamProcessor` when the
-  feature applies to both (e.g., token display, tool call summaries).
+  corresponding updates in `OpenCodeStreamProcessor` and
+  `CodexStreamProcessor` when the feature applies (e.g., token display,
+  tool call summaries).
 
 ### Backends
 
@@ -88,12 +90,15 @@ and all implementations must stay consistent:
   supported by the others, or explicitly documented as backend-specific
   with a clear reason.
 - Container image changes (Containerfiles) must be applied to both
-  Claude and OpenCode variants, plus their OpenShell sandbox variants.
+  repository-provided Claude and OpenCode variants, plus their OpenShell
+  sandbox variants. Codex images are user-supplied until a Codex runner
+  exists in `images/runner/`.
 
 ### Container images
 
-Runner images come in pairs (Claude + OpenCode) and optionally in
-OpenShell sandbox variants. When changing `images/runner/`:
+Repository-provided runner images come in pairs (Claude + OpenCode) and
+optionally in OpenShell sandbox variants. Codex runner images are currently
+user-supplied. When changing `images/runner/`:
 
 - Changes to `shared/Containerfile.base` affect all runners.
 - Changes specific to one runner (e.g., `claude-code/Containerfile`)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://opendatahub-io.github.io/agentic-ci/)
 
 Run AI coding agents in sandboxed CI environments with streaming output
-and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode,
+and Codex)
 and isolation backends so you can choose the right tradeoff between
 simplicity and security.
 
@@ -25,7 +26,8 @@ Good for: running inside an existing CI container (e.g. a Prow step
 image) where the agent CLI is pre-installed and an extra isolation
 layer is unnecessary.
 
-Requires: the agent CLI on PATH (e.g. `claude`).
+Requires: the selected agent CLI on PATH (for example `claude`,
+`opencode`, or `codex`).
 
 ### Podman (default)
 
@@ -112,10 +114,10 @@ agentic-ci {setup,run,stop} [options]
 | Flag | Default | Description |
 |---|---|---|
 | `--backend` | `podman` | Sandbox backend to use |
-| `--harness` | `claude-code` | Agent harness (`claude-code` or `opencode`) |
+| `--harness` | `claude-code` | Agent harness (`claude-code`, `opencode`, or `codex`) |
 | `--workdir PATH` | `.` | Working directory to mount |
 | `--image IMAGE` | — | Container or sandbox base image |
-| `--model MODEL` | harness-dependent | Agent model (`run` only). Defaults to `claude-opus-4-6` for Claude Code, `google-vertex/claude-opus-4-6@default` for OpenCode |
+| `--model MODEL` | harness-dependent | Agent model (`run` only). Defaults to `claude-opus-4-6` for Claude Code, `google-vertex/claude-opus-4-6@default` for OpenCode, and `gpt-5.6-sol` for Codex |
 | `--keep` | off | Keep the sandbox running after the run completes (`run` only) |
 | `--no-streaming` | off | Disable parsed stream output; agent output is printed raw (`run` only) |
 | `--no-otel` | off | Disable OTEL telemetry collection (`run` only) |
@@ -124,7 +126,7 @@ agentic-ci {setup,run,stop} [options]
 | `--policy PATH` | — | OpenShell policy file override (`openshell` backend only) |
 | `--timeout SECS` | `1200` | Container timeout (`podman` backend only) |
 
-Extra arguments after the prompt are passed through to the Claude CLI.
+Extra arguments after the prompt are passed through to the selected agent CLI.
 
 ### Examples
 
@@ -195,7 +197,8 @@ every missing variable and which gate needs it.
 
 ## Credentials
 
-Two authentication modes are supported. The mode is auto-detected
+Anthropic, Vertex AI, and OpenAI authentication are supported. The mode is
+auto-detected
 and logged at startup.
 
 ### Anthropic API key (direct)
@@ -226,6 +229,24 @@ The **openshell** backend uploads the local ADC file
 (`~/.config/gcloud/application_default_credentials.json` or
 `GOOGLE_APPLICATION_CREDENTIALS`) into the sandbox.
 
+### OpenAI Codex
+
+For non-interactive Codex runs, set `CODEX_API_KEY` for the single job or
+invocation. `CODEX_ACCESS_TOKEN` and an existing login under `CODEX_HOME` are
+also supported by the local backend. The Podman backend forwards
+`CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, and `OPENAI_API_KEY` when they are set.
+OpenShell Codex runs currently require `CODEX_API_KEY` or `OPENAI_API_KEY`.
+
+```bash
+export CODEX_API_KEY=...
+agentic-ci run --backend local --harness codex "Fix the bug"
+```
+
+Codex user configuration remains enabled so installed plugins and skills are
+available. During telemetry-enabled runs, agentic-ci supplies per-run Codex
+configuration overrides that export logs, metrics, and traces to its local
+OTLP collector.
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -235,6 +256,11 @@ The **openshell** backend uploads the local ADC file
 | `CLAUDE_CONTAINER_IMAGE` | — | Default container image for Claude Code harness |
 | `OPENCODE_MODEL` | `google-vertex/claude-opus-4-6@default` | Default model for OpenCode harness (overridden by `--model`) |
 | `OPENCODE_CONTAINER_IMAGE` | — | Default container image for OpenCode harness |
+| `CODEX_API_KEY` | — | OpenAI API key scoped to a non-interactive Codex run |
+| `CODEX_ACCESS_TOKEN` | — | ChatGPT/Codex access token for trusted automation |
+| `CODEX_HOME` | `~/.codex` | Codex configuration, authentication, plugins, and skills directory |
+| `CODEX_MODEL` | `gpt-5.6-sol` | Default model for Codex harness (overridden by `--model`) |
+| `CODEX_CONTAINER_IMAGE` | — | Default container image for Codex harness |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | — | Vertex AI project ID |
 | `GCP_PROJECT_ID` | — | Fallback for `ANTHROPIC_VERTEX_PROJECT_ID` |
 | `GOOGLE_CLOUD_PROJECT` | — | GCP project ID (OpenCode uses this before falling back to `ANTHROPIC_VERTEX_PROJECT_ID`) |
@@ -454,4 +480,3 @@ Or to preview with live reload:
 ```bash
 uv run --with '.[docs]' mkdocs serve
 ```
-

--- a/README.md
+++ b/README.md
@@ -197,9 +197,10 @@ every missing variable and which gate needs it.
 
 ## Credentials
 
-Anthropic, Vertex AI, and OpenAI authentication are supported. The mode is
-auto-detected
-and logged at startup.
+Anthropic, Vertex AI, and OpenAI authentication are supported. The auth family
+follows the selected harness — Claude Code auto-detects Anthropic API key vs
+Vertex AI, while Codex always uses OpenAI — and the resolved mode is logged at
+startup.
 
 ### Anthropic API key (direct)
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ OTLP collector.
 | `OPENCODE_CONTAINER_IMAGE` | — | Default container image for OpenCode harness |
 | `CODEX_API_KEY` | — | OpenAI API key scoped to a non-interactive Codex run |
 | `CODEX_ACCESS_TOKEN` | — | ChatGPT/Codex access token for trusted automation |
+| `OPENAI_API_KEY` | — | OpenAI API key accepted as a fallback for Codex runs |
 | `CODEX_HOME` | `~/.codex` | Codex configuration, authentication, plugins, and skills directory |
 | `CODEX_MODEL` | `gpt-5.6-sol` | Default model for Codex harness (overridden by `--model`) |
 | `CODEX_CONTAINER_IMAGE` | — | Default container image for Codex harness |

--- a/docs/image/skills.md
+++ b/docs/image/skills.md
@@ -88,8 +88,9 @@ RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registr
 2. Copies skill directories to `~/.config/opencode/skills/`.
    Uses explicit `skills` paths from the marketplace entry when present
    (e.g. `"skills": ["./helpers/skills"]` for `odh-ai-helpers`), otherwise
-   falls back to standard paths (`.claude/skills/`, `.opencode/skills/`,
-   `skills/`).
+   falls back to standard paths (`.claude/skills/`, `.agents/skills/`,
+   `.opencode/skills/`, `skills/`). The `.agents/skills/` fallback applies
+   to OpenCode installs as well as Codex compatibility installs.
 3. Records the plugin→skill mapping in the
    [plugin-skills manifest](#plugin-skills-manifest).
 
@@ -121,6 +122,10 @@ The existing skills registry also contains legacy Claude-compatible
 marketplaces whose packages do not yet include Codex plugin manifests. If
 Codex reports no native packages for such a marketplace, agentic-ci clones the
 entries and installs their skills under `$CODEX_HOME/skills`.
+
+agentic-ci does not yet provide an `images/runner/codex` image. Codex runner
+images are user-supplied through `--image` or `CODEX_CONTAINER_IMAGE` and must
+include the `codex` binary until that directory exists.
 
 ## Plugin-skills manifest
 

--- a/docs/image/skills.md
+++ b/docs/image/skills.md
@@ -3,7 +3,7 @@
 Skills from the
 [opendatahub-io/skills-registry](https://github.com/opendatahub-io/skills-registry)
 are pre-installed into every runner and sandbox image at build time. Each
-harness (Claude Code, OpenCode) uses a different installation mechanism
+harness (Claude Code, OpenCode, Codex) uses a different installation mechanism
 that matches the tool's native plugin system.
 
 ## Claude Code: plugin seed
@@ -110,6 +110,18 @@ RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registr
 All skills are flat in one directory — no plugin namespacing. OpenCode
 discovers them by scanning for `SKILL.md` files.
 
+## Codex: native plugins with legacy compatibility
+
+Codex has a native plugin and marketplace system. At build time,
+`agentic-ci install-plugins --harness codex --marketplace-json <path>` adds the
+marketplace with `codex plugin marketplace add`, installs its native Codex
+plugins, and records their bundled skills in the plugin-skills manifest.
+
+The existing skills registry also contains legacy Claude-compatible
+marketplaces whose packages do not yet include Codex plugin manifests. If
+Codex reports no native packages for such a marketplace, agentic-ci clones the
+entries and installs their skills under `$CODEX_HOME/skills`.
+
 ## Plugin-skills manifest
 
 Both install scripts generate a manifest at
@@ -125,8 +137,8 @@ plugin names to the skills they contain:
 ```
 
 For Claude Code, the manifest is informational (debugging, auditing).
-For OpenCode, the manifest is functional — `enable-plugins` uses it to
-apply per-skill filtering at runtime (see below).
+For OpenCode and Codex, the manifest is functional — `enable-plugins` uses it
+to apply per-skill filtering at runtime (see below).
 
 ## Filtering plugins at runtime
 
@@ -154,9 +166,13 @@ to use:
 reads this at startup and skips disabled plugins.
 
 **OpenCode** (`AGENT_TOOL=opencode`): Reads the plugin-skills manifest
-to find which skills belong to unwanted plugins, then writes
-`"skill-name": "deny"` entries to `opencode.json`'s `permission.skill`
-section. OpenCode hides denied skills from the agent.
+to find which skills belong to unwanted plugins, then removes unwanted skill
+directories from the ephemeral runtime filesystem before OpenCode starts.
+
+**Codex** (`AGENT_TOOL=codex`): Uses `codex plugin list/remove` for native
+plugins and removes only manifest-managed compatibility skills for unwanted
+plugins from `$CODEX_HOME/skills`. Personal skills that are not managed by the
+manifest are left intact.
 
 ### Error handling
 
@@ -175,7 +191,7 @@ Plugin installation and filtering are `agentic-ci` subcommands
 
 | Command | When | Purpose |
 |---------|------|---------|
-| `agentic-ci install-plugins` | Build time | Install plugins for Claude Code (reads seed dir) or OpenCode (`--harness opencode --marketplace-json <path>`) |
+| `agentic-ci install-plugins` | Build time | Install plugins for Claude Code (reads seed dir), OpenCode, or Codex (`--marketplace-json <path>`) |
 | `agentic-ci enable-plugins` | Runtime | Filter active plugins based on `AGENT_ENABLED_PLUGINS` |
 
 The container entrypoint (`images/runner/shared/entrypoint.sh`) calls

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,15 @@
 # agentic-ci
 
 Run AI coding agents in sandboxed CI environments with streaming output
-and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode,
+and Codex)
 and isolation backends so you can choose the right tradeoff between
 simplicity and security.
 
 ## Features
 
 - **Multiple backends**: Local (direct execution), Podman containers, or OpenShell sandboxes with network policy enforcement
-- **Multiple harnesses**: Claude Code and OpenCode agent CLIs
+- **Multiple harnesses**: Claude Code, OpenCode, and Codex agent CLIs
 - **Setup steps**: Pre-sandbox dependency installation for repos that need it
 - **Streaming output**: Colored, parsed CI logs with tool call summaries and token tracking
 - **OTEL telemetry**: Token usage, cost tracking, and metrics collection

--- a/docs/otel-configuration.md
+++ b/docs/otel-configuration.md
@@ -52,6 +52,26 @@ via `write_sandbox_config()`.
 - `OTEL_METRIC_EXPORT_INTERVAL` — no OTel metrics to export
 - `OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_*` — Claude-specific flags
 
+## Codex
+
+Codex configures OTel through its `[otel]` configuration rather than standard
+OTel environment variables. For each run, the Codex harness passes `-c`
+overrides for three OTLP/HTTP JSON exporters:
+
+| Signal | Endpoint |
+|--------|----------|
+| Logs | `http://...:{port}/v1/logs` |
+| Metrics | `http://...:{port}/v1/metrics` |
+| Traces | `http://...:{port}/v1/traces` |
+
+The log stream includes API requests, response events with token counts, tool
+decisions/results, and redacted prompt metadata. User prompt content remains
+disabled by default. The metrics stream includes Codex API, streaming, and tool
+counters and duration histograms. Exporters flush when Codex shuts down.
+
+The endpoint host is backend-specific: loopback for local and host-networked
+Podman runs, and `host.openshell.internal` for OpenShell.
+
 ## Sandbox config
 
 The `opencode.json` config is written by `write_sandbox_config()` and
@@ -60,5 +80,6 @@ mounted into the container by the backend:
 - **Podman**: mounted as a read-only volume via `sandbox_config_mounts()`
 - **OpenShell**: uploaded and moved into place via `_upload_sandbox_config()`
 
-Claude Code does not require sandbox config for OTel — env vars are
-sufficient.
+Claude Code and Codex do not require a mounted sandbox config for OTel.
+Claude Code uses environment variables; Codex receives per-run CLI config
+overrides.

--- a/images/runner/shared/entrypoint.sh
+++ b/images/runner/shared/entrypoint.sh
@@ -70,6 +70,8 @@ _detect_tool() {
             export OPENCODE_DISABLE_AUTOUPDATE=1
             ;;
         codex)
+            # Codex has no auto-update env var. CodexHarness passes the native
+            # check_for_update_on_startup=false CLI config override instead.
             ;;
         *)
             if [[ "${AGENT_TOOL:-}" == "claude" ]]; then

--- a/images/runner/shared/entrypoint.sh
+++ b/images/runner/shared/entrypoint.sh
@@ -69,6 +69,8 @@ _detect_tool() {
         opencode)
             export OPENCODE_DISABLE_AUTOUPDATE=1
             ;;
+        codex)
+            ;;
         *)
             if [[ "${AGENT_TOOL:-}" == "claude" ]]; then
                 export DISABLE_AUTOUPDATER=1
@@ -108,7 +110,7 @@ agentic-ci enable-plugins
 # the entrypoint to prepend the tool command (matching the runner image
 # behavior where the entrypoint always prepends the agent command).
 case "${1:-}" in
-    claude|claude-code|opencode|bash|sh|true)
+    claude|claude-code|opencode|codex|bash|sh|true)
         exec "$@"
         ;;
     *)

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -27,6 +27,8 @@ class LocalBackend(Backend):
         self._extra_env = extra_env or {}
 
     def setup(self, otel_port=None):
+        env = {**os.environ, **self._extra_env}
+        self.harness.validate_credentials(env, allow_auth_file=True)
         log.section("Local backend (direct execution)")
         self._run_setup_steps()
 

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -52,7 +52,8 @@ class LocalBackend(Backend):
             **self._extra_env,
         }
 
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        otel_endpoint = f"http://127.0.0.1:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         proc = subprocess.Popen(
             agent_args,

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -122,6 +122,7 @@ class OpenShellBackend(Backend):
             otel_port=otel_port,
             workdir=self.workdir,
             approval_mode=self.approval_mode,
+            auth_mode=self.harness.auth_mode,
         )
 
         self._run_setup_steps()

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -167,7 +167,8 @@ class OpenShellBackend(Backend):
         traceparent=None,
     ):
         self._write_env_script(model, otel_port, otel_rate_file, traceparent=traceparent)
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        otel_endpoint = f"http://{_OPENSHELL_HOST}:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         workdir_name = os.path.basename(self.workdir)
         sandbox_workdir = f"/sandbox/{workdir_name}"

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -21,13 +21,24 @@ DEFAULT_ENDPOINTS = [
     "*.gitlab.com:443:full",
     "pypi.org:443:read-only",
     "files.pythonhosted.org:443:read-only",
-    "aiplatform.googleapis.com:443:read-write",
-    "*.aiplatform.googleapis.com:443:read-write",
-    "oauth2.googleapis.com:443:read-write",
-    "api.anthropic.com:443:read-write",
-    "api.openai.com:443:read-write",
-    "chatgpt.com:443:read-write",
 ]
+
+AUTH_ENDPOINTS = {
+    "vertex": [
+        "aiplatform.googleapis.com:443:read-write",
+        "*.aiplatform.googleapis.com:443:read-write",
+        "oauth2.googleapis.com:443:read-write",
+    ],
+    "api-key": [
+        "api.anthropic.com:443:read-write",
+    ],
+    "openai": [
+        "api.openai.com:443:read-write",
+        # Codex's ChatGPT backend API is served under chatgpt.com/backend-api.
+        # OpenShell policies match hosts, not URL paths.
+        "chatgpt.com:443:read-write",
+    ],
+}
 
 
 def _load_endpoints_from_file(path):
@@ -42,11 +53,11 @@ def _load_endpoints_from_file(path):
     return [str(ep) for ep in endpoints]
 
 
-def resolve_endpoints(flag_path=None, workdir="."):
+def resolve_endpoints(flag_path=None, workdir=".", auth_mode=None):
     """Resolve the endpoint list to use for policy update.
 
-    Merges the built-in defaults with extra endpoints from, in priority
-    order:
+    Merges the built-in defaults and endpoints required by *auth_mode* with
+    extra endpoints from, in priority order:
 
     1. Explicit ``--policy`` flag path
     2. ``.agentic-ci/openshell-policy.yml`` in *workdir*
@@ -68,6 +79,7 @@ def resolve_endpoints(flag_path=None, workdir="."):
     print(f"  Policy source: {source}", flush=True)
 
     endpoints = list(DEFAULT_ENDPOINTS)
+    endpoints.extend(AUTH_ENDPOINTS.get(auth_mode, []))
     seen = set(endpoints)
     for ep in extra:
         if ep not in seen:

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -25,6 +25,8 @@ DEFAULT_ENDPOINTS = [
     "*.aiplatform.googleapis.com:443:read-write",
     "oauth2.googleapis.com:443:read-write",
     "api.anthropic.com:443:read-write",
+    "api.openai.com:443:read-write",
+    "chatgpt.com:443:read-write",
 ]
 
 

--- a/src/agentic_ci/backends/openshell/provider.py
+++ b/src/agentic_ci/backends/openshell/provider.py
@@ -11,7 +11,7 @@ from agentic_ci.gcp import read_credential_type as _adc_credential_type
 
 PROVIDER_NAME = "ci-gcp"
 
-_SECRET_PREFIXES = ("private_key=", "GCP_SA_ACCESS_TOKEN=")
+_SECRET_PREFIXES = ("private_key=", "GCP_SA_ACCESS_TOKEN=", "OPENAI_API_KEY=")
 
 
 def _run(args, **kwargs):
@@ -39,7 +39,7 @@ def setup(auth_mode):
     the provider is created bare and refresh is configured separately with
     the service account's email and private key.
 
-    For API key auth, creates an anthropic provider instead.
+    For Anthropic or OpenAI API key auth, creates the corresponding provider.
     """
     if provider_exists():
         # NOTE: switching auth modes (e.g. Vertex → API key) between runs
@@ -48,6 +48,8 @@ def setup(auth_mode):
         print(f"  Provider '{PROVIDER_NAME}' already exists", flush=True)
     elif auth_mode == "api-key":
         _create_anthropic_provider()
+    elif auth_mode == "openai":
+        _create_openai_provider()
     else:
         _create_gcp_provider()
 
@@ -77,6 +79,30 @@ def _create_anthropic_provider():
             "ANTHROPIC_API_KEY",
         ],
         check=True,
+    )
+
+
+def _create_openai_provider():
+    api_key = os.environ.get("CODEX_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OpenShell Codex runs require CODEX_API_KEY or OPENAI_API_KEY")
+
+    print("  Creating OpenAI API key provider", flush=True)
+    env = {**os.environ, "OPENAI_API_KEY": api_key}
+    _run(
+        [
+            "openshell",
+            "provider",
+            "create",
+            "--name",
+            PROVIDER_NAME,
+            "--type",
+            "openai",
+            "--credential",
+            "OPENAI_API_KEY",
+        ],
+        check=True,
+        env=env,
     )
 
 

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -98,6 +98,8 @@ def _apply_policy(policy_path, otel_port=None, workdir="."):
         "/usr/local/bin/claude",
         "--binary",
         "/usr/local/bin/opencode",
+        "--binary",
+        "/usr/local/bin/codex",
     ]
     for ep in endpoints:
         args.extend(["--add-endpoint", ep])

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -29,7 +29,14 @@ def exists():
     return result.returncode == 0
 
 
-def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_mode=None):
+def create(
+    image=None,
+    policy_path=None,
+    otel_port=None,
+    workdir=".",
+    approval_mode=None,
+    auth_mode=None,
+):
     """Create a persistent sandbox with the CI provider attached.
 
     The sandbox is created first, then the network policy is applied
@@ -69,10 +76,15 @@ def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_m
             check=True,
         )
 
-    _apply_policy(policy_path, otel_port=otel_port, workdir=workdir)
+    _apply_policy(
+        policy_path,
+        otel_port=otel_port,
+        workdir=workdir,
+        auth_mode=auth_mode,
+    )
 
 
-def _apply_policy(policy_path, otel_port=None, workdir="."):
+def _apply_policy(policy_path, otel_port=None, workdir=".", auth_mode=None):
     """Apply network policy endpoints and wait for activation.
 
     Two-step process:
@@ -83,7 +95,7 @@ def _apply_policy(policy_path, otel_port=None, workdir="."):
        The google-cloud provider profile is endpointless, so the gateway
        withholds credentials unless the sandbox policy explicitly binds them.
     """
-    endpoints = resolve_endpoints(policy_path, workdir=workdir)
+    endpoints = resolve_endpoints(policy_path, workdir=workdir, auth_mode=auth_mode)
     if otel_port:
         endpoints.append(f"host.openshell.internal:{otel_port}:read-write")
     if not endpoints:

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -41,6 +41,8 @@ class PodmanBackend(Backend):
         self._extra_env = extra_env or {}
 
     def setup(self, otel_port=None):
+        env = {**os.environ, **self._extra_env}
+        self.harness.validate_credentials(env)
         self._resolve_image()
         if self.harness.auth_mode == "vertex":
             self._resolve_credentials()

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -121,7 +121,7 @@ class PodmanBackend(Backend):
         traceparent=None,
     ):
         if not self.is_running():
-            self.setup()
+            self.setup(otel_port=otel_port)
 
         log.section(f"Executing {self.harness.name} in container")
         otel_env = self.harness.build_otel_exec_env(otel_port, traceparent=traceparent)

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -123,7 +123,8 @@ class PodmanBackend(Backend):
 
         log.section(f"Executing {self.harness.name} in container")
         otel_env = self.harness.build_otel_exec_env(otel_port, traceparent=traceparent)
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        otel_endpoint = f"http://127.0.0.1:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         proc = subprocess.Popen(
             [

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -70,6 +70,8 @@ def cmd_install_plugins(args):
             sys.exit(1)
         manifest = Path(args.manifest) if args.manifest else None
         plugins.install_opencode_skills(Path(args.marketplace_json), manifest_path=manifest)
+    elif harness_name == "codex":
+        print("Codex CLI does not support plugin installation; skipping.")
     else:
         print(f"ERROR: unknown harness {harness_name!r}", file=sys.stderr)
         sys.exit(1)
@@ -236,7 +238,7 @@ def main():
     common.add_argument("--image", default=None, metavar="IMAGE", help="Container/sandbox image")
     common.add_argument(
         "--harness",
-        choices=["claude-code", "opencode"],
+        choices=["claude-code", "opencode", "codex"],
         default="claude-code",
         help="AI agent harness (default: claude-code)",
     )
@@ -328,7 +330,7 @@ def main():
     )
     p_install.add_argument(
         "--harness",
-        choices=["claude-code", "opencode"],
+        choices=["claude-code", "opencode", "codex"],
         default=None,
         help="Harness to install for (default: from AGENT_TOOL env or claude-code)",
     )

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -71,7 +71,11 @@ def cmd_install_plugins(args):
         manifest = Path(args.manifest) if args.manifest else None
         plugins.install_opencode_skills(Path(args.marketplace_json), manifest_path=manifest)
     elif harness_name == "codex":
-        print("Codex CLI does not support plugin installation; skipping.")
+        if not args.marketplace_json:
+            print("ERROR: --marketplace-json is required for codex", file=sys.stderr)
+            sys.exit(1)
+        manifest = Path(args.manifest) if args.manifest else None
+        plugins.install_codex_plugins(Path(args.marketplace_json), manifest_path=manifest)
     else:
         print(f"ERROR: unknown harness {harness_name!r}", file=sys.stderr)
         sys.exit(1)
@@ -376,7 +380,12 @@ def main():
 
     log.section(f"Backend: {args.backend}")
     log.detail("Harness", harness.name)
-    log.detail("Auth", "API key" if harness.auth_mode == "api-key" else "Vertex AI")
+    auth_label = {
+        "api-key": "Anthropic API key",
+        "openai": "OpenAI",
+        "vertex": "Vertex AI",
+    }.get(harness.auth_mode, harness.auth_mode)
+    log.detail("Auth", auth_label)
     log.detail("Workdir", os.path.abspath(args.workdir))
     backend = create_backend(
         args.backend,

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -585,6 +585,9 @@ class CodexHarness(Harness):
             "--json",
             "--skip-git-repo-check",
             "--ephemeral",
+            # Codex has no supported auto-update env var; use its native config.
+            "-c",
+            "check_for_update_on_startup=false",
         ]
         if otel_endpoint:
             args.extend(self._otel_config_args(otel_endpoint))

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -11,7 +11,11 @@ import shlex
 from abc import ABC, abstractmethod
 from typing import Any
 
-from agentic_ci.stream import ClaudeCodeStreamProcessor, CodexStreamProcessor, OpenCodeStreamProcessor
+from agentic_ci.stream import (
+    ClaudeCodeStreamProcessor,
+    CodexStreamProcessor,
+    OpenCodeStreamProcessor,
+)
 
 _OPENSHELL_GATEWAY_HOST = "10.200.0.1"
 
@@ -32,7 +36,13 @@ class Harness(ABC):
         """Human-readable name for log messages."""
 
     @abstractmethod
-    def build_args(self, prompt: str, model: str, extra_args: list[str] | None = None) -> list[str]:
+    def build_args(
+        self,
+        prompt: str,
+        model: str,
+        extra_args: list[str] | None = None,
+        otel_endpoint: str | None = None,
+    ) -> list[str]:
         """Build the CLI argument list to run inside the container."""
 
     @abstractmethod
@@ -129,7 +139,7 @@ class ClaudeCodeHarness(Harness):
     def name(self) -> str:
         return "Claude Code"
 
-    def build_args(self, prompt, model, extra_args=None):
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         args = [
             "claude",
             "--permission-mode",
@@ -325,7 +335,7 @@ class OpenCodeHarness(Harness):
     def name(self) -> str:
         return "OpenCode"
 
-    def build_args(self, prompt, model, extra_args=None):
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         args = [
             "opencode",
             "run",
@@ -510,10 +520,27 @@ class CodexHarness(Harness):
 
     @property
     def auth_mode(self) -> str:
-        """Codex uses OpenAI API keys, not Anthropic/Vertex."""
-        return "api-key"
+        """Codex uses OpenAI credentials, not Anthropic or Vertex."""
+        return "openai"
 
-    def build_args(self, prompt, model, extra_args=None):
+    @staticmethod
+    def _otel_config_args(endpoint):
+        endpoint = endpoint.rstrip("/")
+
+        def exporter(signal):
+            url = json.dumps(f"{endpoint}/v1/{signal}")
+            return f'{{ "otlp-http" = {{ endpoint = {url}, protocol = "json" }} }}'
+
+        return [
+            "-c",
+            f"otel.exporter={exporter('logs')}",
+            "-c",
+            f"otel.metrics_exporter={exporter('metrics')}",
+            "-c",
+            f"otel.trace_exporter={exporter('traces')}",
+        ]
+
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         args = [
             "codex",
             "exec",
@@ -521,39 +548,46 @@ class CodexHarness(Harness):
             "--json",
             "--skip-git-repo-check",
             "--ephemeral",
-            "--ignore-user-config",
-            "-m",
-            model,
-            prompt,
         ]
+        if otel_endpoint:
+            args.extend(self._otel_config_args(otel_endpoint))
+        args.extend(["-m", model, prompt])
         if extra_args:
             args.extend(extra_args)
         return args
 
     def build_env_args(self):
-        return [
-            "--env",
-            "OPENAI_API_KEY",
-            "--env",
-            "AGENT_TOOL=codex",
-        ]
+        args = ["--env", "AGENT_TOOL=codex"]
+        for name in ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY"):
+            if os.environ.get(name):
+                args.extend(["--env", name])
+        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            args.extend(["--env", f"AGENT_ENABLED_PLUGINS={enabled_plugins}"])
+        return args
 
     def build_env_script_lines(self, otel_port=None, otel_rate_file=None, traceparent=None):
         lines = [
-            f"export OPENAI_API_KEY={shlex.quote(os.environ.get('OPENAI_API_KEY', ''))}",
+            "mkdir -p /sandbox/.codex",
             "export AGENT_TOOL=codex",
             "export CODEX_HOME=/sandbox/.codex",
         ]
+        for name in ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY"):
+            if os.environ.get(name):
+                lines.append(f"export {name}={shlex.quote(os.environ[name])}")
+        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            lines.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
         return lines
 
     def build_otel_exec_env(self, otel_port=None, traceparent=None):
         return []
 
     def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None):
-        env = {
-            "AGENT_TOOL": "codex",
-            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
-        }
+        env = {"AGENT_TOOL": "codex"}
+        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            env["AGENT_ENABLED_PLUGINS"] = enabled_plugins
         return env
 
     def credential_mount_target(self):
@@ -572,8 +606,8 @@ class CodexHarness(Harness):
         return "gpt-5.6-sol"
 
     @property
-    def autoupdater_env_var(self):
-        return "CODEX_DISABLE_AUTOUPDATE"
+    def supports_otel(self) -> bool:
+        return True
 
 
 def create_harness(name: str) -> Harness:

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -1,7 +1,7 @@
 """Harness abstraction for AI agent CLI tools.
 
 A harness encapsulates everything specific to a particular agent CLI
-(Claude Code, OpenCode, etc.): how to build the command, what env vars
+(Claude Code, OpenCode, Codex, etc.): how to build the command, what env vars
 it needs, where credentials are mounted, and how to parse its output.
 """
 
@@ -9,6 +9,8 @@ import json
 import os
 import shlex
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 from agentic_ci.stream import (
@@ -29,6 +31,18 @@ class Harness(ABC):
         if os.environ.get("ANTHROPIC_API_KEY"):
             return "api-key"
         return "vertex"
+
+    def validate_credentials(
+        self,
+        env: Mapping[str, str] | None = None,
+        *,
+        allow_auth_file: bool = False,
+    ) -> None:
+        """Fail early when harness-specific credentials are unavailable.
+
+        Harnesses without additional validation requirements use this no-op
+        implementation.
+        """
 
     @property
     @abstractmethod
@@ -514,6 +528,8 @@ class OpenCodeHarness(Harness):
 class CodexHarness(Harness):
     """OpenAI Codex CLI harness."""
 
+    _CREDENTIAL_ENV_VARS = ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY")
+
     @property
     def name(self) -> str:
         return "Codex"
@@ -522,6 +538,27 @@ class CodexHarness(Harness):
     def auth_mode(self) -> str:
         """Codex uses OpenAI credentials, not Anthropic or Vertex."""
         return "openai"
+
+    def validate_credentials(
+        self,
+        env: Mapping[str, str] | None = None,
+        *,
+        allow_auth_file: bool = False,
+    ) -> None:
+        credential_env = env if env is not None else os.environ
+        if any(credential_env.get(name) for name in self._CREDENTIAL_ENV_VARS):
+            return
+
+        home = Path(credential_env.get("HOME", str(Path.home())))
+        codex_home = Path(credential_env.get("CODEX_HOME", str(home / ".codex")))
+        auth_path = codex_home / "auth.json"
+        if allow_auth_file and auth_path.is_file():
+            return
+
+        expected = ", ".join(self._CREDENTIAL_ENV_VARS)
+        if allow_auth_file:
+            expected = f"{expected}, or {auth_path}"
+        raise RuntimeError(f"Codex credentials not found. Set one of: {expected}.")
 
     @staticmethod
     def _otel_config_args(endpoint):

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -11,7 +11,7 @@ import shlex
 from abc import ABC, abstractmethod
 from typing import Any
 
-from agentic_ci.stream import ClaudeCodeStreamProcessor, OpenCodeStreamProcessor
+from agentic_ci.stream import ClaudeCodeStreamProcessor, CodexStreamProcessor, OpenCodeStreamProcessor
 
 _OPENSHELL_GATEWAY_HOST = "10.200.0.1"
 
@@ -501,11 +501,90 @@ class OpenCodeHarness(Harness):
         return []
 
 
+class CodexHarness(Harness):
+    """OpenAI Codex CLI harness."""
+
+    @property
+    def name(self) -> str:
+        return "Codex"
+
+    @property
+    def auth_mode(self) -> str:
+        """Codex uses OpenAI API keys, not Anthropic/Vertex."""
+        return "api-key"
+
+    def build_args(self, prompt, model, extra_args=None):
+        args = [
+            "codex",
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--json",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            "--ignore-user-config",
+            "-m",
+            model,
+            prompt,
+        ]
+        if extra_args:
+            args.extend(extra_args)
+        return args
+
+    def build_env_args(self):
+        return [
+            "--env",
+            "OPENAI_API_KEY",
+            "--env",
+            "AGENT_TOOL=codex",
+        ]
+
+    def build_env_script_lines(self, otel_port=None, otel_rate_file=None, traceparent=None):
+        lines = [
+            f"export OPENAI_API_KEY={shlex.quote(os.environ.get('OPENAI_API_KEY', ''))}",
+            "export AGENT_TOOL=codex",
+            "export CODEX_HOME=/sandbox/.codex",
+        ]
+        return lines
+
+    def build_otel_exec_env(self, otel_port=None, traceparent=None):
+        return []
+
+    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None):
+        env = {
+            "AGENT_TOOL": "codex",
+            "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
+        }
+        return env
+
+    def credential_mount_target(self):
+        return os.environ.get("CODEX_CONTAINER_HOME", "/home/agent-ci")
+
+    def create_stream_processor(self, pid=0):
+        return CodexStreamProcessor(agent_pid=pid)
+
+    def image_env_var(self):
+        return "CODEX_CONTAINER_IMAGE"
+
+    def model_env_var(self):
+        return "CODEX_MODEL"
+
+    def default_model(self):
+        return "gpt-5.6-sol"
+
+    @property
+    def autoupdater_env_var(self):
+        return "CODEX_DISABLE_AUTOUPDATE"
+
+
 def create_harness(name: str) -> Harness:
     """Create a harness instance by name."""
     if name == "claude-code":
         return ClaudeCodeHarness()
     elif name == "opencode":
         return OpenCodeHarness()
+    elif name == "codex":
+        return CodexHarness()
     else:
-        raise ValueError(f"Unknown harness: {name!r}. Choose 'claude-code' or 'opencode'.")
+        raise ValueError(
+            f"Unknown harness: {name!r}. Choose 'claude-code', 'opencode', or 'codex'."
+        )

--- a/src/agentic_ci/otel.py
+++ b/src/agentic_ci/otel.py
@@ -175,6 +175,31 @@ def stop_collector(proc):
         proc.wait()
 
 
+def _otel_attribute_value(value):
+    if not isinstance(value, dict):
+        return None
+    for key in (
+        "stringValue",
+        "intValue",
+        "doubleValue",
+        "boolValue",
+        "string_value",
+        "int_value",
+        "double_value",
+        "bool_value",
+    ):
+        if key in value:
+            return value[key]
+    return None
+
+
+def _numeric_attribute(attributes, key):
+    try:
+        return float(attributes.get(key, 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def parse_metrics(records):
     """Parse OTLP JSONL records into structured token/cost data."""
     token_totals = defaultdict(float)
@@ -221,13 +246,32 @@ def parse_metrics(records):
                         event_attrs = {}
                         for a in lr.get("attributes", []):
                             key = a["key"]
-                            val = a["value"]
-                            v = val.get("stringValue", val.get("intValue", val.get("doubleValue")))
+                            v = _otel_attribute_value(a.get("value"))
                             event_attrs[key] = v
                             if key == "event.name":
                                 event_name = v
-                        if event_name == "claude_code.api_request":
+                        if event_name in ("claude_code.api_request", "codex.api_request"):
                             api_requests.append(event_attrs)
+                        elif (
+                            event_name == "codex.sse_event"
+                            and event_attrs.get("event.kind") == "response.completed"
+                        ):
+                            model = event_attrs.get("model", "unknown")
+                            input_tokens = _numeric_attribute(event_attrs, "input_token_count")
+                            cached_tokens = _numeric_attribute(event_attrs, "cached_token_count")
+                            cache_write_tokens = _numeric_attribute(
+                                event_attrs, "cache_write_token_count"
+                            )
+                            fresh_input = max(
+                                input_tokens - cached_tokens - cache_write_tokens,
+                                0,
+                            )
+                            token_totals[(model, "input")] += fresh_input
+                            token_totals[(model, "cacheRead")] += cached_tokens
+                            token_totals[(model, "cacheCreation")] += cache_write_tokens
+                            token_totals[(model, "output")] += _numeric_attribute(
+                                event_attrs, "output_token_count"
+                            )
 
     return token_totals, cost_totals, api_requests, active_time
 

--- a/src/agentic_ci/otel.py
+++ b/src/agentic_ci/otel.py
@@ -219,11 +219,9 @@ def parse_metrics(records):
                         data = metric.get("sum", metric.get("gauge", metric.get("histogram", {})))
                         for dp in data.get("dataPoints", []):
                             attrs = {
-                                a["key"]: a["value"].get(
-                                    "stringValue",
-                                    a["value"].get("intValue", a["value"].get("doubleValue")),
-                                )
+                                a.get("key"): _otel_attribute_value(a.get("value"))
                                 for a in dp.get("attributes", [])
+                                if a.get("key")
                             }
                             value = dp.get("asDouble", dp.get("asInt", 0))
 
@@ -245,7 +243,9 @@ def parse_metrics(records):
                         event_name = ""
                         event_attrs = {}
                         for a in lr.get("attributes", []):
-                            key = a["key"]
+                            key = a.get("key")
+                            if not key:
+                                continue
                             v = _otel_attribute_value(a.get("value"))
                             event_attrs[key] = v
                             if key == "event.name":
@@ -262,6 +262,12 @@ def parse_metrics(records):
                             cache_write_tokens = _numeric_attribute(
                                 event_attrs, "cache_write_token_count"
                             )
+                            # Codex reports input_token_count inclusive of the
+                            # cached and cache-write tokens, so subtract them to
+                            # get the fresh prompt tokens. The max(..., 0) guards
+                            # against exporters that report them separately (in
+                            # which case fresh_input clamps to 0 rather than
+                            # going negative).
                             fresh_input = max(
                                 input_tokens - cached_tokens - cache_write_tokens,
                                 0,

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -1,6 +1,6 @@
 """Plugin and skill installation and runtime filtering.
 
-Provides two build-time operations and one runtime operation:
+Provides three build-time operations and one runtime operation:
 
 Build-time (called from Containerfiles via ``agentic-ci install-plugins``):
 
@@ -8,8 +8,11 @@ Build-time (called from Containerfiles via ``agentic-ci install-plugins``):
   plugins from a marketplace seed directory.
 - :func:`install_opencode_skills` — clones plugin repos and copies SKILL.md
   files into OpenCode's skills directory.
+- :func:`install_codex_plugins` — installs native Codex plugins when the
+  marketplace supports them, with a skills-only fallback for legacy
+  marketplaces.
 
-Both generate a plugin-to-skill manifest at a well-known path.
+All generate a plugin-to-skill manifest at a well-known path.
 
 Runtime (called from entrypoint.sh / OpenShell env script via
 ``agentic-ci enable-plugins``):
@@ -31,7 +34,7 @@ from agentic_ci.git import clone_repo
 
 DEFAULT_MANIFEST_PATH = "/usr/local/share/agentic-ci/plugin-skills.manifest.json"
 
-_FALLBACK_SKILL_DIRS = [".claude/skills", ".opencode/skills", "skills"]
+_FALLBACK_SKILL_DIRS = [".agents/skills", ".claude/skills", ".opencode/skills", "skills"]
 
 
 def _manifest_path() -> Path:
@@ -194,6 +197,96 @@ def install_opencode_skills(
     print(f"==> Manifest written to {manifest_path}")
 
 
+def _codex_marketplace_root(marketplace_json: Path) -> Path:
+    if marketplace_json.parent.name == ".claude-plugin":
+        return marketplace_json.parent.parent
+    if (
+        marketplace_json.parent.name == "plugins"
+        and marketplace_json.parent.parent.name == ".agents"
+    ):
+        return marketplace_json.parent.parent.parent
+    return marketplace_json.parent
+
+
+def _run_codex_json(args: list[str]) -> dict | None:
+    result = subprocess.run(
+        ["codex", *args, "--json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def install_codex_plugins(
+    marketplace_json: Path,
+    skills_dir: Path | None = None,
+    manifest_path: Path | None = None,
+) -> None:
+    """Install plugins for Codex from a marketplace.
+
+    Native Codex plugins are preferred. Legacy Claude-compatible marketplaces
+    that do not expose Codex plugin packages fall back to installing their
+    skills under ``CODEX_HOME/skills``.
+    """
+    marketplace_root = _codex_marketplace_root(marketplace_json)
+    added = _run_codex_json(["plugin", "marketplace", "add", str(marketplace_root)])
+    marketplace_name = added.get("marketplaceName") if added else None
+
+    listing = None
+    if marketplace_name:
+        listing = _run_codex_json(
+            ["plugin", "list", "--available", "--marketplace", marketplace_name]
+        )
+    available = listing.get("available", []) if listing else []
+
+    if not available:
+        print("==> Marketplace has no native Codex plugins; installing skills compatibility layer")
+        if skills_dir is None:
+            codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+            skills_dir = codex_home / "skills"
+        install_opencode_skills(
+            marketplace_json,
+            skills_dir=skills_dir,
+            manifest_path=manifest_path,
+        )
+        return
+
+    for entry in available:
+        name = entry.get("name")
+        selector = entry.get("pluginId")
+        if not selector and name:
+            selector = f"{name}@{marketplace_name}"
+        if not selector:
+            continue
+        print(f"==> Installing {selector}")
+        if _run_codex_json(["plugin", "add", selector]) is None:
+            print(f"WARN: failed to install {selector}")
+
+    installed = _run_codex_json(["plugin", "list"])
+    manifest: dict[str, list[str]] = {}
+    for entry in installed.get("installed", []) if installed else []:
+        if entry.get("marketplaceName") != marketplace_name:
+            continue
+        name = entry.get("name")
+        installed_path = entry.get("installedPath")
+        if not name or not installed_path:
+            continue
+        skill_names = _find_skill_names(Path(installed_path))
+        if skill_names:
+            manifest[name] = skill_names
+
+    manifest_path = manifest_path or _manifest_path()
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    print(f"==> Manifest written to {manifest_path}")
+
+
 # ---------------------------------------------------------------------------
 # Runtime: filter plugins
 # ---------------------------------------------------------------------------
@@ -279,6 +372,61 @@ def _filter_opencode(wanted: set[str]) -> None:
                     shutil.rmtree(entry)
 
 
+def _load_plugin_manifest() -> dict[str, list[str]]:
+    manifest_path = _manifest_path()
+    if not manifest_path.is_file():
+        return {}
+    try:
+        with open(manifest_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        print(
+            f"WARNING: {manifest_path} contains invalid JSON",
+            file=sys.stderr,
+        )
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _filter_codex(wanted: set[str]) -> None:
+    installed = _run_codex_json(["plugin", "list"])
+    native_plugins = installed.get("installed", []) if installed else []
+    manifest = _load_plugin_manifest()
+
+    native_names = {
+        entry.get("name") for entry in native_plugins if isinstance(entry.get("name"), str)
+    }
+    matched = wanted & (native_names | set(manifest))
+    _check_unmatched(wanted, matched)
+
+    for entry in native_plugins:
+        name = entry.get("name")
+        if not name or name in wanted:
+            continue
+        selector = entry.get("pluginId")
+        if not selector:
+            marketplace = entry.get("marketplaceName")
+            selector = f"{name}@{marketplace}" if marketplace else name
+        if _run_codex_json(["plugin", "remove", selector]) is None:
+            print(f"WARN: failed to disable Codex plugin {selector}", file=sys.stderr)
+
+    wanted_skills: set[str] = set()
+    for plugin_name, skills in manifest.items():
+        if plugin_name in wanted:
+            wanted_skills.update(skills)
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    skills_dir = codex_home / "skills"
+    if skills_dir.is_dir():
+        managed_skills = {skill for skills in manifest.values() for skill in skills}
+        for entry in skills_dir.iterdir():
+            if entry.name in managed_skills and entry.name not in wanted_skills:
+                if entry.is_symlink():
+                    entry.unlink()
+                elif entry.is_dir():
+                    shutil.rmtree(entry)
+
+
 def enable_plugins() -> None:
     """Filter active plugins based on ``AGENT_ENABLED_PLUGINS``."""
     wanted_csv = os.environ.get("AGENT_ENABLED_PLUGINS", "")
@@ -305,8 +453,7 @@ def enable_plugins() -> None:
     elif agent_tool == "claude":
         _filter_claude(wanted)
     elif agent_tool == "codex":
-        # Codex does not have a plugin system; nothing to filter.
-        pass
+        _filter_codex(wanted)
     else:
         print(f"ERROR: unknown AGENT_TOOL: {agent_tool!r}", file=sys.stderr)
         sys.exit(1)

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -209,11 +209,14 @@ def _codex_marketplace_root(marketplace_json: Path) -> Path:
 
 
 def _run_codex_json(args: list[str]) -> dict | None:
-    result = subprocess.run(
-        ["codex", *args, "--json"],
-        capture_output=True,
-        text=True,
-    )
+    try:
+        result = subprocess.run(
+            ["codex", *args, "--json"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
     if result.returncode != 0:
         return None
     try:

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -244,6 +244,11 @@ def install_codex_plugins(
     marketplace_root = _codex_marketplace_root(marketplace_json)
     added = _run_codex_json(["plugin", "marketplace", "add", str(marketplace_root)])
     marketplace_name = added.get("marketplaceName") if added else None
+    if added and not marketplace_name:
+        print(
+            "  WARN: codex plugin marketplace add succeeded but returned no "
+            "marketplaceName; falling back to skills compatibility layer"
+        )
 
     listing = None
     if marketplace_name:
@@ -343,22 +348,8 @@ def _filter_claude(wanted: set[str]) -> None:
 def _filter_opencode(wanted: set[str]) -> None:
     config_dir = Path(os.environ.get("OPENCODE_CONFIG_DIR", Path.home() / ".config" / "opencode"))
 
-    manifest_path = _manifest_path()
-    if not manifest_path.is_file():
-        print(
-            f"WARNING: AGENT_ENABLED_PLUGINS is set but {manifest_path} not found",
-            file=sys.stderr,
-        )
-        return
-
-    try:
-        with open(manifest_path) as f:
-            manifest = json.load(f)
-    except (json.JSONDecodeError, ValueError):
-        print(
-            f"WARNING: {manifest_path} contains invalid JSON",
-            file=sys.stderr,
-        )
+    manifest = _load_plugin_manifest(warn_if_missing=True)
+    if manifest is None:
         return
 
     matched = wanted & set(manifest.keys())
@@ -379,10 +370,27 @@ def _filter_opencode(wanted: set[str]) -> None:
                     shutil.rmtree(entry)
 
 
-def _load_plugin_manifest() -> dict[str, list[str]]:
+def _load_plugin_manifest(warn_if_missing: bool = False) -> dict[str, list[str]] | None:
+    """Load the plugin-to-skills manifest.
+
+    Returns the parsed mapping, or ``None`` when the manifest is missing or
+    unreadable (invalid JSON). Callers for which the manifest is the sole
+    source of truth (OpenCode) should treat ``None`` as "do not filter";
+    callers with another source of truth (Codex native plugins) can fall back
+    to ``{}``. A manifest whose top-level JSON is not an object is treated as
+    an empty mapping.
+
+    Set ``warn_if_missing`` to emit the "manifest not found" warning when the
+    file is absent (OpenCode); Codex loads it silently.
+    """
     manifest_path = _manifest_path()
     if not manifest_path.is_file():
-        return {}
+        if warn_if_missing:
+            print(
+                f"WARNING: AGENT_ENABLED_PLUGINS is set but {manifest_path} not found",
+                file=sys.stderr,
+            )
+        return None
     try:
         with open(manifest_path) as f:
             data = json.load(f)
@@ -391,14 +399,14 @@ def _load_plugin_manifest() -> dict[str, list[str]]:
             f"WARNING: {manifest_path} contains invalid JSON",
             file=sys.stderr,
         )
-        return {}
+        return None
     return data if isinstance(data, dict) else {}
 
 
 def _filter_codex(wanted: set[str]) -> None:
     installed = _run_codex_json(["plugin", "list"])
     native_plugins = installed.get("installed", []) if installed else []
-    manifest = _load_plugin_manifest()
+    manifest = _load_plugin_manifest() or {}
 
     native_names = {
         entry.get("name") for entry in native_plugins if isinstance(entry.get("name"), str)

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -214,10 +214,14 @@ def _run_codex_json(args: list[str]) -> dict | None:
             ["codex", *args, "--json"],
             capture_output=True,
             text=True,
+            timeout=120,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"  WARN: failed to run codex {' '.join(args)}: {exc}")
         return None
     if result.returncode != 0:
+        detail = result.stderr.strip() or "no stderr output"
+        print(f"  WARN: codex {' '.join(args)} failed (exit {result.returncode}): {detail}")
         return None
     try:
         data = json.loads(result.stdout)

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -298,12 +298,15 @@ def enable_plugins() -> None:
 
     agent_tool = os.environ.get("AGENT_TOOL")
     if not agent_tool:
-        print("ERROR: AGENT_TOOL must be set (claude or opencode)", file=sys.stderr)
+        print("ERROR: AGENT_TOOL must be set (claude, opencode, or codex)", file=sys.stderr)
         sys.exit(1)
     if agent_tool == "opencode":
         _filter_opencode(wanted)
     elif agent_tool == "claude":
         _filter_claude(wanted)
+    elif agent_tool == "codex":
+        # Codex does not have a plugin system; nothing to filter.
+        pass
     else:
         print(f"ERROR: unknown AGENT_TOOL: {agent_tool!r}", file=sys.stderr)
         sys.exit(1)

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -568,18 +568,9 @@ class OpenCodeStreamProcessor:
 class CodexStreamProcessor:
     """Processes Codex CLI --json JSONL output and prints human-readable CI logs.
 
-    Codex CLI with ``--json`` emits one JSON object per line.  Each object has
-    a ``type`` field.  The main event types are:
-
-    - ``message_start`` -- beginning of a new assistant turn
-    - ``message_delta`` -- incremental text / tool-call deltas
-    - ``message_complete`` -- a full assistant message (text + tool calls)
-    - ``exec_approval`` -- tool execution approval (auto-approved in CI)
-    - ``exec_result`` -- result of a tool execution
-    - ``task_complete`` -- final summary when the session ends
-    - ``error`` -- an error event
-
-    This processor provides a minimal but readable rendering.
+    Codex emits ``thread.started``, ``turn.*``, ``item.*``, and ``error``
+    events. Items cover assistant messages, reasoning, command executions,
+    file changes, MCP calls, web searches, and plan updates.
     """
 
     def __init__(self, color=True, wrap=0, agent_pid=0):
@@ -595,45 +586,93 @@ class CodexStreamProcessor:
         else:
             self.THINK = self.TOOL = self.AGENT = self.RED = self.RESET = ""
 
-        self._in_text = False
-        self._line_buf = ""
         self._errors: list[str] = []
+        self._started_items: set[str] = set()
 
     _INDENT = "  "
 
-    def _print_line(self, line):
-        if self.wrap and len(line) > self.wrap:
-            wrapped = ""
-            col = 0
-            for word in line.split(" "):
-                if col + len(word) > self.wrap and col > 0:
-                    wrapped += f"\n{self._INDENT}"
-                    col = 0
-                if col > 0:
-                    wrapped += " "
-                    col += 1
-                wrapped += word
-                col += len(word)
-            print(f"{self._INDENT}{wrapped}", flush=True)
-        else:
-            print(f"{self._INDENT}{line}", flush=True)
+    def _print_text(self, label, text, style=""):
+        lines = str(text).splitlines() or [""]
+        first_prefix = f"{self._INDENT}{style}{label}"
+        continuation = self._INDENT * 2
+        for index, line in enumerate(lines):
+            prefix = first_prefix if index == 0 else continuation
+            if self.wrap and len(prefix) + len(line) > self.wrap:
+                available = max(self.wrap - len(continuation), 20)
+                words = line.split()
+                chunks = []
+                current = ""
+                for word in words:
+                    candidate = f"{current} {word}".strip()
+                    if current and len(candidate) > available:
+                        chunks.append(current)
+                        current = word
+                    else:
+                        current = candidate
+                chunks.append(current)
+                for chunk_index, chunk in enumerate(chunks):
+                    chunk_prefix = prefix if chunk_index == 0 else continuation
+                    print(f"{chunk_prefix}{chunk}{self.RESET}", flush=True)
+            else:
+                print(f"{prefix}{line}{self.RESET}", flush=True)
 
-    def _emit(self, text):
-        self._line_buf += text
-        while "\n" in self._line_buf:
-            line, self._line_buf = self._line_buf.split("\n", 1)
-            self._print_line(line)
+    @staticmethod
+    def _error_message(error):
+        if isinstance(error, dict):
+            return error.get("message", str(error))
+        return str(error)
 
-    def _flush_emit(self):
-        if self._line_buf:
-            self._print_line(self._line_buf)
-            self._line_buf = ""
+    def _print_command(self, item):
+        command = item.get("command", "")
+        self._print_text("\U0001f527 Shell $ ", command, self.TOOL)
 
-    def _end_text(self):
-        if self._in_text:
-            self._flush_emit()
-            sys.stdout.write(self.RESET + "\n")
-            self._in_text = False
+    def _process_item(self, event_type, item):
+        item_id = item.get("id", "")
+        item_type = item.get("type", "")
+
+        if event_type == "item.started":
+            if item_id:
+                self._started_items.add(item_id)
+            if item_type == "command_execution":
+                self._print_command(item)
+            elif item_type == "mcp_tool_call":
+                server = item.get("server", "")
+                tool = item.get("tool", item.get("name", "unknown"))
+                name = f"{server}/{tool}" if server else tool
+                self._print_text("\U0001f527 MCP ", name, self.TOOL)
+            elif item_type == "web_search":
+                self._print_text("\U0001f50d Web search ", item.get("query", ""), self.TOOL)
+            return
+
+        if item_type == "agent_message":
+            self._print_text("\U0001f4ac Codex ", item.get("text", ""), self.AGENT)
+        elif item_type == "reasoning":
+            text = item.get("text", item.get("summary", ""))
+            if text:
+                self._print_text("\U0001f9e0 Thinking ", text, self.THINK)
+        elif item_type == "command_execution":
+            if item_id not in self._started_items:
+                self._print_command(item)
+            exit_code = item.get("exit_code")
+            if exit_code not in (None, 0):
+                self._print_text("  exit=", str(exit_code), self.RED)
+        elif item_type == "file_change":
+            changes = item.get("changes", [])
+            if changes:
+                for change in changes:
+                    if isinstance(change, dict):
+                        path = change.get("path", "")
+                        kind = change.get("kind", change.get("type", ""))
+                        detail = f"{kind} {path}".strip()
+                    else:
+                        detail = str(change)
+                    self._print_text("\U0001f527 File change ", detail, self.TOOL)
+            else:
+                self._print_text("\U0001f527 File change ", item.get("path", ""), self.TOOL)
+        elif item_type == "plan":
+            text = item.get("text", item.get("plan", ""))
+            if text:
+                self._print_text("\U0001f4cb Plan ", text, self.TOOL)
 
     def flush_errors(self):
         """Print collected errors."""
@@ -641,7 +680,7 @@ class CodexStreamProcessor:
             return
         for error_msg in dict.fromkeys(self._errors):
             print(
-                f"{self._INDENT}{self.RED}Error: {error_msg}{self.RESET}",
+                f"{self._INDENT}{self.RED}❌ Error: {error_msg}{self.RESET}",
                 flush=True,
             )
 
@@ -659,73 +698,31 @@ class CodexStreamProcessor:
         msg_type = msg.get("type", "")
 
         if msg_type == "error":
-            self._end_text()
-            error_msg = msg.get("message", str(msg.get("error", "unknown error")))
+            error_msg = msg.get("message", self._error_message(msg.get("error", "unknown error")))
             self._errors.append(error_msg)
             return False
 
-        if msg_type == "message_complete":
-            self._end_text()
-            content = msg.get("content", "")
-            if content:
-                print(
-                    f"{self._INDENT}{self.AGENT}\U0001f4ac Codex {content}{self.RESET}",
-                    flush=True,
-                )
+        if msg_type in ("item.started", "item.completed"):
+            self._process_item(msg_type, msg.get("item", {}))
             return False
 
-        if msg_type == "message_delta":
-            delta = msg.get("delta", "")
-            if delta:
-                if not self._in_text:
-                    self._end_text()
-                    print(
-                        f"{self._INDENT}{self.AGENT}\U0001f4ac Codex ",
-                        end="",
-                        flush=True,
-                    )
-                    self._in_text = True
-                self._emit(delta)
+        if msg_type == "turn.failed":
+            self._errors.append(self._error_message(msg.get("error", "Codex turn failed")))
             return False
 
-        if msg_type == "exec_approval":
-            self._end_text()
-            command = msg.get("command", {})
-            cmd_type = command.get("type", "")
-            if cmd_type == "shell":
-                cmd_str = " ".join(command.get("command", []))
-                print(
-                    f"{self._INDENT}{self.TOOL}\U0001f527 Shell $ {cmd_str}{self.RESET}",
-                    flush=True,
-                )
-            elif cmd_type == "file_edit":
-                path = command.get("path", "")
-                print(
-                    f"{self._INDENT}{self.TOOL}\U0001f527 FileEdit {path}{self.RESET}",
-                    flush=True,
-                )
-            else:
-                print(
-                    f"{self._INDENT}{self.TOOL}\U0001f527 {cmd_type}{self.RESET}",
-                    flush=True,
-                )
-            return False
-
-        if msg_type == "exec_result":
-            self._end_text()
-            exit_code = msg.get("exit_code")
-            if exit_code and exit_code != 0:
-                print(
-                    f"{self._INDENT}{self.TOOL}  exit={exit_code}{self.RESET}",
-                    flush=True,
-                )
-            return False
-
-        if msg_type == "task_complete":
-            self._end_text()
-            summary = msg.get("summary", "")
-            if summary:
-                print(f"{self._INDENT}\U0001f4cb Task complete: {summary}", flush=True)
+        if msg_type == "turn.completed":
+            usage = msg.get("usage", {})
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            cache_r = usage.get("cached_input_tokens", 0)
+            cache_w = usage.get("cache_write_input_tokens", 0)
+            total = inp + out
+            print(
+                f"{self._INDENT}{self.TOOL}\U0001f4ca TOKENS in={inp} "
+                f"out={out} cache_r={cache_r} cache_w={cache_w} "
+                f"total={total}{self.RESET}",
+                flush=True,
+            )
             return True
 
         return False

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -578,7 +578,7 @@ class CodexStreamProcessor:
         self.agent_pid = agent_pid
 
         if color:
-            self.THINK = "\033[3;31m"
+            self.THINK = "\033[3;36m"
             self.TOOL = "\033[1;90m"
             self.AGENT = ""
             self.RED = "\033[31m"
@@ -594,10 +594,15 @@ class CodexStreamProcessor:
     def _print_text(self, label, text, style=""):
         lines = str(text).splitlines() or [""]
         first_prefix = f"{self._INDENT}{style}{label}"
+        # Width must be measured against visible characters only; the ANSI
+        # ``style`` escape is non-printing, so excluding it keeps wrapping at
+        # the intended column instead of wrapping early when color is enabled.
+        first_prefix_width = len(self._INDENT) + len(label)
         continuation = self._INDENT * 2
         for index, line in enumerate(lines):
             prefix = first_prefix if index == 0 else continuation
-            if self.wrap and len(prefix) + len(line) > self.wrap:
+            prefix_width = first_prefix_width if index == 0 else len(continuation)
+            if self.wrap and prefix_width + len(line) > self.wrap:
                 available = max(self.wrap - len(continuation), 20)
                 words = line.split()
                 chunks = []
@@ -657,7 +662,14 @@ class CodexStreamProcessor:
             if item_id not in self._started_items:
                 self._print_command(item)
             exit_code = item.get("exit_code")
-            if exit_code not in (None, 0):
+            # Codex may serialize exit_code as a number or a numeric string;
+            # normalize before comparing so a successful "0" is not rendered
+            # as a failure.
+            try:
+                normalized = int(exit_code) if exit_code is not None else None
+            except (TypeError, ValueError):
+                normalized = exit_code
+            if normalized not in (None, 0):
                 self._print_text("  exit=", str(exit_code), self.RED)
         elif item_type == "file_change":
             changes = item.get("changes", [])
@@ -720,6 +732,15 @@ class CodexStreamProcessor:
             return False
 
         if msg_type == "turn.completed":
+            # ``codex exec`` runs a single turn per invocation and reports its
+            # terminal token usage here, so the first turn.completed marks the
+            # end of the run. Returning True is load-bearing for telemetry:
+            # backend._process_stream uses it to wait for the OTEL batch
+            # exporter to flush (otherwise the root span is often lost) and to
+            # promote a post-completion non-zero exit code to success. If a
+            # future Codex exec mode emits multiple turns, completion should be
+            # keyed off a thread-level terminal event instead of this first
+            # turn.completed to avoid truncating the run.
             usage = msg.get("usage", {})
             inp = usage.get("input_tokens", 0)
             out = usage.get("output_tokens", 0)

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -626,6 +626,12 @@ class CodexStreamProcessor:
         command = item.get("command", "")
         self._print_text("\U0001f527 Shell $ ", command, self.TOOL)
 
+    @staticmethod
+    def _mcp_name(item):
+        server = item.get("server", "")
+        tool = item.get("tool", item.get("name", "unknown"))
+        return f"{server}/{tool}" if server else tool
+
     def _process_item(self, event_type, item):
         item_id = item.get("id", "")
         item_type = item.get("type", "")
@@ -636,10 +642,7 @@ class CodexStreamProcessor:
             if item_type == "command_execution":
                 self._print_command(item)
             elif item_type == "mcp_tool_call":
-                server = item.get("server", "")
-                tool = item.get("tool", item.get("name", "unknown"))
-                name = f"{server}/{tool}" if server else tool
-                self._print_text("\U0001f527 MCP ", name, self.TOOL)
+                self._print_text("\U0001f527 MCP ", self._mcp_name(item), self.TOOL)
             elif item_type == "web_search":
                 self._print_text("\U0001f50d Web search ", item.get("query", ""), self.TOOL)
             return
@@ -669,6 +672,12 @@ class CodexStreamProcessor:
                     self._print_text("\U0001f527 File change ", detail, self.TOOL)
             else:
                 self._print_text("\U0001f527 File change ", item.get("path", ""), self.TOOL)
+        elif item_type == "mcp_tool_call":
+            error = item.get("error")
+            if error or item.get("status") in ("failed", "error"):
+                message = self._error_message(error or "MCP tool call failed")
+                label = f"❌ MCP {self._mcp_name(item)} failed: "
+                self._print_text(label, message, self.RED)
         elif item_type == "plan":
             text = item.get("text", item.get("plan", ""))
             if text:

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -563,3 +563,178 @@ class OpenCodeStreamProcessor:
             if self.process_line(line):
                 return True
         return False
+
+
+class CodexStreamProcessor:
+    """Processes Codex CLI --json JSONL output and prints human-readable CI logs.
+
+    Codex CLI with ``--json`` emits one JSON object per line.  Each object has
+    a ``type`` field.  The main event types are:
+
+    - ``message_start`` -- beginning of a new assistant turn
+    - ``message_delta`` -- incremental text / tool-call deltas
+    - ``message_complete`` -- a full assistant message (text + tool calls)
+    - ``exec_approval`` -- tool execution approval (auto-approved in CI)
+    - ``exec_result`` -- result of a tool execution
+    - ``task_complete`` -- final summary when the session ends
+    - ``error`` -- an error event
+
+    This processor provides a minimal but readable rendering.
+    """
+
+    def __init__(self, color=True, wrap=0, agent_pid=0):
+        self.wrap = wrap
+        self.agent_pid = agent_pid
+
+        if color:
+            self.THINK = "\033[3;31m"
+            self.TOOL = "\033[1;90m"
+            self.AGENT = ""
+            self.RED = "\033[31m"
+            self.RESET = "\033[0m"
+        else:
+            self.THINK = self.TOOL = self.AGENT = self.RED = self.RESET = ""
+
+        self._in_text = False
+        self._line_buf = ""
+        self._errors: list[str] = []
+
+    _INDENT = "  "
+
+    def _print_line(self, line):
+        if self.wrap and len(line) > self.wrap:
+            wrapped = ""
+            col = 0
+            for word in line.split(" "):
+                if col + len(word) > self.wrap and col > 0:
+                    wrapped += f"\n{self._INDENT}"
+                    col = 0
+                if col > 0:
+                    wrapped += " "
+                    col += 1
+                wrapped += word
+                col += len(word)
+            print(f"{self._INDENT}{wrapped}", flush=True)
+        else:
+            print(f"{self._INDENT}{line}", flush=True)
+
+    def _emit(self, text):
+        self._line_buf += text
+        while "\n" in self._line_buf:
+            line, self._line_buf = self._line_buf.split("\n", 1)
+            self._print_line(line)
+
+    def _flush_emit(self):
+        if self._line_buf:
+            self._print_line(self._line_buf)
+            self._line_buf = ""
+
+    def _end_text(self):
+        if self._in_text:
+            self._flush_emit()
+            sys.stdout.write(self.RESET + "\n")
+            self._in_text = False
+
+    def flush_errors(self):
+        """Print collected errors."""
+        if not self._errors:
+            return
+        for error_msg in dict.fromkeys(self._errors):
+            print(
+                f"{self._INDENT}{self.RED}Error: {error_msg}{self.RESET}",
+                flush=True,
+            )
+
+    def process_line(self, line):
+        """Process a single JSONL line from Codex. Returns True when run is complete."""
+        line = line.strip()
+        if not line:
+            return False
+
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return False
+
+        msg_type = msg.get("type", "")
+
+        if msg_type == "error":
+            self._end_text()
+            error_msg = msg.get("message", str(msg.get("error", "unknown error")))
+            self._errors.append(error_msg)
+            return False
+
+        if msg_type == "message_complete":
+            self._end_text()
+            content = msg.get("content", "")
+            if content:
+                print(
+                    f"{self._INDENT}{self.AGENT}\U0001f4ac Codex {content}{self.RESET}",
+                    flush=True,
+                )
+            return False
+
+        if msg_type == "message_delta":
+            delta = msg.get("delta", "")
+            if delta:
+                if not self._in_text:
+                    self._end_text()
+                    print(
+                        f"{self._INDENT}{self.AGENT}\U0001f4ac Codex ",
+                        end="",
+                        flush=True,
+                    )
+                    self._in_text = True
+                self._emit(delta)
+            return False
+
+        if msg_type == "exec_approval":
+            self._end_text()
+            command = msg.get("command", {})
+            cmd_type = command.get("type", "")
+            if cmd_type == "shell":
+                cmd_str = " ".join(command.get("command", []))
+                print(
+                    f"{self._INDENT}{self.TOOL}\U0001f527 Shell $ {cmd_str}{self.RESET}",
+                    flush=True,
+                )
+            elif cmd_type == "file_edit":
+                path = command.get("path", "")
+                print(
+                    f"{self._INDENT}{self.TOOL}\U0001f527 FileEdit {path}{self.RESET}",
+                    flush=True,
+                )
+            else:
+                print(
+                    f"{self._INDENT}{self.TOOL}\U0001f527 {cmd_type}{self.RESET}",
+                    flush=True,
+                )
+            return False
+
+        if msg_type == "exec_result":
+            self._end_text()
+            exit_code = msg.get("exit_code")
+            if exit_code and exit_code != 0:
+                print(
+                    f"{self._INDENT}{self.TOOL}  exit={exit_code}{self.RESET}",
+                    flush=True,
+                )
+            return False
+
+        if msg_type == "task_complete":
+            self._end_text()
+            summary = msg.get("summary", "")
+            if summary:
+                print(f"{self._INDENT}\U0001f4cb Task complete: {summary}", flush=True)
+            return True
+
+        return False
+
+    def process(self, input_stream):
+        """Process a stream of lines. Returns True if run completed normally."""
+        for line in input_stream:
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="replace")
+            if self.process_line(line):
+                return True
+        return False

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -135,6 +135,37 @@ if [[ -s "$TMPDIR_E2E/nostream-out.txt" ]]; then
     echo "--- end non-streaming output ---"
 fi
 
+# -- Codex streaming + OTEL test ---------------------------------------------
+print_header "=== agentic-ci run --backend local: Codex + OTEL ==="
+
+_has_codex_creds() {
+    [[ -n "${CODEX_API_KEY:-}" ]] || \
+    [[ -n "${CODEX_ACCESS_TOKEN:-}" ]] || \
+    [[ -n "${OPENAI_API_KEY:-}" ]] || \
+    [[ -f "${CODEX_HOME:-${HOME}/.codex}/auth.json" ]]
+}
+
+if command -v codex >/dev/null 2>&1 && _has_codex_creds; then
+    WORKDIR="$TMPDIR_E2E/codex"
+    mkdir -p "$WORKDIR"
+
+    print_step "Running Codex via local backend with OTEL..."
+    RC=0
+    agentic-ci run --backend local \
+        "Reply with only the word codex-pong" \
+        --harness codex \
+        --workdir "$WORKDIR" \
+        > "$TMPDIR_E2E/codex-out.txt" 2>"$TMPDIR_E2E/codex-err.txt" || RC=$?
+
+    assert_ok "Codex local run exited successfully" test "$RC" -eq 0
+    assert_contains "Codex streaming output contains response" \
+        "$(cat "$TMPDIR_E2E/codex-out.txt")" "codex-pong"
+    assert_contains "Codex exported OTEL API request events" \
+        "$(cat "$TMPDIR_E2E/codex-out.txt")" "API Requests:"
+else
+    print_warning "Skipping Codex local test (codex CLI or credentials unavailable)"
+fi
+
 # -- Extra args passthrough test ----------------------------------------------
 print_header "=== agentic-ci run --backend local: extra args ==="
 

--- a/tests/images/test_entrypoint.sh
+++ b/tests/images/test_entrypoint.sh
@@ -89,6 +89,12 @@ OC_ENV=$(run_detect "opencode")
 assert_contains "opencode: sets OPENCODE_DISABLE_AUTOUPDATE=1" "$OC_ENV" "OPENCODE_DISABLE_AUTOUPDATE=1"
 assert_not_contains "opencode: does not set DISABLE_AUTOUPDATER" "$OC_ENV" "DISABLE_AUTOUPDATER"
 
+print_header "=== Entrypoint tool detection: codex ==="
+
+CODEX_ENV=$(run_detect "codex")
+assert_not_contains "codex: does not set Claude auto-update vars" "$CODEX_ENV" "DISABLE_AUTOUPDATER"
+assert_not_contains "codex: does not set OpenCode auto-update vars" "$CODEX_ENV" "OPENCODE_DISABLE_AUTOUPDATE"
+
 print_header "=== Entrypoint tool detection: AGENT_TOOL fallback ==="
 
 AGENT_TOOL_CLAUDE_ENV=$(env -i HOME="$HOME" PATH="$PATH" AGENT_TOOL=claude bash -c "

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,7 +9,7 @@ from agentic_ci.backends import create_backend
 from agentic_ci.backends.local import LocalBackend
 from agentic_ci.backends.openshell import OpenShellBackend, _token_keepalive
 from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import ClaudeCodeHarness, create_harness
+from agentic_ci.harness import ClaudeCodeHarness, CodexHarness, create_harness
 
 
 @pytest.fixture()
@@ -77,6 +77,29 @@ def test_create_openshell_with_approval_mode(harness):
 def test_unknown_backend_raises(harness):
     with pytest.raises(ValueError, match="Unknown backend"):
         create_backend("docker", harness=harness)
+
+
+def test_local_codex_credentials_fail_fast(monkeypatch, tmp_path):
+    for name in ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-home"))
+
+    backend = LocalBackend(workdir=str(tmp_path), harness=CodexHarness())
+
+    with pytest.raises(RuntimeError, match="CODEX_API_KEY"):
+        backend.setup()
+
+
+def test_local_codex_accepts_auth_file(monkeypatch, tmp_path):
+    for name in ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    backend = LocalBackend(workdir=str(tmp_path), harness=CodexHarness())
+    backend.setup()
 
 
 def test_backends_have_stop_method(harness):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -447,9 +447,9 @@ class TestCodexHarness:
     def test_name(self):
         assert CodexHarness().name == "Codex"
 
-    def test_auth_mode_always_api_key(self, monkeypatch):
+    def test_auth_mode_is_openai(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
-        assert CodexHarness().auth_mode == "api-key"
+        assert CodexHarness().auth_mode == "openai"
 
     def test_build_args(self):
         harness = CodexHarness()
@@ -460,10 +460,21 @@ class TestCodexHarness:
         assert "--json" in args
         assert "--skip-git-repo-check" in args
         assert "--ephemeral" in args
-        assert "--ignore-user-config" in args
+        assert "--ignore-user-config" not in args
         assert "-m" in args
         assert "gpt-5.6-sol" in args
         assert "do something" in args
+
+    def test_build_args_with_otel(self):
+        args = CodexHarness().build_args(
+            "prompt",
+            "model",
+            otel_endpoint="http://127.0.0.1:4318",
+        )
+        config_values = [args[index + 1] for index, arg in enumerate(args) if arg == "-c"]
+        assert any("http://127.0.0.1:4318/v1/logs" in value for value in config_values)
+        assert any("http://127.0.0.1:4318/v1/metrics" in value for value in config_values)
+        assert any("http://127.0.0.1:4318/v1/traces" in value for value in config_values)
 
     def test_build_args_with_extra(self):
         harness = CodexHarness()
@@ -471,28 +482,37 @@ class TestCodexHarness:
         assert "--foo" in args
         assert "bar" in args
 
-    def test_build_env_args(self):
+    def test_build_env_args(self, monkeypatch):
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.setenv("CODEX_ACCESS_TOKEN", "test-token")
         harness = CodexHarness()
         args = harness.build_env_args()
-        assert "OPENAI_API_KEY" in args
+        assert "CODEX_API_KEY" in args
+        assert "CODEX_ACCESS_TOKEN" in args
         assert "AGENT_TOOL=codex" in args
 
     def test_build_env_script_lines(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setenv("CODEX_API_KEY", "sk-test-key")
         harness = CodexHarness()
         lines = harness.build_env_script_lines()
-        assert any("OPENAI_API_KEY=sk-test-key" in line for line in lines)
+        assert any("CODEX_API_KEY=sk-test-key" in line for line in lines)
+        assert "mkdir -p /sandbox/.codex" in lines
         assert any("AGENT_TOOL=codex" in line for line in lines)
         assert any("CODEX_HOME=/sandbox/.codex" in line for line in lines)
+
+    def test_build_env_script_lines_forwards_enabled_plugins(self, monkeypatch):
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "alpha,beta")
+        lines = CodexHarness().build_env_script_lines()
+        assert any("AGENT_ENABLED_PLUGINS=alpha,beta" in line for line in lines)
 
     def test_build_otel_exec_env_always_empty(self):
         assert CodexHarness().build_otel_exec_env(otel_port=4318) == []
 
     def test_build_local_env(self, monkeypatch):
-        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "alpha")
         env = CodexHarness().build_local_env()
         assert env["AGENT_TOOL"] == "codex"
-        assert env["OPENAI_API_KEY"] == "sk-test-key"
+        assert env["AGENT_ENABLED_PLUGINS"] == "alpha"
 
     def test_credential_mount_target(self):
         assert CodexHarness().credential_mount_target() == "/home/agent-ci"
@@ -516,8 +536,5 @@ class TestCodexHarness:
     def test_default_model(self):
         assert CodexHarness().default_model() == "gpt-5.6-sol"
 
-    def test_supports_otel_false(self):
-        assert CodexHarness().supports_otel is False
-
-    def test_autoupdater_env_var(self):
-        assert CodexHarness().autoupdater_env_var == "CODEX_DISABLE_AUTOUPDATE"
+    def test_supports_otel(self):
+        assert CodexHarness().supports_otel is True

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -461,6 +461,8 @@ class TestCodexHarness:
         assert "--skip-git-repo-check" in args
         assert "--ephemeral" in args
         assert "--ignore-user-config" not in args
+        config_values = [args[index + 1] for index, arg in enumerate(args) if arg == "-c"]
+        assert "check_for_update_on_startup=false" in config_values
         assert "-m" in args
         assert "gpt-5.6-sol" in args
         assert "do something" in args

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4,6 +4,7 @@ import pytest
 
 from agentic_ci.harness import (
     ClaudeCodeHarness,
+    CodexHarness,
     OpenCodeHarness,
     create_harness,
 )
@@ -17,6 +18,11 @@ def test_create_claude_code_harness():
 def test_create_opencode_harness():
     harness = create_harness("opencode")
     assert isinstance(harness, OpenCodeHarness)
+
+
+def test_create_codex_harness():
+    harness = create_harness("codex")
+    assert isinstance(harness, CodexHarness)
 
 
 def test_create_unknown_harness_raises():
@@ -435,3 +441,83 @@ class TestOpenCodeHarness:
         harness = OpenCodeHarness()
         mounts = harness.sandbox_config_mounts(str(tmp_path))
         assert mounts == []
+
+
+class TestCodexHarness:
+    def test_name(self):
+        assert CodexHarness().name == "Codex"
+
+    def test_auth_mode_always_api_key(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert CodexHarness().auth_mode == "api-key"
+
+    def test_build_args(self):
+        harness = CodexHarness()
+        args = harness.build_args("do something", "gpt-5.6-sol")
+        assert args[0] == "codex"
+        assert "exec" in args
+        assert "--dangerously-bypass-approvals-and-sandbox" in args
+        assert "--json" in args
+        assert "--skip-git-repo-check" in args
+        assert "--ephemeral" in args
+        assert "--ignore-user-config" in args
+        assert "-m" in args
+        assert "gpt-5.6-sol" in args
+        assert "do something" in args
+
+    def test_build_args_with_extra(self):
+        harness = CodexHarness()
+        args = harness.build_args("prompt", "model", extra_args=["--foo", "bar"])
+        assert "--foo" in args
+        assert "bar" in args
+
+    def test_build_env_args(self):
+        harness = CodexHarness()
+        args = harness.build_env_args()
+        assert "OPENAI_API_KEY" in args
+        assert "AGENT_TOOL=codex" in args
+
+    def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        harness = CodexHarness()
+        lines = harness.build_env_script_lines()
+        assert any("OPENAI_API_KEY=sk-test-key" in line for line in lines)
+        assert any("AGENT_TOOL=codex" in line for line in lines)
+        assert any("CODEX_HOME=/sandbox/.codex" in line for line in lines)
+
+    def test_build_otel_exec_env_always_empty(self):
+        assert CodexHarness().build_otel_exec_env(otel_port=4318) == []
+
+    def test_build_local_env(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        env = CodexHarness().build_local_env()
+        assert env["AGENT_TOOL"] == "codex"
+        assert env["OPENAI_API_KEY"] == "sk-test-key"
+
+    def test_credential_mount_target(self):
+        assert CodexHarness().credential_mount_target() == "/home/agent-ci"
+
+    def test_credential_mount_target_env_override(self, monkeypatch):
+        monkeypatch.setenv("CODEX_CONTAINER_HOME", "/home/codex")
+        assert CodexHarness().credential_mount_target() == "/home/codex"
+
+    def test_create_stream_processor(self):
+        from agentic_ci.stream import CodexStreamProcessor
+
+        proc = CodexHarness().create_stream_processor(pid=789)
+        assert isinstance(proc, CodexStreamProcessor)
+
+    def test_image_env_var(self):
+        assert CodexHarness().image_env_var() == "CODEX_CONTAINER_IMAGE"
+
+    def test_model_env_var(self):
+        assert CodexHarness().model_env_var() == "CODEX_MODEL"
+
+    def test_default_model(self):
+        assert CodexHarness().default_model() == "gpt-5.6-sol"
+
+    def test_supports_otel_false(self):
+        assert CodexHarness().supports_otel is False
+
+    def test_autoupdater_env_var(self):
+        assert CodexHarness().autoupdater_env_var == "CODEX_DISABLE_AUTOUPDATE"

--- a/tests/test_openshell_provider.py
+++ b/tests/test_openshell_provider.py
@@ -5,7 +5,11 @@ from unittest import mock
 
 import pytest
 
-from agentic_ci.backends.openshell.provider import PROVIDER_NAME, rotate_token
+from agentic_ci.backends.openshell.provider import (
+    PROVIDER_NAME,
+    rotate_token,
+    setup,
+)
 
 
 class TestRotateToken:
@@ -33,3 +37,46 @@ class TestRotateToken:
         ):
             with pytest.raises(subprocess.CalledProcessError):
                 rotate_token()
+
+
+class TestProviderSetup:
+    def test_openai_provider_uses_codex_api_key(self, monkeypatch):
+        monkeypatch.setenv("CODEX_API_KEY", "test-key")
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with (
+            mock.patch(
+                "agentic_ci.backends.openshell.provider.provider_exists",
+                return_value=False,
+            ),
+            mock.patch("agentic_ci.backends.openshell.provider._run") as mock_run,
+        ):
+            setup("openai")
+
+        args = mock_run.call_args.args[0]
+        env = mock_run.call_args.kwargs["env"]
+        assert args == [
+            "openshell",
+            "provider",
+            "create",
+            "--name",
+            PROVIDER_NAME,
+            "--type",
+            "openai",
+            "--credential",
+            "OPENAI_API_KEY",
+        ]
+        assert env["OPENAI_API_KEY"] == "test-key"
+
+    def test_openai_provider_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("CODEX_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with (
+            mock.patch(
+                "agentic_ci.backends.openshell.provider.provider_exists",
+                return_value=False,
+            ),
+            pytest.raises(RuntimeError, match="CODEX_API_KEY"),
+        ):
+            setup("openai")

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -556,3 +556,80 @@ class TestInjectRootSpans:
         span = records[1]["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         assert int(span["startTimeUnixNano"]) == 500
         assert int(span["endTimeUnixNano"]) == 12000
+
+
+class TestParseMetricsRobustness:
+    """parse_metrics must tolerate malformed OTLP attribute entries."""
+
+    def test_metrics_attribute_missing_key_is_skipped(self):
+        records = [
+            {
+                "path": "/v1/metrics",
+                "payload": {
+                    "resourceMetrics": [
+                        {
+                            "scopeMetrics": [
+                                {
+                                    "metrics": [
+                                        {
+                                            "name": "claude_code.token.usage",
+                                            "sum": {
+                                                "dataPoints": [
+                                                    {
+                                                        "asInt": 5,
+                                                        "attributes": [
+                                                            {"value": {"stringValue": "orphan"}},
+                                                            {
+                                                                "key": "model",
+                                                                "value": {"stringValue": "gpt-5"},
+                                                            },
+                                                            {
+                                                                "key": "type",
+                                                                "value": {"stringValue": "input"},
+                                                            },
+                                                        ],
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+        token_totals, _, _, _ = parse_metrics(records)
+        assert token_totals[("gpt-5", "input")] == 5
+
+    def test_logs_attribute_missing_key_is_skipped(self):
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "logRecords": [
+                                        {
+                                            "attributes": [
+                                                {"value": {"stringValue": "orphan"}},
+                                                {
+                                                    "key": "event.name",
+                                                    "value": {"stringValue": "codex.api_request"},
+                                                },
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+        _, _, api_requests, _ = parse_metrics(records)
+        assert len(api_requests) == 1
+        assert api_requests[0]["event.name"] == "codex.api_request"

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -11,6 +11,7 @@ from agentic_ci.otel import (
     _has_any_traces,
     generate_trace_context,
     inject_root_spans,
+    parse_metrics,
     start_collector,
     stop_collector,
 )
@@ -212,6 +213,58 @@ class TestGenerateTraceContext:
         trace_id, span_id, _ = generate_trace_context()
         int(trace_id, 16)
         int(span_id, 16)
+
+
+class TestParseMetrics:
+    def test_parses_codex_token_usage_and_api_requests(self):
+        attributes = {
+            "event.name": "codex.sse_event",
+            "event.kind": "response.completed",
+            "model": "gpt-test",
+            "input_token_count": "100",
+            "cached_token_count": 40,
+            "cache_write_token_count": 10,
+            "output_token_count": "20",
+        }
+
+        def attr(key, value):
+            value_key = "intValue" if isinstance(value, int) else "stringValue"
+            return {"key": key, "value": {value_key: value}}
+
+        response_record = {"attributes": [attr(key, value) for key, value in attributes.items()]}
+        request_record = {
+            "attributes": [
+                attr("event.name", "codex.api_request"),
+                attr("duration_ms", "123"),
+            ]
+        }
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "logRecords": [
+                                        response_record,
+                                        request_record,
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+
+        token_totals, _, api_requests, _ = parse_metrics(records)
+
+        assert token_totals[("gpt-test", "input")] == 50
+        assert token_totals[("gpt-test", "cacheRead")] == 40
+        assert token_totals[("gpt-test", "cacheCreation")] == 10
+        assert token_totals[("gpt-test", "output")] == 20
+        assert api_requests == [{"event.name": "codex.api_request", "duration_ms": "123"}]
 
 
 class TestFindOrphanTraces:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -184,12 +184,30 @@ class TestEnablePluginsOpenCode:
         assert not orphan.exists()
         assert (tmp_path / "skills" / "skill-a1" / "SKILL.md").is_file()
 
-    def test_missing_manifest_returns_ok(self, monkeypatch, tmp_path):
+    def test_missing_manifest_returns_ok(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("AGENT_TOOL", "opencode")
         monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path))
         monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
-        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(tmp_path / "nonexistent.json"))
+        manifest = tmp_path / "nonexistent.json"
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
         enable_plugins()
+        assert f"{manifest} not found" in capsys.readouterr().err
+
+    def test_invalid_manifest_returns_ok(self, monkeypatch, tmp_path, capsys):
+        """An unreadable (invalid JSON) manifest warns and skips filtering."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text("{ not valid json")
+        skills_dir = tmp_path / "skills" / "skill-a1"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: skill-a1\n---\n")
+        monkeypatch.setenv("AGENT_TOOL", "opencode")
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+        enable_plugins()
+        # Filtering is skipped, so the on-disk skill is left untouched.
+        assert (tmp_path / "skills" / "skill-a1" / "SKILL.md").is_file()
+        assert "invalid JSON" in capsys.readouterr().err
 
 
 # -- enable_plugins: Codex filtering -----------------------------------------
@@ -481,6 +499,33 @@ class TestInstallCodexPlugins:
                 manifest_path=manifest,
             )
 
+        install_skills.assert_called_once_with(
+            marketplace,
+            skills_dir=skills_dir,
+            manifest_path=manifest,
+        )
+
+    def test_marketplace_add_without_name_falls_back_and_warns(self, tmp_path, capsys):
+        """A marketplace add that returns no marketplaceName warns and falls back."""
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        skills_dir = tmp_path / "skills"
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                side_effect=[{"ok": True}],
+            ),
+            mock.patch("agentic_ci.plugins.install_opencode_skills") as install_skills,
+        ):
+            install_codex_plugins(
+                marketplace,
+                skills_dir=skills_dir,
+                manifest_path=manifest,
+            )
+
+        assert "returned no marketplaceName" in capsys.readouterr().out
         install_skills.assert_called_once_with(
             marketplace,
             skills_dir=skills_dir,

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,6 +9,7 @@ import pytest
 from agentic_ci.plugins import (
     _find_skill_names,
     enable_plugins,
+    install_codex_plugins,
     install_opencode_skills,
 )
 
@@ -187,6 +188,67 @@ class TestEnablePluginsOpenCode:
         enable_plugins()
 
 
+# -- enable_plugins: Codex filtering -----------------------------------------
+
+
+class TestEnablePluginsCodex:
+    def test_filters_native_plugins_and_compatibility_skills(self, monkeypatch, tmp_path):
+        codex_home = tmp_path / "codex"
+        skills_dir = codex_home / "skills"
+        for name in ("skill-a", "skill-b", "personal-skill"):
+            skill_dir = skills_dir / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"plugin-a": ["skill-a"], "plugin-b": ["skill-b"]}))
+        installed = {
+            "installed": [
+                {
+                    "name": "plugin-a",
+                    "pluginId": "plugin-a@test",
+                    "marketplaceName": "test",
+                },
+                {
+                    "name": "plugin-b",
+                    "pluginId": "plugin-b@test",
+                    "marketplaceName": "test",
+                },
+            ]
+        }
+
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with mock.patch(
+            "agentic_ci.plugins._run_codex_json",
+            side_effect=[installed, {"pluginId": "plugin-b@test"}],
+        ) as run_codex:
+            enable_plugins()
+
+        assert run_codex.call_args_list[-1] == mock.call(["plugin", "remove", "plugin-b@test"])
+        assert (skills_dir / "skill-a").is_dir()
+        assert not (skills_dir / "skill-b").exists()
+        assert (skills_dir / "personal-skill").is_dir()
+
+    def test_unknown_plugin_exits(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "missing")
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(tmp_path / "missing-manifest.json"))
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                return_value={"installed": []},
+            ),
+            pytest.raises(SystemExit),
+        ):
+            enable_plugins()
+
+
 # -- install_opencode_skills -------------------------------------------------
 
 
@@ -315,3 +377,80 @@ class TestInstallOpencodeSkills:
         install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
 
         assert json.loads(manifest.read_text()) == {}
+
+
+# -- install_codex_plugins ---------------------------------------------------
+
+
+class TestInstallCodexPlugins:
+    def test_installs_native_plugins_and_writes_manifest(self, tmp_path):
+        marketplace_dir = tmp_path / ".agents" / "plugins"
+        marketplace_dir.mkdir(parents=True)
+        marketplace = marketplace_dir / "marketplace.json"
+        marketplace.write_text("{}")
+
+        installed_plugin = tmp_path / "installed-plugin"
+        skill = installed_plugin / "skills" / "review"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: review\n---\n")
+        manifest = tmp_path / "manifest.json"
+
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            {"pluginId": "review-plugin@test-marketplace"},
+            {
+                "installed": [
+                    {
+                        "name": "review-plugin",
+                        "marketplaceName": "test-marketplace",
+                        "installedPath": str(installed_plugin),
+                    }
+                ]
+            },
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses) as run_codex:
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert run_codex.call_args_list[0] == mock.call(
+            ["plugin", "marketplace", "add", str(tmp_path)]
+        )
+        assert json.loads(manifest.read_text()) == {"review-plugin": ["review"]}
+
+    def test_legacy_marketplace_falls_back_to_skills(self, tmp_path):
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        marketplace = marketplace_dir / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        skills_dir = tmp_path / "skills"
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                side_effect=[
+                    {"marketplaceName": "legacy"},
+                    {"available": []},
+                ],
+            ),
+            mock.patch("agentic_ci.plugins.install_opencode_skills") as install_skills,
+        ):
+            install_codex_plugins(
+                marketplace,
+                skills_dir=skills_dir,
+                manifest_path=manifest,
+            )
+
+        install_skills.assert_called_once_with(
+            marketplace,
+            skills_dir=skills_dir,
+            manifest_path=manifest,
+        )

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,6 +2,7 @@
 
 import json
 import shutil
+import subprocess
 from unittest import mock
 
 import pytest
@@ -537,3 +538,27 @@ class TestInstallCodexPlugins:
 def test_run_codex_json_handles_missing_or_unexecutable_binary(error):
     with mock.patch("agentic_ci.plugins.subprocess.run", side_effect=error):
         assert _run_codex_json(["plugin", "list"]) is None
+
+
+def test_run_codex_json_times_out_and_warns(capsys):
+    error = subprocess.TimeoutExpired(["codex", "plugin", "list"], 120)
+    with mock.patch("agentic_ci.plugins.subprocess.run", side_effect=error) as run:
+        assert _run_codex_json(["plugin", "list"]) is None
+
+    assert run.call_args.kwargs["timeout"] == 120
+    assert "WARN: failed to run codex plugin list" in capsys.readouterr().out
+
+
+def test_run_codex_json_reports_stderr(capsys):
+    result = subprocess.CompletedProcess(
+        ["codex", "plugin", "list"],
+        returncode=2,
+        stdout="",
+        stderr="plugin registry unavailable",
+    )
+    with mock.patch("agentic_ci.plugins.subprocess.run", return_value=result):
+        assert _run_codex_json(["plugin", "list"]) is None
+
+    output = capsys.readouterr().out
+    assert "exit 2" in output
+    assert "plugin registry unavailable" in output

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -7,7 +7,10 @@ from unittest import mock
 import pytest
 
 from agentic_ci.plugins import (
+    _codex_marketplace_root,
+    _filter_codex,
     _find_skill_names,
+    _run_codex_json,
     enable_plugins,
     install_codex_plugins,
     install_opencode_skills,
@@ -248,6 +251,27 @@ class TestEnablePluginsCodex:
         ):
             enable_plugins()
 
+    def test_plugin_list_failure_still_filters_compatibility_skills(self, monkeypatch, tmp_path):
+        codex_home = tmp_path / "codex"
+        skills_dir = codex_home / "skills"
+        for name in ("skill-a", "skill-b", "personal-skill"):
+            skill_dir = skills_dir / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").touch()
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"plugin-a": ["skill-a"], "plugin-b": ["skill-b"]}))
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", return_value=None) as run_codex:
+            _filter_codex({"plugin-a"})
+
+        run_codex.assert_called_once_with(["plugin", "list"])
+        assert (skills_dir / "skill-a").is_dir()
+        assert not (skills_dir / "skill-b").exists()
+        assert (skills_dir / "personal-skill").is_dir()
+
 
 # -- install_opencode_skills -------------------------------------------------
 
@@ -383,6 +407,13 @@ class TestInstallOpencodeSkills:
 
 
 class TestInstallCodexPlugins:
+    def test_marketplace_root_plain_directory(self, tmp_path):
+        marketplace = tmp_path / "registry" / "marketplace.json"
+        marketplace.parent.mkdir()
+        marketplace.touch()
+
+        assert _codex_marketplace_root(marketplace) == marketplace.parent
+
     def test_installs_native_plugins_and_writes_manifest(self, tmp_path):
         marketplace_dir = tmp_path / ".agents" / "plugins"
         marketplace_dir.mkdir(parents=True)
@@ -454,3 +485,55 @@ class TestInstallCodexPlugins:
             skills_dir=skills_dir,
             manifest_path=manifest,
         )
+
+    def test_final_plugin_list_failure_writes_empty_manifest(self, tmp_path):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            {"pluginId": "review-plugin@test-marketplace"},
+            None,
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses):
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert json.loads(manifest.read_text()) == {}
+
+    def test_plugin_add_failure_warns(self, tmp_path, capsys):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            None,
+            {"installed": []},
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses):
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert "WARN: failed to install review-plugin@test-marketplace" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError(), OSError("exec failed")])
+def test_run_codex_json_handles_missing_or_unexecutable_binary(error):
+    with mock.patch("agentic_ci.plugins.subprocess.run", side_effect=error):
+        assert _run_codex_json(["plugin", "list"]) is None

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess as _subprocess
+from unittest import mock
 
 import pytest
 
@@ -304,3 +305,22 @@ def test_is_local_image_missing_remote(monkeypatch, tmp_path, claude_harness):
     monkeypatch.setattr(_subprocess, "run", mock_run)
 
     assert backend._is_local_image() is False
+
+
+def test_run_passes_otel_port_to_implicit_setup(tmp_path, claude_harness):
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        image="localhost/test:latest",
+        harness=claude_harness,
+    )
+
+    with (
+        mock.patch.object(backend, "is_running", return_value=False),
+        mock.patch.object(backend, "setup") as setup,
+        mock.patch.object(backend, "_process_stream", return_value=(0, True)),
+        mock.patch.object(backend, "_wait_for_otel_flush"),
+        mock.patch("agentic_ci.backends.podman.subprocess.Popen"),
+    ):
+        assert backend.run("test", "test-model", otel_port=4318) == 0
+
+    setup.assert_called_once_with(otel_port=4318)

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -7,7 +7,7 @@ import subprocess as _subprocess
 import pytest
 
 from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import ClaudeCodeHarness, OpenCodeHarness
+from agentic_ci.harness import ClaudeCodeHarness, CodexHarness, OpenCodeHarness
 
 
 @pytest.fixture()
@@ -91,6 +91,20 @@ def test_resolve_image_raises_with_correct_env_var(monkeypatch, tmp_path, openco
     backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
     with pytest.raises(RuntimeError, match="OPENCODE_CONTAINER_IMAGE"):
         backend._resolve_image()
+
+
+def test_setup_codex_credentials_fail_fast(monkeypatch, tmp_path):
+    for name in ("CODEX_API_KEY", "CODEX_ACCESS_TOKEN", "OPENAI_API_KEY"):
+        monkeypatch.delenv(name, raising=False)
+
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        image="localhost/codex:test",
+        harness=CodexHarness(),
+    )
+
+    with pytest.raises(RuntimeError, match="CODEX_API_KEY"):
+        backend.setup()
 
 
 def test_build_vol_args_claude_mount_target(monkeypatch, tmp_path, claude_harness):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,6 +1,7 @@
 """Tests for policy resolution."""
 
 from agentic_ci.backends.openshell.policy import (
+    AUTH_ENDPOINTS,
     DEFAULT_ENDPOINTS,
     build_credential_binding_patch,
     resolve_endpoints,
@@ -56,13 +57,17 @@ def test_duplicate_endpoints_deduplicated(tmp_path):
 
 
 def test_endpoints_include_vertex_ai():
-    result = resolve_endpoints()
+    result = resolve_endpoints(auth_mode="vertex")
     assert any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.anthropic.com" in ep for ep in result)
+    assert not any("api.openai.com" in ep for ep in result)
 
 
 def test_endpoints_include_anthropic_api():
-    result = resolve_endpoints()
+    result = resolve_endpoints(auth_mode="api-key")
     assert any("api.anthropic.com" in ep for ep in result)
+    assert not any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.openai.com" in ep for ep in result)
 
 
 def test_credential_binding_patch_adds_binding_to_gcp():
@@ -133,6 +138,7 @@ def test_credential_binding_patch_preserves_existing_binding():
 
 
 def test_endpoints_include_openai_apis():
-    result = resolve_endpoints()
-    assert any("api.openai.com" in ep for ep in result)
-    assert any("chatgpt.com" in ep for ep in result)
+    result = resolve_endpoints(auth_mode="openai")
+    assert result == list(DEFAULT_ENDPOINTS) + AUTH_ENDPOINTS["openai"]
+    assert not any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.anthropic.com" in ep for ep in result)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -130,3 +130,9 @@ def test_credential_binding_patch_preserves_existing_binding():
         },
     }
     assert build_credential_binding_patch(policy_get_output) is None
+
+
+def test_endpoints_include_openai_apis():
+    result = resolve_endpoints()
+    assert any("api.openai.com" in ep for ep in result)
+    assert any("chatgpt.com" in ep for ep in result)

--- a/tests/test_stream_codex.py
+++ b/tests/test_stream_codex.py
@@ -84,6 +84,46 @@ class TestProcessLine:
         assert "Shell $ false" in output
         assert "exit=1" in output
 
+    def test_string_exit_code_zero_not_failure(self, capsys):
+        """Codex may serialize exit_code as the string "0"; treat it as success."""
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="true",
+                exit_code="0",
+                status="completed",
+            ),
+        )
+        proc.process_line(line)
+        assert "exit=" not in capsys.readouterr().out
+
+    def test_string_exit_code_nonzero_is_failure(self, capsys):
+        """A string exit_code like "2" is still rendered as a failure."""
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="false",
+                exit_code="2",
+                status="failed",
+            ),
+        )
+        proc.process_line(line)
+        assert "exit=2" in capsys.readouterr().out
+
+    def test_thinking_uses_cyan_color(self, capsys):
+        """Reasoning output uses cyan (not red, which is reserved for errors)."""
+        proc = CodexStreamProcessor(color=True)
+        line = _make_event(
+            "item.completed",
+            item=_item("reasoning", text="Checking the repository"),
+        )
+        proc.process_line(line)
+        assert "\033[3;36m" in capsys.readouterr().out
+
     def test_file_change(self, capsys):
         proc = CodexStreamProcessor(color=False)
         line = _make_event(

--- a/tests/test_stream_codex.py
+++ b/tests/test_stream_codex.py
@@ -105,6 +105,22 @@ class TestProcessLine:
         proc.process_line(line)
         assert "MCP github/get_pr" in capsys.readouterr().out
 
+    def test_failed_mcp_tool_call(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "mcp_tool_call",
+                server="github",
+                tool="get_pr",
+                status="failed",
+                error={"message": "repository unavailable"},
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "❌ MCP github/get_pr failed: repository unavailable" in output
+
     def test_web_search(self, capsys):
         proc = CodexStreamProcessor(color=False)
         line = _make_event(
@@ -146,6 +162,20 @@ class TestProcessLine:
     def test_unknown_type_ignored(self):
         proc = CodexStreamProcessor(color=False)
         assert proc.process_line(_make_event("something_unknown", data="foo")) is False
+
+    def test_wraps_long_agent_message(self, capsys):
+        proc = CodexStreamProcessor(color=False, wrap=30)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "agent_message",
+                text="one two three four five six seven eight nine ten",
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "💬 Codex one two three four five" in output
+        assert "\n    six seven eight nine ten\n" in output
 
 
 class TestProcess:

--- a/tests/test_stream_codex.py
+++ b/tests/test_stream_codex.py
@@ -6,123 +6,172 @@ from agentic_ci.stream import CodexStreamProcessor
 
 
 def _make_event(event_type, **kwargs):
-    """Build a Codex JSONL event."""
     event = {"type": event_type}
     event.update(kwargs)
     return json.dumps(event)
 
 
+def _item(item_type, item_id="item_1", **kwargs):
+    item = {"id": item_id, "type": item_type}
+    item.update(kwargs)
+    return item
+
+
 class TestProcessLine:
     def test_empty_line(self):
-        proc = CodexStreamProcessor(color=False)
-        assert proc.process_line("") is False
+        assert CodexStreamProcessor(color=False).process_line("") is False
 
     def test_invalid_json(self):
-        proc = CodexStreamProcessor(color=False)
-        assert proc.process_line("not json") is False
+        assert CodexStreamProcessor(color=False).process_line("not json") is False
 
-    def test_message_delta(self, capsys):
-        proc = CodexStreamProcessor(color=False)
-        line = _make_event("message_delta", delta="Hello world\n")
-        assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        assert "Codex" in captured.out
-        assert "Hello world" in captured.out
-
-    def test_message_complete(self, capsys):
-        proc = CodexStreamProcessor(color=False)
-        line = _make_event("message_complete", content="Done with analysis")
-        assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        assert "Codex" in captured.out
-        assert "Done with analysis" in captured.out
-
-    def test_exec_approval_shell(self, capsys):
+    def test_agent_message(self, capsys):
         proc = CodexStreamProcessor(color=False)
         line = _make_event(
-            "exec_approval",
-            command={"type": "shell", "command": ["ls", "-la"]},
+            "item.completed",
+            item=_item("agent_message", text="Done with analysis"),
         )
         assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        assert "Shell" in captured.out
-        assert "ls -la" in captured.out
+        assert "💬 Codex Done with analysis" in capsys.readouterr().out
 
-    def test_exec_approval_file_edit(self, capsys):
+    def test_reasoning(self, capsys):
         proc = CodexStreamProcessor(color=False)
         line = _make_event(
-            "exec_approval",
-            command={"type": "file_edit", "path": "/tmp/test.py"},
+            "item.completed",
+            item=_item("reasoning", text="Checking the repository"),
         )
-        assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        assert "FileEdit" in captured.out
-        assert "/tmp/test.py" in captured.out
+        proc.process_line(line)
+        assert "Thinking Checking the repository" in capsys.readouterr().out
 
-    def test_exec_result_success(self, capsys):
+    def test_command_execution(self, capsys):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("exec_result", exit_code=0)
-        assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        # exit_code=0 should not print anything
-        assert "exit=" not in captured.out
+        started = _make_event(
+            "item.started",
+            item=_item(
+                "command_execution",
+                command="/bin/bash -lc 'ls -la'",
+                status="in_progress",
+            ),
+        )
+        completed = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="/bin/bash -lc 'ls -la'",
+                exit_code=0,
+                status="completed",
+            ),
+        )
+        assert proc.process_line(started) is False
+        assert proc.process_line(completed) is False
+        output = capsys.readouterr().out
+        assert "Shell $" in output
+        assert "ls -la" in output
+        assert output.count("Shell $") == 1
 
-    def test_exec_result_failure(self, capsys):
+    def test_failed_command_prints_exit_code(self, capsys):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("exec_result", exit_code=1)
-        assert proc.process_line(line) is False
-        captured = capsys.readouterr()
-        assert "exit=1" in captured.out
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="false",
+                exit_code=1,
+                status="failed",
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "Shell $ false" in output
+        assert "exit=1" in output
 
-    def test_task_complete(self, capsys):
+    def test_file_change(self, capsys):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("task_complete", summary="All done")
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "file_change",
+                changes=[{"path": "src/app.py", "kind": "update"}],
+            ),
+        )
+        proc.process_line(line)
+        assert "File change update src/app.py" in capsys.readouterr().out
+
+    def test_mcp_tool_call(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.started",
+            item=_item("mcp_tool_call", server="github", tool="get_pr"),
+        )
+        proc.process_line(line)
+        assert "MCP github/get_pr" in capsys.readouterr().out
+
+    def test_web_search(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.started",
+            item=_item("web_search", query="Codex telemetry"),
+        )
+        proc.process_line(line)
+        assert "Web search Codex telemetry" in capsys.readouterr().out
+
+    def test_turn_completed(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "turn.completed",
+            usage={
+                "input_tokens": 100,
+                "cached_input_tokens": 40,
+                "cache_write_input_tokens": 10,
+                "output_tokens": 20,
+                "reasoning_output_tokens": 5,
+            },
+        )
         assert proc.process_line(line) is True
-        captured = capsys.readouterr()
-        assert "Task complete" in captured.out
-        assert "All done" in captured.out
+        output = capsys.readouterr().out
+        assert "TOKENS in=100 out=20 cache_r=40 cache_w=10 total=120" in output
 
     def test_error_event(self, capsys):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("error", message="API key invalid")
+        assert proc.process_line(_make_event("error", message="token invalid")) is False
+        proc.flush_errors()
+        assert "token invalid" in capsys.readouterr().out
+
+    def test_turn_failed(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("turn.failed", error={"message": "request failed"})
         assert proc.process_line(line) is False
         proc.flush_errors()
-        captured = capsys.readouterr()
-        assert "API key invalid" in captured.out
+        assert "request failed" in capsys.readouterr().out
 
     def test_unknown_type_ignored(self):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("something_unknown", data="foo")
-        assert proc.process_line(line) is False
+        assert proc.process_line(_make_event("something_unknown", data="foo")) is False
 
 
 class TestProcess:
-    def test_full_run(self, capsys):
+    def test_full_run(self):
         proc = CodexStreamProcessor(color=False)
         events = [
-            _make_event("message_delta", delta="Working on it..."),
+            _make_event("thread.started", thread_id="thread-1"),
+            _make_event("turn.started"),
             _make_event(
-                "exec_approval",
-                command={"type": "shell", "command": ["echo", "hello"]},
+                "item.completed",
+                item=_item("agent_message", text="Finished"),
             ),
-            _make_event("exec_result", exit_code=0),
-            _make_event("task_complete", summary="Finished"),
+            _make_event("turn.completed", usage={}),
         ]
-        result = proc.process(events)
-        assert result is True
+        assert proc.process(events) is True
 
     def test_incomplete_stream(self):
         proc = CodexStreamProcessor(color=False)
-        events = [
-            _make_event("message_delta", delta="Hello"),
-        ]
-        result = proc.process(events)
-        assert result is False
+        events = [_make_event("turn.started")]
+        assert proc.process(events) is False
 
     def test_bytes_input(self, capsys):
         proc = CodexStreamProcessor(color=False)
-        line = _make_event("message_complete", content="Hello")
-        result = proc.process([line.encode("utf-8")])
-        assert result is False
-        captured = capsys.readouterr()
-        assert "Hello" in captured.out
+        line = _make_event(
+            "item.completed",
+            item=_item("agent_message", text="Hello"),
+        )
+        assert proc.process([line.encode("utf-8")]) is False
+        assert "Hello" in capsys.readouterr().out

--- a/tests/test_stream_codex.py
+++ b/tests/test_stream_codex.py
@@ -1,0 +1,128 @@
+"""Tests for CodexStreamProcessor."""
+
+import json
+
+from agentic_ci.stream import CodexStreamProcessor
+
+
+def _make_event(event_type, **kwargs):
+    """Build a Codex JSONL event."""
+    event = {"type": event_type}
+    event.update(kwargs)
+    return json.dumps(event)
+
+
+class TestProcessLine:
+    def test_empty_line(self):
+        proc = CodexStreamProcessor(color=False)
+        assert proc.process_line("") is False
+
+    def test_invalid_json(self):
+        proc = CodexStreamProcessor(color=False)
+        assert proc.process_line("not json") is False
+
+    def test_message_delta(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("message_delta", delta="Hello world\n")
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Codex" in captured.out
+        assert "Hello world" in captured.out
+
+    def test_message_complete(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("message_complete", content="Done with analysis")
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Codex" in captured.out
+        assert "Done with analysis" in captured.out
+
+    def test_exec_approval_shell(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "exec_approval",
+            command={"type": "shell", "command": ["ls", "-la"]},
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "Shell" in captured.out
+        assert "ls -la" in captured.out
+
+    def test_exec_approval_file_edit(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "exec_approval",
+            command={"type": "file_edit", "path": "/tmp/test.py"},
+        )
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "FileEdit" in captured.out
+        assert "/tmp/test.py" in captured.out
+
+    def test_exec_result_success(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("exec_result", exit_code=0)
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        # exit_code=0 should not print anything
+        assert "exit=" not in captured.out
+
+    def test_exec_result_failure(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("exec_result", exit_code=1)
+        assert proc.process_line(line) is False
+        captured = capsys.readouterr()
+        assert "exit=1" in captured.out
+
+    def test_task_complete(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("task_complete", summary="All done")
+        assert proc.process_line(line) is True
+        captured = capsys.readouterr()
+        assert "Task complete" in captured.out
+        assert "All done" in captured.out
+
+    def test_error_event(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("error", message="API key invalid")
+        assert proc.process_line(line) is False
+        proc.flush_errors()
+        captured = capsys.readouterr()
+        assert "API key invalid" in captured.out
+
+    def test_unknown_type_ignored(self):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("something_unknown", data="foo")
+        assert proc.process_line(line) is False
+
+
+class TestProcess:
+    def test_full_run(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        events = [
+            _make_event("message_delta", delta="Working on it..."),
+            _make_event(
+                "exec_approval",
+                command={"type": "shell", "command": ["echo", "hello"]},
+            ),
+            _make_event("exec_result", exit_code=0),
+            _make_event("task_complete", summary="Finished"),
+        ]
+        result = proc.process(events)
+        assert result is True
+
+    def test_incomplete_stream(self):
+        proc = CodexStreamProcessor(color=False)
+        events = [
+            _make_event("message_delta", delta="Hello"),
+        ]
+        result = proc.process(events)
+        assert result is False
+
+    def test_bytes_input(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("message_complete", content="Hello")
+        result = proc.process([line.encode("utf-8")])
+        assert result is False
+        captured = capsys.readouterr()
+        assert "Hello" in captured.out


### PR DESCRIPTION
## Summary

- Add Codex as a supported agentic-ci harness across the local, Podman, and OpenShell backends.
- Parse Codex's `codex exec --json` JSONL events, including agent messages, reasoning, command execution, file changes, MCP calls and failures, web searches, plans, run failures, and token usage.
- Support Codex's native plugin marketplace/package commands. For legacy marketplaces that only expose skill directories, install compatibility skills under `$CODEX_HOME/skills` and preserve unmanaged personal skills during runtime filtering.
- Degrade cleanly to compatibility and warning paths when the Codex plugin CLI is unavailable or a plugin operation fails.
- Collect Codex OpenTelemetry logs, metrics, and traces through agentic-ci's embedded OTLP/HTTP JSON collector. The summary extracts model, input/output/cache tokens, API request count, and API duration.
- Support Codex authentication through `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, `OPENAI_API_KEY`, or local `$CODEX_HOME/auth.json` login state, with early credential validation before local or Podman execution.
- Add OpenAI credential injection and network policy support for OpenShell.
- Document Codex harness, plugin, authentication, telemetry, parity, and troubleshooting behavior.

## Follow-up

Codex runner and OpenShell image definitions under `images/runner/codex` are intentionally left for a later follow-up. Until those images are added, Codex runner images are user-supplied through `--image` or `CODEX_CONTAINER_IMAGE`.

## Validation

- [x] `uvx tox -e py313` — 802 tests passed
- [x] `uvx tox -e lint`
- [x] `uvx tox -e check-format`
- [x] `uvx tox -e typecheck`
- [x] `make image-lint`
- [x] `make image-test` — 13 entrypoint tests passed
- [x] Real Codex 0.146.0 local run through agentic-ci exited 0 and produced model, token, API-request, and API-duration telemetry
- [x] Integration-tested with `openshift-eng/ai-helpers#657` at `706b46bde54b34ebd8e0279fff7d8f273ec57c76` in a Fedora 43/aarch64 Codex-only image using the updated agentic-ci wheel
- [x] The integration image installed 39 ai-helpers skills under `/workspace/.agents/skills`; Codex invoked `$fetch-releases`, returned the expected `GET /api/releases`, emitted `AI_HELPERS_CODEX_OK`, exited 0, and produced the agentic-ci OpenTelemetry summary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex as a supported harness (including streaming output, OTEL support, and plugin install/filtering).
  * Added Codex/OpenShell auth-mode handling and expanded OpenShell policy endpoint resolution.
* **Documentation**
  * Updated guides for Codex usage, credentials, plugins, OTEL configuration, troubleshooting, and contribution/testing parity.
* **Bug Fixes**
  * Improved harness authentication status/logging, hardened credential validation, and redacted OpenShell secrets in command logs.
  * Updated Codex streaming event rendering (and changed “thinking” label color).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->