### PR TITLE
feat(forge): add GitLab/GitHub helpers to check, create, and attach MR labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ pipelines:
 
 - **`agentic_ci.jira`** — Jira REST API client with `acli` delegation,
   ADF (Atlassian Document Format) conversion, and rate limiting.
+- **`agentic_ci.forge`** — GitHub/GitLab MR/PR helpers (status, comments,
+  labels: exists / create / attach) plus `agentic-ci forge` CLI.
 - **`agentic_ci.git`** — Git operations (clone, branch, push, diff,
   commit info extraction) with security hardening.
 - **`agentic_ci.pipeline`** — GitLab child pipeline YAML generation

--- a/src/agentic_ci/forge/__init__.py
+++ b/src/agentic_ci/forge/__init__.py
@@ -10,6 +10,13 @@ Usage::
 
     forge = Forge.detect("https://gitlab.com/org/repo/-/merge_requests/42")
     status = forge.mr_status("https://gitlab.com/org/repo/-/merge_requests/42")
+
+Label helpers (callers choose names and create-vs-attach policy)::
+
+    forge = Forge.detect(repo_url)
+    if not forge.label_exists(repo_url, "autofix"):
+        forge.create_label(repo_url, "autofix")
+    forge.add_mr_labels(mr_url, ["autofix"])
 """
 
 from __future__ import annotations
@@ -17,6 +24,9 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from urllib.parse import urlparse
+
+# Default hex color for newly created labels (no leading '#').
+DEFAULT_LABEL_COLOR = "808080"
 
 
 class ForgeError(Exception):
@@ -121,6 +131,45 @@ class Forge(ABC):
 
         Only the provided keyword arguments are updated; omitted fields
         are left unchanged.
+
+        Raises ``ForgeError`` on API failure.
+        """
+
+    @abstractmethod
+    def label_exists(self, repo_url: str, label: str) -> bool:
+        """Return whether ``label`` exists on the repository/project.
+
+        Does not create the label. Returns ``False`` when the label is
+        missing (including HTTP 404). Raises ``ForgeError`` on other
+        API failures.
+        """
+
+    @abstractmethod
+    def create_label(
+        self,
+        repo_url: str,
+        label: str,
+        *,
+        color: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        """Create a repository/project label.
+
+        Callers must opt in explicitly; attaching labels does not
+        implicitly create them via this API. When ``color`` is omitted,
+        ``DEFAULT_LABEL_COLOR`` is used.
+
+        Raises ``ForgeError`` on API failure (including if the label
+        already exists).
+        """
+
+    @abstractmethod
+    def add_mr_labels(self, mr_url: str, labels: list[str]) -> None:
+        """Attach labels to an existing MR/PR, preserving current labels.
+
+        No-op when ``labels`` is empty. Does not check whether labels
+        exist on the repository first — callers that need that policy
+        should use :meth:`label_exists` / :meth:`create_label`.
 
         Raises ``ForgeError`` on API failure.
         """

--- a/src/agentic_ci/forge/cli.py
+++ b/src/agentic_ci/forge/cli.py
@@ -11,6 +11,9 @@ Usage::
     agentic-ci forge mr-resolve <URL> <thread_id>
     agentic-ci forge pipeline-failures <URL>
     agentic-ci forge mr-diff-position <URL>
+    agentic-ci forge label-exists <REPO_URL> <label>
+    agentic-ci forge label-create <REPO_URL> <label> [--color HEX] [--description TEXT]
+    agentic-ci forge mr-add-labels <URL> --labels LABEL [LABEL ...]
     agentic-ci forge github-token --app-id ID --installation-id ID --private-key PEM
 """
 
@@ -77,6 +80,33 @@ def cmd_mr_update(args: argparse.Namespace) -> None:
     forge = Forge.detect(args.url, github_token=args.token)
     forge.update_description(args.url, title=args.title, description=args.description)
     print(f"Updated {args.url}")
+
+
+def cmd_label_exists(args: argparse.Namespace) -> None:
+    """Check whether a repository/project label exists."""
+    forge = Forge.detect(args.url, github_token=args.token)
+    exists = forge.label_exists(args.url, args.label)
+    json.dump(exists, sys.stdout)
+    print()
+
+
+def cmd_label_create(args: argparse.Namespace) -> None:
+    """Create a repository/project label."""
+    forge = Forge.detect(args.url, github_token=args.token)
+    forge.create_label(
+        args.url,
+        args.label,
+        color=args.color,
+        description=args.description,
+    )
+    print(f"Created label {args.label!r} on {args.url}")
+
+
+def cmd_mr_add_labels(args: argparse.Namespace) -> None:
+    """Attach labels to an existing MR/PR."""
+    forge = Forge.detect(args.url, github_token=args.token)
+    forge.add_mr_labels(args.url, args.labels)
+    print(f"Added labels {args.labels} to {args.url}")
 
 
 def cmd_mr_diff_position(args: argparse.Namespace) -> None:
@@ -158,6 +188,33 @@ def register_subcommands(forge_parser: argparse.ArgumentParser) -> None:
     p_update.add_argument("--title", help="New title")
     p_update.add_argument("--description", help="New description")
     p_update.set_defaults(func=cmd_mr_update)
+
+    p_label_exists = subparsers.add_parser(
+        "label-exists", help="Check whether a repository/project label exists"
+    )
+    p_label_exists.add_argument("url", help="Repository URL")
+    p_label_exists.add_argument("label", help="Label name")
+    p_label_exists.set_defaults(func=cmd_label_exists)
+
+    p_label_create = subparsers.add_parser("label-create", help="Create a repository/project label")
+    p_label_create.add_argument("url", help="Repository URL")
+    p_label_create.add_argument("label", help="Label name")
+    p_label_create.add_argument(
+        "--color",
+        help="Label color as hex (with or without leading #); default 808080",
+    )
+    p_label_create.add_argument("--description", help="Label description")
+    p_label_create.set_defaults(func=cmd_label_create)
+
+    p_add_labels = subparsers.add_parser("mr-add-labels", help="Attach labels to an existing MR/PR")
+    p_add_labels.add_argument("url", help="MR/PR URL")
+    p_add_labels.add_argument(
+        "--labels",
+        nargs="+",
+        required=True,
+        help="One or more label names to attach",
+    )
+    p_add_labels.set_defaults(func=cmd_mr_add_labels)
 
     p_diffpos = subparsers.add_parser(
         "mr-diff-position",

--- a/src/agentic_ci/forge/github.py
+++ b/src/agentic_ci/forge/github.py
@@ -11,12 +11,14 @@ import logging
 import os
 import re
 import time
+import urllib.parse
 from datetime import datetime
 from pathlib import Path
 
 import requests
 
 from agentic_ci.forge import (
+    DEFAULT_LABEL_COLOR,
     DEFAULT_SKIP_PATTERNS,
     Forge,
     ForgeError,
@@ -131,6 +133,53 @@ class GitHubForge(Forge):
         if resp.status_code != 200:
             error = extract_api_error(resp)
             raise ForgeError(f"HTTP {resp.status_code} updating PR: {error}")
+
+    def label_exists(self, repo_url: str, label: str) -> bool:
+        repo_path = repo_path_from_url(repo_url)
+        enc = urllib.parse.quote(label, safe="")
+        resp = self._session.get(f"https://api.github.com/repos/{repo_path}/labels/{enc}")
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 404:
+            return False
+        error = extract_api_error(resp)
+        raise ForgeError(f"HTTP {resp.status_code} checking label {label!r}: {error}")
+
+    def create_label(
+        self,
+        repo_url: str,
+        label: str,
+        *,
+        color: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        repo_path = repo_path_from_url(repo_url)
+        hex_color = (color or DEFAULT_LABEL_COLOR).lstrip("#")
+        payload: dict[str, str] = {
+            "name": label,
+            "color": hex_color,
+        }
+        if description is not None:
+            payload["description"] = description
+        resp = self._session.post(
+            f"https://api.github.com/repos/{repo_path}/labels",
+            json=payload,
+        )
+        if resp.status_code not in (200, 201):
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} creating label {label!r}: {error}")
+
+    def add_mr_labels(self, mr_url: str, labels: list[str]) -> None:
+        if not labels:
+            return
+        repo_path, pr_number = parse_github_pr_url(mr_url)
+        resp = self._session.post(
+            f"https://api.github.com/repos/{repo_path}/issues/{pr_number}/labels",
+            json={"labels": labels},
+        )
+        if resp.status_code not in (200, 201):
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} adding PR labels: {error}")
 
     def review_comments(self, mr_url: str) -> list[dict]:
         repo_path, pr_number = parse_github_pr_url(mr_url)

--- a/src/agentic_ci/forge/gitlab.py
+++ b/src/agentic_ci/forge/gitlab.py
@@ -12,6 +12,7 @@ import urllib.parse
 from datetime import datetime
 
 from agentic_ci.forge import (
+    DEFAULT_LABEL_COLOR,
     DEFAULT_SKIP_PATTERNS,
     Forge,
     ForgeError,
@@ -153,6 +154,56 @@ class GitLabForge(Forge):
         if resp.status_code != 200:
             error = extract_api_error(resp)
             raise ForgeError(f"HTTP {resp.status_code} updating MR: {error}")
+
+    def label_exists(self, repo_url: str, label: str) -> bool:
+        project_path = repo_path_from_url(repo_url)
+        pid = self.project_id(project_path)
+        enc = urllib.parse.quote(label, safe="")
+        resp = self._session.get(f"https://gitlab.com/api/v4/projects/{pid}/labels/{enc}")
+        if resp.status_code == 200:
+            return True
+        if resp.status_code == 404:
+            return False
+        error = extract_api_error(resp)
+        raise ForgeError(f"HTTP {resp.status_code} checking label {label!r}: {error}")
+
+    def create_label(
+        self,
+        repo_url: str,
+        label: str,
+        *,
+        color: str | None = None,
+        description: str | None = None,
+    ) -> None:
+        project_path = repo_path_from_url(repo_url)
+        pid = self.project_id(project_path)
+        hex_color = (color or DEFAULT_LABEL_COLOR).lstrip("#")
+        payload: dict[str, str] = {
+            "name": label,
+            "color": f"#{hex_color}",
+        }
+        if description is not None:
+            payload["description"] = description
+        resp = self._session.post(
+            f"https://gitlab.com/api/v4/projects/{pid}/labels",
+            json=payload,
+        )
+        if resp.status_code not in (200, 201):
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} creating label {label!r}: {error}")
+
+    def add_mr_labels(self, mr_url: str, labels: list[str]) -> None:
+        if not labels:
+            return
+        project_path, mr_iid = parse_gitlab_mr_url(mr_url)
+        pid = self.project_id(project_path)
+        resp = self._session.put(
+            f"https://gitlab.com/api/v4/projects/{pid}/merge_requests/{mr_iid}",
+            json={"add_labels": ",".join(labels)},
+        )
+        if resp.status_code != 200:
+            error = extract_api_error(resp)
+            raise ForgeError(f"HTTP {resp.status_code} adding MR labels: {error}")
 
     def review_comments(self, mr_url: str) -> list[dict]:
         project_path, mr_iid = parse_gitlab_mr_url(mr_url)

--- a/tests/test_forge_cli.py
+++ b/tests/test_forge_cli.py
@@ -176,6 +176,61 @@ class TestGithubTokenCommand:
         assert output == "inst-tok"
 
 
+class TestLabelExistsCommand:
+    def test_dispatches_correctly(self, capsys):
+        mock_forge = MagicMock()
+        mock_forge.label_exists.return_value = True
+        with patch("agentic_ci.forge.cli.Forge.detect", return_value=mock_forge):
+            _run_forge_cli(["label-exists", "https://gitlab.com/o/r", "autofix"])
+
+        mock_forge.label_exists.assert_called_once_with("https://gitlab.com/o/r", "autofix")
+        assert json.loads(capsys.readouterr().out) is True
+
+
+class TestLabelCreateCommand:
+    def test_dispatches_with_optional_fields(self, capsys):
+        mock_forge = MagicMock()
+        with patch("agentic_ci.forge.cli.Forge.detect", return_value=mock_forge):
+            _run_forge_cli(
+                [
+                    "label-create",
+                    "https://github.com/o/r",
+                    "autofix",
+                    "--color",
+                    "#FFAABB",
+                    "--description",
+                    "Opened by autofix",
+                ]
+            )
+
+        mock_forge.create_label.assert_called_once_with(
+            "https://github.com/o/r",
+            "autofix",
+            color="#FFAABB",
+            description="Opened by autofix",
+        )
+
+
+class TestMrAddLabelsCommand:
+    def test_dispatches_correctly(self, capsys):
+        mock_forge = MagicMock()
+        with patch("agentic_ci.forge.cli.Forge.detect", return_value=mock_forge):
+            _run_forge_cli(
+                [
+                    "mr-add-labels",
+                    "https://gitlab.com/o/r/-/merge_requests/1",
+                    "--labels",
+                    "autofix",
+                    "package-onboarding",
+                ]
+            )
+
+        mock_forge.add_mr_labels.assert_called_once_with(
+            "https://gitlab.com/o/r/-/merge_requests/1",
+            ["autofix", "package-onboarding"],
+        )
+
+
 class TestMrUpdateCommand:
     def test_dispatches_with_description(self, capsys):
         mock_forge = MagicMock()

--- a/tests/test_forge_github.py
+++ b/tests/test_forge_github.py
@@ -126,6 +126,75 @@ class TestCreateMergeRequest:
         assert error is None
 
 
+class TestLabelExists:
+    def test_returns_true_when_found(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"name": "autofix"})
+        assert forge.label_exists("https://github.com/owner/repo", "autofix") is True
+        assert mock_session.get.call_args[0][0].endswith("/labels/autofix")
+
+    def test_url_encodes_slash_in_label_name(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"name": "security/critical"})
+        assert forge.label_exists("https://github.com/owner/repo", "security/critical") is True
+        assert mock_session.get.call_args[0][0].endswith("/labels/security%2Fcritical")
+
+    def test_returns_false_when_missing(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(404, text="Not Found")
+        assert forge.label_exists("https://github.com/owner/repo", "missing") is False
+
+    def test_raises_on_other_http_error(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(403, {"message": "Forbidden"}, "Forbidden")
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.label_exists("https://github.com/owner/repo", "autofix")
+
+
+class TestCreateLabel:
+    def test_creates_with_default_color(self, forge, mock_session):
+        mock_session.post.return_value = _make_response(201, {"name": "autofix"})
+        forge.create_label("https://github.com/owner/repo", "autofix")
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload == {"name": "autofix", "color": "808080"}
+
+    def test_strips_hash_from_color(self, forge, mock_session):
+        mock_session.post.return_value = _make_response(201, {"name": "autofix"})
+        forge.create_label(
+            "https://github.com/owner/repo",
+            "autofix",
+            color="#FFAABB",
+            description="Opened by autofix",
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload == {
+            "name": "autofix",
+            "color": "FFAABB",
+            "description": "Opened by autofix",
+        }
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.post.return_value = _make_response(
+            422, {"message": "Validation Failed"}, "error"
+        )
+        with pytest.raises(ForgeError, match="HTTP 422"):
+            forge.create_label("https://github.com/owner/repo", "autofix")
+
+
+class TestAddMrLabels:
+    def test_adds_labels(self, forge, mock_session):
+        mock_session.post.return_value = _make_response(200, [{"name": "autofix"}])
+        forge.add_mr_labels("https://github.com/owner/repo/pull/42", ["autofix"])
+        url = mock_session.post.call_args[0][0]
+        assert url.endswith("/issues/42/labels")
+        assert mock_session.post.call_args[1]["json"] == {"labels": ["autofix"]}
+
+    def test_noop_when_empty(self, forge, mock_session):
+        forge.add_mr_labels("https://github.com/owner/repo/pull/42", [])
+        mock_session.post.assert_not_called()
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.post.return_value = _make_response(403, {"message": "Forbidden"}, "Forbidden")
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.add_mr_labels("https://github.com/owner/repo/pull/42", ["autofix"])
+
+
 class TestUpdateMergeRequest:
     def test_updates_body(self, forge, mock_session):
         mock_session.patch.return_value = _make_response(200)

--- a/tests/test_forge_gitlab.py
+++ b/tests/test_forge_gitlab.py
@@ -155,6 +155,96 @@ class TestCreateMergeRequest:
         assert error is None
 
 
+class TestLabelExists:
+    def test_returns_true_when_found(self, forge, mock_session):
+        mock_session.get.side_effect = [
+            _make_response(200, {"id": 1}),
+            _make_response(200, {"name": "autofix"}),
+        ]
+        assert forge.label_exists("https://gitlab.com/org/repo", "autofix") is True
+
+    def test_url_encodes_slash_in_label_name(self, forge, mock_session):
+        mock_session.get.side_effect = [
+            _make_response(200, {"id": 1}),
+            _make_response(200, {"name": "security/critical"}),
+        ]
+        assert forge.label_exists("https://gitlab.com/org/repo", "security/critical") is True
+        assert mock_session.get.call_args_list[-1][0][0].endswith("/labels/security%2Fcritical")
+
+    def test_returns_false_when_missing(self, forge, mock_session):
+        mock_session.get.side_effect = [
+            _make_response(200, {"id": 1}),
+            _make_response(404, text="Not Found"),
+        ]
+        assert forge.label_exists("https://gitlab.com/org/repo", "missing") is False
+
+    def test_raises_on_other_http_error(self, forge, mock_session):
+        mock_session.get.side_effect = [
+            _make_response(200, {"id": 1}),
+            _make_response(403, {"message": "Forbidden"}, "Forbidden"),
+        ]
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.label_exists("https://gitlab.com/org/repo", "autofix")
+
+
+class TestCreateLabel:
+    def test_creates_with_default_color(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.post.return_value = _make_response(201, {"name": "autofix"})
+        forge.create_label("https://gitlab.com/org/repo", "autofix")
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload == {"name": "autofix", "color": "#808080"}
+
+    def test_creates_with_color_and_description(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.post.return_value = _make_response(201, {"name": "autofix"})
+        forge.create_label(
+            "https://gitlab.com/org/repo",
+            "autofix",
+            color="#FFAABB",
+            description="Opened by autofix",
+        )
+        payload = mock_session.post.call_args[1]["json"]
+        assert payload == {
+            "name": "autofix",
+            "color": "#FFAABB",
+            "description": "Opened by autofix",
+        }
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.post.return_value = _make_response(
+            400, {"message": "Label already exists"}, "error"
+        )
+        with pytest.raises(ForgeError, match="HTTP 400"):
+            forge.create_label("https://gitlab.com/org/repo", "autofix")
+
+
+class TestAddMrLabels:
+    def test_adds_labels(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(200)
+        forge.add_mr_labels(
+            "https://gitlab.com/org/repo/-/merge_requests/10",
+            ["package-onboarding", "autofix"],
+        )
+        call_kwargs = mock_session.put.call_args
+        assert call_kwargs[1]["json"] == {"add_labels": "package-onboarding,autofix"}
+
+    def test_noop_when_empty(self, forge, mock_session):
+        forge.add_mr_labels("https://gitlab.com/org/repo/-/merge_requests/10", [])
+        mock_session.put.assert_not_called()
+
+    def test_raises_on_failure(self, forge, mock_session):
+        mock_session.get.return_value = _make_response(200, {"id": 1})
+        mock_session.put.return_value = _make_response(403, {"message": "Forbidden"}, "Forbidden")
+        with pytest.raises(ForgeError, match="HTTP 403"):
+            forge.add_mr_labels(
+                "https://gitlab.com/org/repo/-/merge_requests/10",
+                ["autofix"],
+            )
+
+
 class TestUpdateMergeRequest:
     def test_updates_description(self, forge, mock_session):
         mock_session.get.return_value = _make_response(200, {"id": 1})


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add label_exists, create_label, and add_mr_labels on the forge API and CLI so pipelines can tag MRs/PRs without reimplementing forge HTTP calls. Callers choose label names, colors, and whether to create or only attach. 
Document the module under Additional Modules in the README.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added commands to check whether repository or project labels exist.
  - Added support for creating labels with optional colors and descriptions.
  - Added commands to apply one or more labels to pull requests and merge requests.
  - Supports both GitHub and GitLab workflows with clear confirmation or JSON output.
  - Handles default label colors and safely ignores empty label lists.

- **Documentation**
  - Updated the README with the forge module and command-line capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->