### PR TITLE
RHAIFIRST-416: Fix stream processor false-positive SIGTERM on sentinel substring

### DIFF
--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -247,7 +247,7 @@ class ClaudeCodeStreamProcessor:
             for block in msg.get("message", {}).get("content", []):
                 if block.get("type") == "tool_result":
                     content = block.get("content", "")
-                    if isinstance(content, str) and "FULL RUN COMPLETE" in content:
+                    if isinstance(content, str) and content.strip() == "FULL RUN COMPLETE":
                         self._end_block()
                         if self.claude_pid:
                             log.section("FULL RUN COMPLETE detected, terminating Claude")

--- a/tests/test_completion_validator.py
+++ b/tests/test_completion_validator.py
@@ -39,7 +39,7 @@ class FakeStreamProcessor:
             for block in msg.get("message", {}).get("content", []):
                 if block.get("type") == "tool_result":
                     content = block.get("content", "")
-                    if isinstance(content, str) and "FULL RUN COMPLETE" in content:
+                    if isinstance(content, str) and content.strip() == "FULL RUN COMPLETE":
                         return True
         return False
 
@@ -138,6 +138,26 @@ class TestVerdictPathGuard:
         proc = _make_proc(['{"type": "system"}\n'], returncode=1)
         rc, stream_complete = backend._process_stream(proc, streaming=True)
         assert rc == 1
+        assert stream_complete is False
+
+    def test_sentinel_substring_in_file_read_not_treated_as_completion(self):
+        """A tool_result containing the sentinel as a substring must not trigger termination."""
+        embedded_msg = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": "The pipeline prints FULL RUN COMPLETE when done.",
+                        }
+                    ]
+                },
+            }
+        )
+        backend = ConcreteBackend(harness=FakeHarness())
+        proc = _make_proc([embedded_msg + "\n"], returncode=0)
+        rc, stream_complete = backend._process_stream(proc, streaming=True)
         assert stream_complete is False
 
 


### PR DESCRIPTION
## Summary

- Change the `FULL RUN COMPLETE` sentinel check in `stream.py` from substring match (`in`) to exact match (`==` after `.strip()`), preventing false-positive SIGTERM when the agent reads files containing the sentinel phrase as part of larger content.
- Add regression test for the false-positive scenario (sentinel embedded in a tool_result from a file read).

## Test plan

- [x] All 13 existing tests pass
- [x] New `test_sentinel_substring_in_file_read_not_treated_as_completion` confirms embedded sentinel does not trigger termination
- [x] `ruff check` and `ruff format --check` pass

Closes RHAIFIRST-416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved completion detection for Claude stream processing.
  - Runs now finish only when the tool result exactly matches the completion signal, preventing premature termination when that text appears within other content.

- **Tests**
  - Added regression coverage to verify that embedded completion text does not incorrectly end a run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->