### PR TITLE
Work around crun incompatibility on GH Actions runners

### DIFF
--- a/.github/actions/setup-podman/action.yml
+++ b/.github/actions/setup-podman/action.yml
@@ -1,0 +1,17 @@
+# Workaround for crun "unknown version specified" on GitHub Actions runners.
+# The runner image ships a crun build incompatible with podman 5.8.x.
+# Configuring podman to use runc (available from containerd) sidesteps it.
+# Remove this action once the runner image is fixed.
+name: Setup podman runtime
+description: Configure podman to use runc as OCI runtime
+
+runs:
+  using: composite
+  steps:
+    - name: Configure podman to use runc
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo mkdir -p /etc/containers
+        printf '[engine]\nruntime = "runc"\n' | sudo tee /etc/containers/containers.conf
+        podman info --format 'Runtime: {{.Host.OCIRuntime.Name}} {{.Host.OCIRuntime.Path}}'

--- a/.github/workflows/images-dev.yml
+++ b/.github/workflows/images-dev.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
@@ -112,6 +115,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
@@ -157,6 +163,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
@@ -191,6 +200,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
@@ -233,6 +245,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
@@ -274,6 +289,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)
         with:
@@ -308,6 +326,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Log in to quay.io
         uses: redhat-actions/podman-login@2e76993ec4585e058ea832c23ee3d885970936af # v1 (node24)

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -69,6 +69,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Image metadata
         id: meta
         run: echo "image=${IMAGE_PREFIX}/claude-runner:${CI_TAG}" >> "$GITHUB_OUTPUT"
@@ -149,6 +152,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Image metadata
         id: meta
@@ -231,6 +237,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Image metadata
         id: meta
         run: echo "image=${IMAGE_PREFIX}/podman:${CI_TAG}" >> "$GITHUB_OUTPUT"
@@ -300,6 +309,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Image metadata
         id: meta
@@ -374,6 +386,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Image metadata
         id: meta
         run: echo "image=${IMAGE_PREFIX}/opencode-sandbox:${CI_TAG}" >> "$GITHUB_OUTPUT"
@@ -447,6 +462,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
       - name: Image metadata
         id: meta
         run: echo "image=${IMAGE_PREFIX}/openshell-supervisor:${CI_TAG}" >> "$GITHUB_OUTPUT"
@@ -516,6 +534,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
 
       - name: Image metadata
         id: meta

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -13,6 +13,9 @@ on:
     paths:
       - 'images/**'
       - 'src/agentic_ci/**'
+      - '.github/actions/setup-podman/**'
+      - '.github/workflows/images.yml'
+      - '.github/workflows/images-dev.yml'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
@@ -22,6 +25,9 @@ on:
       - 'tests/e2e/**'
       - 'src/agentic_ci/**'
       - 'Makefile'
+      - '.github/actions/setup-podman/**'
+      - '.github/workflows/images.yml'
+      - '.github/workflows/images-dev.yml'
   schedule:
     # Daily at 6am UTC
     - cron: '0 6 * * *'

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,7 +22,8 @@
 #     - Lint
 #     - Image tests
 #
-#   images.yml (paths: images/, tests/images/, tests/e2e/, src/agentic_ci/, Makefile):
+#   images.yml (paths: images/, tests/images/, tests/e2e/, src/agentic_ci/, Makefile,
+#               .github/actions/setup-podman/, .github/workflows/images*.yml):
 #     - Build claude-runner
 #     - Build opencode-runner
 #     - Build ci-podman
@@ -39,7 +40,8 @@
 # Path overlap between the two image workflows:
 #   Both fire:          images/, tests/images/, tests/e2e/
 #   images-pr.yml only: scripts/bump-versions.py
-#   images.yml only:    src/agentic_ci/, Makefile
+#   images.yml only:    src/agentic_ci/, Makefile, .github/actions/setup-podman/,
+#                       .github/workflows/images*.yml
 
 merge_protections:
   # ---------------------------------------------------------------------------
@@ -185,15 +187,16 @@ merge_protections:
       - -draft
       - -conflict
 
