### PR TITLE
Build OpenCode OpenShell sandbox on the OpenCode agentic base image

### DIFF
--- a/.github/workflows/images-dev.yml
+++ b/.github/workflows/images-dev.yml
@@ -255,12 +255,6 @@ jobs:
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
-      - name: Build openshell-base
-        run: |
-          podman build --no-cache -t localhost/openshell-base:latest \
-            -f images/runner/shared/Containerfile.openshell-base \
-            .
-
       - name: Build and push opencode-sandbox
         env:
           DEV_TAG: ${{ needs.compute-tag.outputs.dev_tag }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -379,7 +379,8 @@ jobs:
         run: podman push "${IMAGE_PREFIX}/claude-sandbox:${VERSION_TAG}"
 
   # --------------------------------------------------------------------------
-  # opencode-sandbox: OpenShell sandbox, requires openshell-base built first
+  # opencode-sandbox: OpenShell sandbox, builds on the agentic base image
+  # (quay.io/aipcc/base-images/agentic/opencode), not openshell-base
   # --------------------------------------------------------------------------
   build-opencode-sandbox:
     name: Build opencode-sandbox
@@ -406,9 +407,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Build openshell-base
-        run: podman build -t localhost/openshell-base:latest -f images/runner/shared/Containerfile.openshell-base .
 
       - name: Build opencode-sandbox
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,8 @@ images/
       Containerfile.openshell       — Claude Code sandbox image (OpenShell)
     opencode/
       Containerfile                 — OpenCode runner image
-      Containerfile.openshell       — OpenCode sandbox image (OpenShell)
+      Containerfile.openshell       — OpenCode sandbox image (OpenShell); builds
+                                      on the agentic base image, not openshell-base
       opencode.json                 — Seed config for CI headless mode
   ci/
     Containerfile.podman            — CI environment image (podman + tools, UBI10)
@@ -93,6 +94,14 @@ OpenShell-path images (`Containerfile.openshell`,
 `Containerfile.openshell-base`) are therefore UBI9; the podman-path images
 stay on UBI10.
 
+The OpenCode sandbox image (`images/runner/opencode/Containerfile.openshell`)
+is the exception: it builds `FROM` the agentic base image
+(`quay.io/aipcc/base-images/agentic/opencode`, pinned by digest) rather
+than `openshell-base`. That base ships the OpenCode binary and Node on UBI9;
+the Containerfile layers the agentic-ci tooling (Python, uv, forge CLIs,
+agentic-ci, skills) on top. The Claude sandbox still builds on `openshell-base`
+because there is no equivalent agentic Claude Code base image yet.
+
 The runner-base Containerfile (`images/runner/shared/Containerfile.base`)
 is pre-built as `localhost/base:latest` before building the Claude and
 OpenCode runner images. It is NOT published to any registry as a
@@ -107,7 +116,7 @@ make opencode-build          # build OpenCode runner image (includes base)
 make ci-build                # build CI podman image
 make openshell-base-build    # build OpenShell sandbox base image
 make openshell-claude-build  # build Claude sandbox (includes openshell-base)
-make openshell-opencode-build # build OpenCode sandbox (includes openshell-base)
+make openshell-opencode-build # build OpenCode sandbox (builds on the agentic base image)
 make openshell-ci-build      # build OpenShell CI image
 make image-lint              # shellcheck + ruff on image scripts
 make image-test              # run image unit tests

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ openshell-claude-build: openshell-base-build ## Build the OpenShell Claude sandb
 	podman build -t localhost/claude-sandbox:latest -f images/runner/claude-code/Containerfile.openshell .
 
 .PHONY: openshell-opencode-build
-openshell-opencode-build: openshell-base-build ## Build the OpenShell OpenCode sandbox image locally
+openshell-opencode-build: ## Build the OpenShell OpenCode sandbox image locally (builds on the agentic base image, not openshell-base)
 	podman build -t localhost/opencode-sandbox:latest -f images/runner/opencode/Containerfile.openshell .
 
 .PHONY: openshell-ci-build

--- a/docs/image/build.md
+++ b/docs/image/build.md
@@ -20,7 +20,7 @@ schedule triggers builds. Images are tagged with:
 | `claude-runner` | `images/runner/claude-code/Containerfile` | Claude Code runner |
 | `opencode-runner` | `images/runner/opencode/Containerfile` | OpenCode runner |
 | `claude-sandbox` | `images/runner/claude-code/Containerfile.openshell` | Claude Code sandbox |
-| `opencode-sandbox` | `images/runner/opencode/Containerfile.openshell` | OpenCode sandbox |
+| `opencode-sandbox` | `images/runner/opencode/Containerfile.openshell` | OpenCode sandbox (builds on the agentic base image `quay.io/aipcc/base-images/agentic/opencode`, not `openshell-base`) |
 
 ## Local builds
 
@@ -30,7 +30,7 @@ make openshell-ci-build        # openshell CI image
 make base-build                # runner base
 make claude-build              # claude-runner (depends on base-build)
 make opencode-build            # opencode-runner (depends on base-build)
-make openshell-base-build      # sandbox base
-make openshell-claude-build    # claude-sandbox
-make openshell-opencode-build  # opencode-sandbox
+make openshell-base-build      # sandbox base (used by claude-sandbox)
+make openshell-claude-build    # claude-sandbox (depends on openshell-base-build)
+make openshell-opencode-build  # opencode-sandbox (builds on the agentic base image)
 ```

--- a/images/runner/opencode/Containerfile.openshell
+++ b/images/runner/opencode/Containerfile.openshell
@@ -3,34 +3,122 @@
 # Use with: agentic-ci run --backend openshell --image <this-image> ...
 # Or:       openshell sandbox create --from <this-image> --provider ...
 #
+# Builds on the agentic base image
+# (quay.io/aipcc/base-images/agentic/opencode), which provides OpenCode (a real
+# binary at /usr/local/bin/opencode) and Node on UBI9 with the /sandbox layout,
+# the sandbox user with a non-root primary group, and iproute for OpenShell's
+# netns setup. This Containerfile layers the agentic-ci tooling (Python, uv,
+# forge CLIs, agentic-ci) on top. The base image is pinned by digest (Renovate
+# keeps it current).
+#
+# Requires a base image with the AIPCC-29106 fixes (non-root sandbox primary
+# group, iproute, and /usr/local/bin/opencode as a real binary rather than a
+# symlink into node_modules). The digest below must point at that version or
+# later.
+#
 # Build:
-#   podman build -t openshell-base -f images/runner/shared/Containerfile.openshell-base .
 #   podman build -t openshell-opencode -f images/runner/opencode/Containerfile.openshell .
+#
+# x86_64 only.
 
-FROM localhost/openshell-base:latest
+ARG OPENCODE_BASE_IMAGE=quay.io/aipcc/base-images/agentic/opencode:latest@sha256:8a10661d7592e592f0954bda274e7f24096fbfcf73036656d3246135f88d5d73
+FROM ${OPENCODE_BASE_IMAGE}
 
-ARG OPENCODE_VERSION=1.18.8
-ARG OPENCODE_SHA256=b72014b8b53427fdb5a628d2433569ee7ccd289bd5c4490636064b24791c1305
+ARG UV_VERSION=0.11.32
+ARG UV_SHA256=1fd052f196108d87e61fc3d98fe06b4ec758c9a1eb1466a6fd1a436fe45885f2
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+
+ARG GH_VERSION=2.96.0
+ARG GH_SHA256=83d5c2ccad5498f58bf6368acb1ab32588cf43ab3a4b1c301bf36328b1c8bd60
+
+ARG GLAB_VERSION=1.110.0
+ARG GLAB_SHA256=978485e47c90b5c7d33638944838f28ddc5cb6833f01c9a0a80011a27d2766e3
 
 USER root
 
-RUN curl -fsSL -o /tmp/opencode.tar.gz \
-        "https://github.com/anomalyco/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
-    && echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum -c - \
-    && tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin \
-    && chmod +x /usr/local/bin/opencode \
-    && rm -f /tmp/opencode.tar.gz
+# System packages the base image doesn't provide. The base already ships
+# git, node, tar, curl, gzip, findutils, shadow-utils and iproute.
+RUN microdnf install -y --nodocs \
+        python3.12 \
+        python3.12-pip \
+        jq \
+        make \
+        which \
+        xz \
+    && microdnf clean all
 
-COPY images/runner/opencode/opencode.json /sandbox/.config/opencode/opencode.json
-RUN chown -R sandbox:sandbox /sandbox/.config
+# UBI9 defaults python3 to 3.9; agentic-ci needs 3.10+, so make 3.12 the
+# default python3/python via /usr/local/bin (ahead of /usr/bin on PATH).
+RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
 
+# uv (pinned)
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+# GitHub CLI (pinned)
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+# GitLab CLI (pinned)
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# ShellCheck (pinned)
+RUN curl -fsSL -o /tmp/shellcheck.tar.xz \
+        "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    && echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/shellcheck.tar.xz -C /tmp \
+    && mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck \
+    && chmod +x /usr/local/bin/shellcheck \
+    && rm -rf /tmp/shellcheck.tar.xz /tmp/shellcheck-v${SHELLCHECK_VERSION}
+
+COPY images/runner/shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY pyproject.toml README.md /tmp/agentic-ci/
+COPY src/ /tmp/agentic-ci/src/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && uv pip install --system --python python3.12 --no-cache /tmp/agentic-ci ruff==0.16.0 \
+    && rm -rf /tmp/agentic-ci \
+    && install -d -m 755 -o sandbox -g sandbox /usr/local/share/agentic-ci
+
+# Sandbox home directories. The base image provides the sandbox user
+# (uid 1001, now with the dedicated sandbox group) and /sandbox home;
+# create the dirs agentic-ci and OpenCode expect.
 USER sandbox
+RUN mkdir -p /sandbox/.local/bin /sandbox/.config/opencode /sandbox/.claude /sandbox/.agents
+COPY --chown=sandbox:sandbox images/runner/shared/AGENTS.openshell.md /sandbox/AGENTS.md
+COPY --chown=sandbox:sandbox images/runner/opencode/opencode.json /sandbox/.config/opencode/opencode.json
+RUN ln -s AGENTS.md /sandbox/CLAUDE.md \
+    && ln -s ../AGENTS.md /sandbox/.claude/CLAUDE.md
+ENV PATH="/sandbox/.local/bin:${PATH}"
+
+ENV AGENT_TOOL=opencode
+ENV OPENCODE_CONFIG_DIR=/sandbox/.config/opencode
+
+# Install skills from the skills-registry marketplace into OpenCode's
+# skills dir (OPENCODE_CONFIG_DIR/skills) and write the plugin manifest.
 RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registry.git /tmp/skills-registry \
     && agentic-ci install-plugins --harness opencode \
        --marketplace-json /tmp/skills-registry/.claude-plugin/marketplace.json \
     && rm -rf /tmp/skills-registry
 
-ENV AGENT_TOOL=opencode
-ENV OPENCODE_CONFIG_DIR=/sandbox/.config/opencode
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["opencode"]
+WORKDIR /sandbox

--- a/renovate.json
+++ b/renovate.json
@@ -28,6 +28,11 @@
       "matchDatasources": ["docker"],
       "matchPackagePrefixes": ["ubi10/"],
       "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/aipcc/base-images/agentic/opencode"],
+      "minimumReleaseAge": "0 days"
     }
   ],
   "customManagers": [
@@ -36,6 +41,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -49,7 +55,8 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$"
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ARG SHELLCHECK_VERSION=(?<currentValue>[^\\n]+)"],
       "depNameTemplate": "koalaman/shellcheck",
@@ -62,6 +69,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -76,6 +84,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -148,8 +157,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^images/runner/opencode/Containerfile$",
-        "^images/runner/opencode/Containerfile\\.openshell$"
+        "^images/runner/opencode/Containerfile$"
       ],
       "matchStrings": ["ARG OPENCODE_VERSION=(?<currentValue>[^\\n]+)"],
       "depNameTemplate": "anomalyco/opencode",
@@ -161,7 +169,8 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$"
+        "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ruff==(?<currentValue>[^\\s]+)"],
       "depNameTemplate": "ruff",
@@ -172,6 +181,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/shared/Containerfile\\.openshell-base$",
+        "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -188,6 +198,14 @@
       "datasourceTemplate": "docker",
       "registryUrlTemplate": "https://registry.access.redhat.com",
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/opencode/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG OPENCODE_BASE_IMAGE=(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
+      "datasourceTemplate": "docker"
     }
   ]
 }

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -110,7 +110,7 @@ def bump_uv(check_only):
 
     result = {"tool": "uv", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "UV_VERSION", version)
                 _update_arg(cf, "UV_SHA256", sha)
@@ -127,7 +127,7 @@ def bump_shellcheck(check_only):
 
     result = {"tool": "shellcheck", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "SHELLCHECK_VERSION", version)
                 _update_arg(cf, "SHELLCHECK_SHA256", sha)
@@ -141,7 +141,7 @@ def bump_gh(check_only):
 
     result = {"tool": "gh", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "GH_VERSION", version)
                 _update_arg(cf, "GH_SHA256", sha)
@@ -161,7 +161,7 @@ def bump_glab(check_only):
 
     result = {"tool": "glab", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "GLAB_VERSION", version)
                 _update_arg(cf, "GLAB_SHA256", sha)
@@ -219,7 +219,7 @@ def bump_opencode(check_only):
 
     result = {"tool": "opencode", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [OPENCODE_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "OPENCODE_VERSION", version)
                 _update_arg(cf, "OPENCODE_SHA256", sha)
@@ -322,7 +322,7 @@ def bump_ruff(check_only):
 
     result = {"tool": "ruff", "version": version}
     if not check_only:
-        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 text = cf.read_text()
                 text = re.sub(r"ruff==[\d.]+", f"ruff=={version}", text)
@@ -337,7 +337,7 @@ def bump_agentic_ci(check_only):
     result = {"tool": "agentic-ci", "version": version}
     if not check_only:
         # CI images install from local source; only bump runner base images.
-        for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
             if not cf.exists():
                 continue
             text = cf.read_text()
@@ -374,7 +374,7 @@ def _current_value(path, arg_name):
 
 def sync_uv():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "UV_VERSION")
@@ -396,7 +396,7 @@ def sync_uv():
 
 def sync_shellcheck():
     versions = {}
-    for cf in [BASE_CF, OPENSHELL_BASE_CF]:
+    for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "SHELLCHECK_VERSION")
@@ -417,7 +417,7 @@ def sync_shellcheck():
 
 def sync_gh():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "GH_VERSION")
@@ -438,7 +438,7 @@ def sync_gh():
 
 def sync_glab():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "GLAB_VERSION")
@@ -521,7 +521,7 @@ def sync_claude():
 
 def sync_opencode():
     versions = {}
-    for cf in [OPENCODE_CF, OPENSHELL_OPENCODE_CF]:
+    for cf in [OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "OPENCODE_VERSION")


### PR DESCRIPTION
Migrate the OpenCode OpenShell sandbox image
(images/runner/opencode/Containerfile.openshell) to build FROM the Red Hat agentic OpenCode base image
(quay.io/aipcc/base-images/agentic/opencode, pinned by digest) instead of localhost/openshell-base. The base ships OpenCode (a real binary at /usr/local/bin/opencode) and Node on UBI9 with the /sandbox layout, a non-root sandbox primary group, and iproute; this Containerfile layers the agentic-ci tooling (Python, uv, forge CLIs, agentic-ci, skills) on top.

The Claude Code sandbox and the podman OpenCode runner are unchanged (there is no Claude base image, and the podman runner still downloads OpenCode from GitHub).

Supporting changes:
- Makefile: openshell-opencode-build no longer depends on openshell-base-build.
- CI: drop the openshell-base build step from the opencode-sandbox jobs.
- renovate.json: track the base image digest (docker datasource); move the opencode github-releases manager off Containerfile.openshell and add it to the uv/gh/glab/shellcheck/ruff/agentic-ci managers.
- scripts/bump-versions.py: adjust the per-tool Containerfile lists to match.
- Docs updated.

Requires a base image with the non-root sandbox primary group, iproute, and a real /usr/local/bin/opencode (AIPCC-29106); the pinned digest must point at that version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenShell’s OpenCode sandbox now includes pinned developer tooling such as Python, package management, GitHub and GitLab CLIs, ShellCheck, Ruff, and agentic-ci.
  * The sandbox provides updated configuration, shared instructions, and workspace setup for a more consistent development environment.

* **Documentation**
  * Updated image-building documentation and local build instructions to reflect the new sandbox image setup.

* **Chores**
  * Improved automated version and security update tracking for the sandbox image and included tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->