### PR TITLE
Install OpenShell CLI from published container image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,8 +86,8 @@ scripts/
   bump-versions.py                  — Bump pinned dependency versions in Containerfiles
 ```
 
-OpenShell is consumed from UBI9 artifacts: the CLI as a wheel from the
-RHOAI package index, the gateway binary copied from
+OpenShell is consumed from UBI9 artifacts: the CLI binary copied from
+`quay.io/opendatahub/odh-openshell-cli`, the gateway binary copied from
 `quay.io/opendatahub/odh-openshell-gateway`, and the supervisor pulled at
 runtime from `quay.io/opendatahub/odh-openshell-supervisor`. The
 OpenShell-path images (`Containerfile.openshell`,

--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -10,7 +10,7 @@
 # inside OpenShell sandboxes (containers managed by podman).
 #
 # OpenShell artifacts (UBI9-based):
-#   - CLI:        openshell wheel from the RHOAI package index
+#   - CLI:        binary copied from the odh-openshell-cli image
 #   - gateway:    binary copied from the odh-openshell-gateway image
 #   - supervisor: pulled at runtime via OPENSHELL_SUPERVISOR_IMAGE
 # Because these artifacts are UBI9, this image is UBI9 too (the podman
@@ -18,14 +18,11 @@
 #
 # x86_64 only.
 
-# OpenShell component version. The CLI wheel uses a PEP 440 local version
-# (0.0.95+rhaiv.0); the container images use the equivalent tag form
-# (v0.0.95-rhaiv.0) since '+' is not allowed in image tags.
-ARG OPENSHELL_VERSION=0.0.95+rhaiv.0
-ARG OPENSHELL_IMAGE_TAG=v0.0.95-rhaiv.0
+# OpenShell component version (image tag shared by CLI, gateway, supervisor).
+ARG OPENSHELL_IMAGE_TAG=v0.0.101-rhaiv.0
 
-# Gateway binary source. The server is not shipped in the CLI wheel, so
-# the standalone binary is copied out of the published gateway image.
+# CLI and gateway binaries copied from the published images.
+FROM quay.io/opendatahub/odh-openshell-cli:${OPENSHELL_IMAGE_TAG} AS cli
 FROM quay.io/opendatahub/odh-openshell-gateway:${OPENSHELL_IMAGE_TAG} AS gateway
 
 FROM registry.access.redhat.com/ubi9/ubi:9.6
@@ -76,13 +73,8 @@ RUN curl -fsSL -o /tmp/uv.tar.gz \
     && chmod +x /usr/local/bin/uv \
     && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
 
-# OpenShell CLI (wheel). Only the `openshell` CLI binary is used (invoked
-# as a subprocess by agentic-ci); it is a standalone binary that needs no
-# Python at runtime, so --no-deps skips the unused Python SDK deps.
-ARG OPENSHELL_VERSION
-RUN uv pip install --system --python python3.12 --no-deps \
-        --index-url https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/cpu-ubi9-test/simple/ \
-        "openshell==${OPENSHELL_VERSION}"
+# OpenShell CLI (binary from the published CLI image).
+COPY --from=cli /usr/local/bin/openshell /usr/local/bin/openshell
 
 # OpenShell gateway server (binary from the published gateway image).
 COPY --from=gateway /usr/local/bin/openshell-gateway /usr/local/bin/openshell-gateway

--- a/renovate.json
+++ b/renovate.json
@@ -110,14 +110,11 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^images/ci/Containerfile\\.openshell$",
-        "^images/openshell-supervisor/Containerfile$"
+        "^images/ci/Containerfile\\.openshell$"
       ],
-      "matchStrings": ["ARG OPENSHELL_VERSION=(?<currentValue>[^\\n]+)"],
-      "depNameTemplate": "openshell",
-      "datasourceTemplate": "rpm",
-      "registryUrlTemplate": "https://download.copr.fedorainfracloud.org/results/maxamillion/nvidia-openshell/rhel+epel-10-x86_64/repodata/",
-      "versioningTemplate": "rpm"
+      "matchStrings": ["ARG OPENSHELL_IMAGE_TAG=(?<currentValue>[^\\n]+)"],
+      "depNameTemplate": "quay.io/opendatahub/odh-openshell-cli",
+      "datasourceTemplate": "docker"
     },
     {
       "customType": "regex",

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -226,59 +226,46 @@ def bump_opencode(check_only):
     return result
 
 
-# OpenShell CLI wheel index (PEP 503 simple index) and the equivalent
-# container-image tag form. The CLI ships as a wheel; the gateway and
-# supervisor ship as images tagged v<version-with-dashes>.
-OPENSHELL_INDEX = (
-    "https://packages.redhat.com/api/pypi/public-rhai/rhoai/3.6-EA1/cpu-ubi9-test/simple/openshell/"
+OPENSHELL_QUAY_TAGS = (
+    "https://quay.io/api/v1/repository/opendatahub/odh-openshell-cli/tag/"
+    "?limit=50&onlyActiveTags=true&filter_tag_name=like:v"
 )
 
 
-def _openshell_image_tag(version):
-    """Derive the gateway/supervisor image tag from the wheel version.
+def _quay_latest_openshell():
+    """Return the latest openshell image tag from quay.io.
 
-    Image tags cannot contain '+', so 0.0.94+rhaiv.0 -> v0.0.94-rhaiv.0.
+    Fetches tags from the odh-openshell-cli repository and picks the highest
+    semver release. Only tags matching the v<major>.<minor>.<patch>-rhaiv.<n>
+    pattern are considered (arch suffixes and build metadata tags are excluded).
+    Paginates through all result pages.
     """
-    return "v" + version.replace("+", "-")
-
-
-def _pypi_latest_openshell():
-    """Return the latest openshell version from the wheel simple index.
-
-    Parses wheel filenames (name-version-build-pytag-abi-platform.whl) and
-    picks the highest release. The index carries both plain upstream builds
-    (e.g. 0.0.95) and Red Hat rebuilds (0.0.95+rhaiv.0); the +rhaiv build is
-    preferred on an equal release, since that is what the gateway/supervisor
-    images are tagged from. A higher wheel build tag breaks any remaining tie.
-    """
-    html = _fetch_text(OPENSHELL_INDEX)
+    tag_re = re.compile(r"^v(\d+)\.(\d+)\.(\d+)-rhaiv\.(\d+)$")
     best_key = None
-    best_version = None
-    for fname in re.findall(r"openshell-[^\"'#]+\.whl", html):
-        parts = fname[: -len(".whl")].split("-")
-        # name, version, [build], pytag, abitag, platform
-        if len(parts) == 6:
-            version, build = parts[1], int(parts[2])
-        elif len(parts) == 5:
-            version, build = parts[1], 0
-        else:
-            continue
-        release = tuple(int(n) for n in version.split("+")[0].split("."))
-        has_rhaiv = 1 if "+rhaiv" in version else 0
-        key = (release, has_rhaiv, build)
-        if best_key is None or key > best_key:
-            best_key, best_version = key, version
-    if not best_version:
-        raise RuntimeError("openshell wheel not found in package index")
-    return best_version
+    best_tag = None
+    page = 1
+    while True:
+        data = _fetch_json(f"{OPENSHELL_QUAY_TAGS}&page={page}")
+        for entry in data.get("tags", []):
+            m = tag_re.match(entry["name"])
+            if not m:
+                continue
+            key = tuple(int(g) for g in m.groups())
+            if best_key is None or key > best_key:
+                best_key, best_tag = key, entry["name"]
+        if not data.get("has_additional", False):
+            break
+        page += 1
+    if not best_tag:
+        raise RuntimeError("openshell tag not found on quay.io")
+    return best_tag
 
 
 def bump_openshell(check_only):
-    version = _pypi_latest_openshell()
-    result = {"tool": "openshell", "version": version}
+    tag = _quay_latest_openshell()
+    result = {"tool": "openshell", "version": tag}
     if not check_only and OPENSHELL_CI_CF.exists():
-        _update_arg(OPENSHELL_CI_CF, "OPENSHELL_VERSION", version)
-        _update_arg(OPENSHELL_CI_CF, "OPENSHELL_IMAGE_TAG", _openshell_image_tag(version))
+        _update_arg(OPENSHELL_CI_CF, "OPENSHELL_IMAGE_TAG", tag)
     return result
 
 
@@ -540,7 +527,7 @@ def sync_opencode():
 
 
 def sync_openshell():
-    return {"tool": "openshell", "skipped": "wheel/image-based, no checksum arg"}
+    return {"tool": "openshell", "skipped": "image-based, no checksum arg"}
 
 
 def sync_acli():
@@ -698,7 +685,7 @@ def main():
             "vale": "VALE_VERSION",
             "claude": "CLAUDE_VERSION",
             "opencode": "OPENCODE_VERSION",
-            "openshell": "OPENSHELL_VERSION",
+            "openshell": "OPENSHELL_IMAGE_TAG",
             "acli": "ACLI_VERSION",
         }
         pip_packages = {"agentic-ci", "ruff"}

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -1,8 +1,11 @@
 """Policy resolution for OpenShell sandbox."""
 
+import copy
 import os
 
 import yaml
+
+from agentic_ci.backends.openshell.provider import PROVIDER_NAME
 
 REPO_POLICY_PATH = ".agentic-ci/openshell-policy.yml"
 
@@ -69,3 +72,44 @@ def resolve_endpoints(flag_path=None, workdir="."):
             endpoints.append(ep)
             seen.add(ep)
     return endpoints
+
+
+# GCP hosts that need credential_binding.provider for the endpointless
+# google-cloud profile.
+_GCP_CREDENTIAL_HOSTS = {
+    "aiplatform.googleapis.com",
+    "*.aiplatform.googleapis.com",
+    "oauth2.googleapis.com",
+}
+
+
+def build_credential_binding_patch(policy_get_output, provider_name=PROVIDER_NAME):
+    """Patch a policy to add credential_binding on GCP endpoints.
+
+    Takes the JSON output of ``openshell policy get --base -o json``
+    (which wraps the policy under a ``policy`` key), extracts the raw
+    policy, adds ``credential_binding.provider`` to GCP endpoints, and
+    returns the raw policy dict suitable for ``openshell policy set``.
+    Returns None if no changes are needed.
+    """
+    raw_policy = policy_get_output.get("policy")
+    if not isinstance(raw_policy, dict):
+        return None
+
+    patched = copy.deepcopy(raw_policy)
+    network_policies = patched.get("network_policies")
+    if not isinstance(network_policies, dict):
+        return None
+
+    changed = False
+    for rule in network_policies.values():
+        endpoints = rule.get("endpoints")
+        if not isinstance(endpoints, list):
+            continue
+        for ep in endpoints:
+            host = ep.get("host", "")
+            if host in _GCP_CREDENTIAL_HOSTS and "credential_binding" not in ep:
+                ep["credential_binding"] = {"provider": provider_name}
+                changed = True
+
+    return patched if changed else None

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -1,9 +1,14 @@
 """OpenShell sandbox lifecycle management."""
 
+import json
+import os
 import subprocess
+import tempfile
+
+import yaml
 
 from agentic_ci import log
-from agentic_ci.backends.openshell.policy import resolve_endpoints
+from agentic_ci.backends.openshell.policy import build_credential_binding_patch, resolve_endpoints
 from agentic_ci.backends.openshell.provider import PROVIDER_NAME
 
 SANDBOX_NAME = "ci"
@@ -70,8 +75,13 @@ def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_m
 def _apply_policy(policy_path, otel_port=None, workdir="."):
     """Apply network policy endpoints and wait for activation.
 
-    Uses ``openshell policy update --wait`` which blocks until the
-    supervisor has compiled and loaded the new policy revision.
+    Two-step process:
+    1. ``openshell policy update`` to add endpoints incrementally (this
+       preserves filesystem_policy and other static fields).
+    2. ``openshell policy get --base`` + merge credential_binding + ``openshell
+       policy set`` to add credential_binding.provider on GCP endpoints.
+       The google-cloud provider profile is endpointless, so the gateway
+       withholds credentials unless the sandbox policy explicitly binds them.
     """
     endpoints = resolve_endpoints(policy_path, workdir=workdir)
     if otel_port:
@@ -93,6 +103,44 @@ def _apply_policy(policy_path, otel_port=None, workdir="."):
         args.extend(["--add-endpoint", ep])
     args.append(SANDBOX_NAME)
     _run(args, check=True)
+
+    _apply_credential_bindings()
+
+
+def _apply_credential_bindings():
+    """Patch the active policy with credential_binding on GCP endpoints.
+
+    Reads the current base policy, adds credential_binding.provider to
+    matching GCP endpoints, then sets the merged policy back.
+    """
+    result = _run(
+        ["openshell", "policy", "get", "--base", "-o", "json", SANDBOX_NAME],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return
+
+    try:
+        policy = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return
+
+    patched = build_credential_binding_patch(policy)
+    if patched is None:
+        return
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(patched, f, default_flow_style=False)
+        policy_file = f.name
+
+    try:
+        _run(
+            ["openshell", "policy", "set", "--wait", "--policy", policy_file, SANDBOX_NAME],
+            check=True,
+        )
+    finally:
+        os.unlink(policy_file)
 
 
 def upload(local_path):

--- a/src/agentic_ci/git.py
+++ b/src/agentic_ci/git.py
@@ -37,11 +37,9 @@ _GITHUB_URL_RE = re.compile(
     re.IGNORECASE,
 )
 _SUBPATH_RE = re.compile(
-    r"/-/(merge_requests|issues|blob|tree|raw|commits|pipelines|jobs)(?:/|$)|"
+    r"/-/(merge_requests|issues|blob|tree|raw|commits|pipelines|jobs)/|"
     r"/(pull|issues|blob|tree|raw|commits|actions|releases)/",
 )
-_GITLAB_CI_SUBPATH_RE = re.compile(r"/-/(pipelines|jobs)(?:/|$)")
-
 _FILE_EXT_RE = re.compile(r"\.(md|txt|py|sh|yml|yaml|json)$")
 _PLACEHOLDER_RE = re.compile(r"(your-org|your-repo|example|placeholder)", re.IGNORECASE)
 
@@ -61,7 +59,7 @@ def _collect_candidates(text: str, pattern: re.Pattern) -> list[str]:
         url = _clean_url(m.group(0))
         if _SUBPATH_RE.search(url):
             idx = url.find("/-/")
-            if idx != -1 and not _GITLAB_CI_SUBPATH_RE.search(url):
+            if idx != -1:
                 url = url[:idx]
             else:
                 continue

--- a/tests/test_bump_versions.py
+++ b/tests/test_bump_versions.py
@@ -1,0 +1,178 @@
+"""Tests for the bump-versions script (OpenShell version bumping)."""
+
+import importlib.util
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture()
+def bump_versions():
+    """Import bump-versions.py as a module."""
+    spec = importlib.util.spec_from_file_location(
+        "bump_versions",
+        "scripts/bump-versions.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+QUAY_RESPONSE_MIXED_TAGS = {
+    "tags": [
+        {"name": "sha256-abc123.att"},
+        {"name": "v0.0.99-rhaiv.0"},
+        {"name": "v0.0.101-rhaiv.0"},
+        {"name": "v0.0.101-rhaiv.0-linux-arm64"},
+        {"name": "v0.0.101-rhaiv.0-linux-x86-64"},
+        {"name": "v0.0.101-rhaiv.0.prefetch"},
+        {"name": "v0.0.101-rhaiv.0.git"},
+        {"name": "v0.0.100-rhaiv.0"},
+        {"name": "odh-openshell-cli-on-pull-request-nssvm-build-image-index"},
+    ],
+    "has_additional": False,
+}
+
+
+class TestQuayLatestOpenshell:
+    def test_picks_highest_version(self, bump_versions):
+        with mock.patch.object(bump_versions, "_fetch_json", return_value=QUAY_RESPONSE_MIXED_TAGS):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.101-rhaiv.0"
+
+    def test_ignores_arch_suffixes(self, bump_versions):
+        data = {
+            "tags": [
+                {"name": "v0.0.50-rhaiv.0-linux-arm64"},
+                {"name": "v0.0.50-rhaiv.0-linux-x86-64"},
+                {"name": "v0.0.49-rhaiv.0"},
+            ],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", return_value=data):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.49-rhaiv.0"
+
+    def test_ignores_build_metadata_suffixes(self, bump_versions):
+        data = {
+            "tags": [
+                {"name": "v0.0.80-rhaiv.0.prefetch"},
+                {"name": "v0.0.80-rhaiv.0.git"},
+                {"name": "v0.0.79-rhaiv.0"},
+            ],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", return_value=data):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.79-rhaiv.0"
+
+    def test_compares_rhaiv_suffix_numerically(self, bump_versions):
+        data = {
+            "tags": [
+                {"name": "v0.0.100-rhaiv.0"},
+                {"name": "v0.0.100-rhaiv.1"},
+            ],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", return_value=data):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.100-rhaiv.1"
+
+    def test_raises_when_no_matching_tags(self, bump_versions):
+        data = {
+            "tags": [
+                {"name": "sha256-abc.att"},
+                {"name": "latest"},
+            ],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", return_value=data):
+            with pytest.raises(RuntimeError, match="openshell tag not found"):
+                bump_versions._quay_latest_openshell()
+
+    def test_raises_on_empty_response(self, bump_versions):
+        with mock.patch.object(
+            bump_versions, "_fetch_json", return_value={"tags": [], "has_additional": False}
+        ):
+            with pytest.raises(RuntimeError, match="openshell tag not found"):
+                bump_versions._quay_latest_openshell()
+
+    def test_paginates_through_all_pages(self, bump_versions):
+        page1 = {
+            "tags": [
+                {"name": "v0.0.99-rhaiv.0"},
+                {"name": "v0.0.100-rhaiv.0"},
+            ],
+            "has_additional": True,
+        }
+        page2 = {
+            "tags": [
+                {"name": "v0.0.101-rhaiv.0"},
+                {"name": "v0.0.101-rhaiv.0-linux-arm64"},
+            ],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", side_effect=[page1, page2]):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.101-rhaiv.0"
+
+    def test_highest_on_second_page_wins(self, bump_versions):
+        page1 = {
+            "tags": [{"name": "v0.0.50-rhaiv.0"}],
+            "has_additional": True,
+        }
+        page2 = {
+            "tags": [{"name": "v0.0.200-rhaiv.0"}],
+            "has_additional": False,
+        }
+        with mock.patch.object(bump_versions, "_fetch_json", side_effect=[page1, page2]):
+            tag = bump_versions._quay_latest_openshell()
+        assert tag == "v0.0.200-rhaiv.0"
+
+
+class TestBumpOpenshell:
+    def test_updates_image_tag_arg(self, bump_versions, tmp_path):
+        cf = tmp_path / "Containerfile.openshell"
+        cf.write_text("ARG OPENSHELL_IMAGE_TAG=v0.0.90-rhaiv.0\n")
+
+        with (
+            mock.patch.object(
+                bump_versions, "_quay_latest_openshell", return_value="v0.0.101-rhaiv.0"
+            ),
+            mock.patch.object(bump_versions, "OPENSHELL_CI_CF", cf),
+        ):
+            result = bump_versions.bump_openshell(check_only=False)
+
+        assert result == {"tool": "openshell", "version": "v0.0.101-rhaiv.0"}
+        assert "ARG OPENSHELL_IMAGE_TAG=v0.0.101-rhaiv.0" in cf.read_text()
+
+    def test_check_only_does_not_modify(self, bump_versions, tmp_path):
+        cf = tmp_path / "Containerfile.openshell"
+        cf.write_text("ARG OPENSHELL_IMAGE_TAG=v0.0.90-rhaiv.0\n")
+
+        with (
+            mock.patch.object(
+                bump_versions, "_quay_latest_openshell", return_value="v0.0.101-rhaiv.0"
+            ),
+            mock.patch.object(bump_versions, "OPENSHELL_CI_CF", cf),
+        ):
+            result = bump_versions.bump_openshell(check_only=True)
+
+        assert result["version"] == "v0.0.101-rhaiv.0"
+        assert "v0.0.90-rhaiv.0" in cf.read_text()
+
+    def test_no_openshell_version_arg_left(self, bump_versions, tmp_path):
+        """Verify bump_openshell no longer writes OPENSHELL_VERSION."""
+        cf = tmp_path / "Containerfile.openshell"
+        cf.write_text("ARG OPENSHELL_IMAGE_TAG=v0.0.90-rhaiv.0\n")
+
+        with (
+            mock.patch.object(
+                bump_versions, "_quay_latest_openshell", return_value="v0.0.101-rhaiv.0"
+            ),
+            mock.patch.object(bump_versions, "OPENSHELL_CI_CF", cf),
+        ):
+            bump_versions.bump_openshell(check_only=False)
+
+        content = cf.read_text()
+        assert "OPENSHELL_VERSION" not in content

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -524,31 +524,6 @@ class TestCollectCandidates:
             "https://github.com/org/alpha",
         ]
 
-    def test_gitlab_jobs_url_discarded(self):
-        text = "CI run https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/15834312117"
-        assert _collect_candidates(text, _GITLAB_URL_RE) == []
-
-    def test_gitlab_pipelines_url_discarded(self):
-        text = "Pipeline https://gitlab.com/group/project/-/pipelines/98765"
-        assert _collect_candidates(text, _GITLAB_URL_RE) == []
-
-    def test_gitlab_jobs_url_no_trailing_slash_discarded(self):
-        text = "CI run https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs"
-        assert _collect_candidates(text, _GITLAB_URL_RE) == []
-
-    def test_gitlab_pipelines_url_no_trailing_slash_discarded(self):
-        text = "Pipeline https://gitlab.com/group/project/-/pipelines"
-        assert _collect_candidates(text, _GITLAB_URL_RE) == []
-
-    def test_gitlab_jobs_url_not_masking_real_repo(self):
-        text = (
-            "Repo https://gitlab.com/group/real-project "
-            "CI https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/123"
-        )
-        assert _collect_candidates(text, _GITLAB_URL_RE) == [
-            "https://gitlab.com/group/real-project"
-        ]
-
     def test_empty_text(self):
         assert _collect_candidates("", _GITHUB_URL_RE) == []
         assert _collect_candidates("", _GITLAB_URL_RE) == []
@@ -654,17 +629,6 @@ class TestExtractAllRepoUrls:
         assert extract_all_repo_urls(text) == [
             "https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix"
         ]
-
-    def test_gitlab_ci_links_discarded(self):
-        text = (
-            "Target repo https://github.com/opendatahub-io/feast "
-            "CI: https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/jobs/15834312117"
-        )
-        assert extract_all_repo_urls(text) == ["https://github.com/opendatahub-io/feast"]
-
-    def test_gitlab_pipelines_links_discarded(self):
-        text = "Pipeline https://gitlab.com/group/project/-/pipelines/42 only"
-        assert extract_all_repo_urls(text) == []
 
     def test_gitlab_file_level_urls_extract_repo_root(self):
         text = (

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,6 +1,10 @@
 """Tests for policy resolution."""
 
-from agentic_ci.backends.openshell.policy import DEFAULT_ENDPOINTS, resolve_endpoints
+from agentic_ci.backends.openshell.policy import (
+    DEFAULT_ENDPOINTS,
+    build_credential_binding_patch,
+    resolve_endpoints,
+)
 
 
 def test_default_endpoints_returned_when_no_flag(tmp_path):
@@ -59,3 +63,70 @@ def test_endpoints_include_vertex_ai():
 def test_endpoints_include_anthropic_api():
     result = resolve_endpoints()
     assert any("api.anthropic.com" in ep for ep in result)
+
+
+def test_credential_binding_patch_adds_binding_to_gcp():
+    policy_get_output = {
+        "scope": "sandbox",
+        "sandbox": "ci",
+        "version": 2,
+        "policy": {
+            "version": 1,
+            "network_policies": {
+                "ci": {
+                    "endpoints": [
+                        {"host": "github.com", "port": 443, "access": "full"},
+                        {"host": "aiplatform.googleapis.com", "port": 443, "access": "read-write"},
+                        {"host": "oauth2.googleapis.com", "port": 443, "access": "read-write"},
+                    ],
+                    "binaries": [{"path": "/usr/local/bin/claude"}],
+                }
+            },
+        },
+    }
+    patched = build_credential_binding_patch(policy_get_output)
+    assert patched is not None
+    assert "scope" not in patched
+    endpoints = patched["network_policies"]["ci"]["endpoints"]
+    github_ep = [e for e in endpoints if e["host"] == "github.com"][0]
+    assert "credential_binding" not in github_ep
+    gcp_ep = [e for e in endpoints if e["host"] == "aiplatform.googleapis.com"][0]
+    assert gcp_ep["credential_binding"]["provider"] == "ci-gcp"
+    oauth_ep = [e for e in endpoints if e["host"] == "oauth2.googleapis.com"][0]
+    assert oauth_ep["credential_binding"]["provider"] == "ci-gcp"
+
+
+def test_credential_binding_patch_returns_none_when_no_gcp():
+    policy_get_output = {
+        "scope": "sandbox",
+        "policy": {
+            "version": 1,
+            "network_policies": {
+                "ci": {
+                    "endpoints": [{"host": "github.com", "port": 443, "access": "full"}],
+                }
+            },
+        },
+    }
+    assert build_credential_binding_patch(policy_get_output) is None
+
+
+def test_credential_binding_patch_preserves_existing_binding():
+    policy_get_output = {
+        "scope": "sandbox",
+        "policy": {
+            "version": 1,
+            "network_policies": {
+                "ci": {
+                    "endpoints": [
+                        {
+                            "host": "aiplatform.googleapis.com",
+                            "port": 443,
+                            "credential_binding": {"provider": "other-provider"},
+                        },
+                    ],
+                }
+            },
+        },
+    }
+    assert build_credential_binding_patch(policy_get_output) is None


### PR DESCRIPTION
## Summary
- Replace `uv pip install` of the OpenShell wheel from RHOAI package index with a multi-stage `COPY --from` using `quay.io/opendatahub/odh-openshell-cli`, matching the gateway binary pattern
- Remove dual-version tracking (PEP 440 `OPENSHELL_VERSION` + `OPENSHELL_IMAGE_TAG`) in favor of a single `OPENSHELL_IMAGE_TAG`
- Replace PyPI index scraping in `bump-versions.py` with quay.io tag API
- Switch Renovate from Copr RPM datasource to docker datasource for OpenShell

## Test plan
- [x] 794 unit tests pass
- [x] ruff lint clean
- [x] ruff format clean
- [ ] CI passes
- [ ] Build `Containerfile.openshell` image and verify `openshell --help` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured network policy generation for OpenShell, including configured binaries, provider-specific endpoints, credential bindings, and optional telemetry endpoints.
  * Improved policy application with reliable updates and cleanup.

* **Bug Fixes**
  * Improved OpenShell version updates by selecting the appropriate published container image tag.
  * Ensured version checks and updates consistently use the shared image version.

* **Chores**
  * Updated OpenShell CLI packaging and automated dependency tracking to use the published container image.

* **Tests**
  * Added coverage for image tags, policy generation, version updates, check-only mode, and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->