### PR TITLE
feat: tee stream-json output to output_file for transcript extraction

### DIFF
--- a/src/agentic_ci/backend.py
+++ b/src/agentic_ci/backend.py
@@ -32,6 +32,7 @@ class Backend(ABC):
         self.image = image
         self.harness = harness
         self.verdict_path: Path | None = None
+        self.output_file: Path | None = None
 
     @abstractmethod
     def setup(self, otel_port: int | None = None):
@@ -77,18 +78,33 @@ class Backend(ABC):
 
         stream_complete = False
 
-        processor = None
-        if streaming:
-            processor = self.harness.create_stream_processor(pid=proc.pid)
-            for line in proc.stdout:
-                text = line.decode("utf-8", errors="replace")
-                if processor.process_line(text):
-                    stream_complete = True
-                    break
-        else:
-            for line in proc.stdout:
-                sys.stdout.buffer.write(line)
-                sys.stdout.buffer.flush()
+        out_fh = None
+        if self.output_file is not None:
+            self.output_file.parent.mkdir(parents=True, exist_ok=True)
+            out_fh = open(self.output_file, "w", encoding="utf-8")
+
+        try:
+            processor = None
+            if streaming:
+                processor = self.harness.create_stream_processor(pid=proc.pid)
+                for line in proc.stdout:
+                    text = line.decode("utf-8", errors="replace")
+                    if out_fh is not None:
+                        out_fh.write(text)
+                        out_fh.flush()
+                    if processor.process_line(text):
+                        stream_complete = True
+                        break
+            else:
+                for line in proc.stdout:
+                    if out_fh is not None:
+                        out_fh.write(line.decode("utf-8", errors="replace"))
+                        out_fh.flush()
+                    sys.stdout.buffer.write(line)
+                    sys.stdout.buffer.flush()
+        finally:
+            if out_fh is not None:
+                out_fh.close()
 
         if stream_complete:
             # Stream processor detected the run is done but the process is

--- a/src/agentic_ci/skill.py
+++ b/src/agentic_ci/skill.py
@@ -151,6 +151,7 @@ def _default_run_container(
     )
     if verdict_path is not None:
         backend.verdict_path = verdict_path
+    backend.output_file = output_file
 
     otel_proc = None
     otel_port = None

--- a/tests/test_completion_validator.py
+++ b/tests/test_completion_validator.py
@@ -161,6 +161,47 @@ class TestVerdictPathGuard:
         assert stream_complete is False
 
 
+class TestOutputFileTee:
+    """Verify _process_stream tees raw lines to output_file when set."""
+
+    def test_streaming_writes_raw_lines(self, tmp_path):
+        lines = ['{"type": "system"}\n', '{"type": "stream_event"}\n']
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.output_file = tmp_path / "out.jsonl"
+        proc = _make_proc(lines, returncode=0)
+        backend._process_stream(proc, streaming=True)
+        assert backend.output_file.read_text() == "".join(lines)
+
+    def test_non_streaming_writes_raw_lines(self, tmp_path):
+        lines = ['{"type": "system"}\n', '{"type": "stream_event"}\n']
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.output_file = tmp_path / "out.jsonl"
+        proc = _make_proc(lines, returncode=0)
+        backend._process_stream(proc, streaming=False)
+        assert backend.output_file.read_text() == "".join(lines)
+
+    def test_no_output_file_does_not_fail(self):
+        backend = ConcreteBackend(harness=FakeHarness())
+        proc = _make_proc(['{"type": "system"}\n'], returncode=0)
+        rc, _ = backend._process_stream(proc, streaming=True)
+        assert rc == 0
+
+    def test_creates_parent_dirs(self, tmp_path):
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.output_file = tmp_path / "sub" / "dir" / "out.jsonl"
+        proc = _make_proc(['{"type": "system"}\n'], returncode=0)
+        backend._process_stream(proc, streaming=True)
+        assert backend.output_file.exists()
+
+    def test_stream_completion_still_writes(self, tmp_path):
+        backend = ConcreteBackend(harness=FakeHarness())
+        backend.output_file = tmp_path / "out.jsonl"
+        proc = _make_proc([FULL_RUN_MSG + "\n"], returncode=-9)
+        _, stream_complete = backend._process_stream(proc, streaming=True)
+        assert stream_complete is True
+        assert FULL_RUN_MSG in backend.output_file.read_text()
+
+
 class TestOpenShellDownloadBeforeVerdict:
     """Verify OpenShellBackend downloads the workdir before checking the verdict."""
 


### PR DESCRIPTION
## Summary

- Tee raw stream-json lines to `output_file` in `Backend._process_stream()`, writing every line to disk while processing (both streaming and non-streaming paths)
- Wire `backend.output_file = output_file` in `_default_run_container()` so the skill runner path produces `agent-output.txt` with the full conversation
- Add 5 tests covering streaming tee, non-streaming tee, no-op when unset, parent dir creation, and tee during stream completion

Resolves [AIPCC-29963](https://redhat.atlassian.net/browse/AIPCC-29963)

## Test plan

- [x] `tox -e py313` (804 passed)
- [x] `tox -e lint` (clean)
- [x] `tox -e check-format` (clean)
- [x] `tox -e typecheck` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIPCC-29963]: https://redhat.atlassian.net/browse/AIPCC-29963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