### PR TITLE
Add pip/pip3 symlinks to UBI9 openshell images

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -61,7 +61,9 @@ RUN dnf install -y --nodocs \
 # UBI9 defaults python3 to 3.9; agentic-ci needs 3.10+, so make 3.12 the
 # default python3/python via /usr/local/bin (ahead of /usr/bin on PATH).
 RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
-    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
+    && ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3 \
+    && ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
 
 # uv
 ARG UV_VERSION=0.11.33

--- a/images/runner/shared/Containerfile.openshell-base
+++ b/images/runner/shared/Containerfile.openshell-base
@@ -50,7 +50,9 @@ RUN microdnf install -y --nodocs \
 # UBI9 defaults python3 to 3.9; agentic-ci needs 3.10+, so make 3.12 the
 # default python3/python via /usr/local/bin (ahead of /usr/bin on PATH).
 RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
-    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python \
+    && ln -sf /usr/bin/pip3.12 /usr/local/bin/pip3 \
+    && ln -sf /usr/bin/pip3.12 /usr/local/bin/pip
 
 # sandbox user — matches the OpenShell convention
 RUN groupadd -g 998 sandbox \


### PR DESCRIPTION
## Summary

- UBI9 installs `python3.12-pip` which provides `/usr/bin/pip3.12` but not bare `pip` or `pip3` commands.
- Add symlinks in both `Containerfile.openshell` (CI image) and `Containerfile.openshell-base` (sandbox base) so downstream consumers (autofix CI, etc.) can call `pip install` without modification.
- Root cause of autofix MR !1375 e2e failures after the 0.3.30 image bump.

## Test plan

- [x] Container Images workflow builds successfully
- [ ] Retry autofix renovate MR !1375 after merging and releasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added standard `pip` and `pip3` command aliases to Python 3.12 environments.
  * Ensured both Python-based environments provide consistent `python`, `python3`, `pip`, and `pip3` commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->