-  # PRs touching only src/agentic_ci/ or Makefile (triggers images.yml only,
-  # NOT images-pr.yml). Don't require Lint or Image tests that won't run.
+  # PRs touching only src/agentic_ci/, Makefile, or .github/actions/setup-podman/,
+  # .github/workflows/images*.yml (triggers images.yml only, NOT images-pr.yml).
+  # Don't require Lint or Image tests that won't run.
   - name: maintainer-images-build-only
     if:
       - "author=@opendatahub-io/agentic-ci-maintainers"
       - "-author=aipcc-renovate-bot[bot]"
       - "-author=dependabot[bot]"
       - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$)"
-      - "files~=^(src/agentic_ci/|Makefile$)"
+      - "files~=^(src/agentic_ci/|Makefile$|\\.github/actions/setup-podman/|\\.github/workflows/images)"
     success_conditions:
       - "#approved-reviews-by>=1"
       # ci.yml
@@ -230,7 +233,7 @@ merge_protections:
       - "author=@opendatahub-io/agentic-ci-maintainers"
       - "-author=aipcc-renovate-bot[bot]"
       - "-author=dependabot[bot]"
-      - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$|src/agentic_ci/|Makefile$)"
+      - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$|src/agentic_ci/|Makefile$|\\.github/actions/setup-podman/|\\.github/workflows/images)"
     success_conditions:
       - "#approved-reviews-by>=1"
       # ci.yml
@@ -314,14 +317,15 @@ merge_protections:
       - -draft
       - -conflict
 
-  # Non-maintainer PRs touching only src/agentic_ci/ or Makefile.
+  # Non-maintainer PRs touching only src/agentic_ci/, Makefile, or
+  # .github/actions/setup-podman/, .github/workflows/images*.yml.
   - name: default-images-build-only
     if:
       - "-author=@opendatahub-io/agentic-ci-maintainers"
       - "-author=aipcc-renovate-bot[bot]"
       - "-author=dependabot[bot]"
       - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$)"
-      - "files~=^(src/agentic_ci/|Makefile$)"
+      - "files~=^(src/agentic_ci/|Makefile$|\\.github/actions/setup-podman/|\\.github/workflows/images)"
     success_conditions:
       - "#approved-reviews-by>=2"
       # ci.yml
@@ -358,7 +362,7 @@ merge_protections:
       - "-author=@opendatahub-io/agentic-ci-maintainers"
       - "-author=aipcc-renovate-bot[bot]"
       - "-author=dependabot[bot]"
-      - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$|src/agentic_ci/|Makefile$)"
+      - "-files~=^(images/|tests/images/|tests/e2e/|scripts/bump-versions\\.py$|src/agentic_ci/|Makefile$|\\.github/actions/setup-podman/|\\.github/workflows/images)"
     success_conditions:
       - "#approved-reviews-by>=2"
       # ci.yml


### PR DESCRIPTION
## Summary

- GitHub Actions runners updated `crun` to a version incompatible with podman 5.8.x, breaking **all** container image builds since 2026-07-30
- All `podman build` commands fail at the first `RUN` instruction with: `error running container: from /usr/bin/crun creating container for [...]: unknown version specified`
- This adds a local composite action (`.github/actions/setup-podman`) that configures podman to use `runc` (available from containerd on the runner) instead of `crun`
- The setup step is added to all 14 build jobs across `images.yml` and `images-dev.yml`
- Also adds `.github/actions/setup-podman/` and `.github/workflows/images*.yml` to the `paths:` triggers so workflow infrastructure changes actually run the build jobs, and updates `.mergify.yml` regexes to match

## Evidence

- Last passing run on main: [2026-07-29](https://github.com/opendatahub-io/agentic-ci/actions/runs/30535410498)
- First failing run on main: [2026-07-30](https://github.com/opendatahub-io/agentic-ci/actions/runs/30562655940)
- PR #293 (unrelated vale bump) also fails, confirming it is not PR-specific

## Test plan

- [ ] All 7 image build jobs pass in this PR's CI run
- [ ] `podman info` in the "Setup podman" step shows runc as the runtime
- [ ] Remove the composite action once GitHub ships a fixed runner image

🤖 Generated with [Claude Code](https://claude.com/claude-code)