### PR TITLE
RHAIFIRST-576: Add get_issue_links() to JiraClient

### DIFF
--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -521,6 +521,48 @@ class JiraClient:
 
         return sorted(parent_keys)
 
+    def get_issue_links(self, key: str) -> list[dict]:
+        """Return an issue's links as a normalised list.
+
+        Each entry describes one link and the issue on the other end:
+
+          - ``type``: the link type name (e.g. ``"Blocks"``).
+          - ``direction``: ``"inward"`` or ``"outward"`` -- which side the
+            linked issue sits on. For a ``"Blocks"`` link, ``"inward"``
+            means *this* issue is blocked by the linked issue; ``"outward"``
+            means this issue blocks it.
+          - ``key``: the linked issue key (e.g. ``"PROJ-123"``).
+          - ``status``: the linked issue's status name (e.g. ``"Open"``),
+            or ``""`` if unavailable.
+
+        Returns an empty list if the issue has no links.
+        """
+        resp = self._request(
+            "get",
+            self._api_url(f"issue/{key}") + "?fields=issuelinks",
+            headers=self._headers(),
+        )
+        self._check(resp)
+
+        links: list[dict] = []
+        for link in resp.json().get("fields", {}).get("issuelinks") or []:
+            if link.get("inwardIssue"):
+                direction, issue = "inward", link["inwardIssue"]
+            elif link.get("outwardIssue"):
+                direction, issue = "outward", link["outwardIssue"]
+            else:
+                continue
+            status = ((issue.get("fields") or {}).get("status") or {}).get("name", "")
+            links.append(
+                {
+                    "type": (link.get("type") or {}).get("name", ""),
+                    "direction": direction,
+                    "key": issue.get("key", ""),
+                    "status": status,
+                }
+            )
+        return links
+
     # ------------------------------------------------------------------
     # Write operations
     # ------------------------------------------------------------------

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -146,6 +146,80 @@ class TestSearch:
         assert results[0]["key"] == "TEST-1"
 
 
+class TestGetIssueLinks:
+    @staticmethod
+    def _resp(payload):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = payload
+        return resp
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_normalises_inward_and_outward(self, mock_requests, client):
+        mock_requests.get.return_value = self._resp(
+            {
+                "fields": {
+                    "issuelinks": [
+                        {
+                            "type": {"name": "Blocks", "inward": "is blocked by"},
+                            "inwardIssue": {
+                                "key": "TEST-2",
+                                "fields": {"status": {"name": "Open"}},
+                            },
+                        },
+                        {
+                            "type": {"name": "Blocks", "outward": "blocks"},
+                            "outwardIssue": {
+                                "key": "TEST-3",
+                                "fields": {"status": {"name": "Done"}},
+                            },
+                        },
+                    ]
+                }
+            }
+        )
+
+        links = client.get_issue_links("TEST-1")
+        assert links == [
+            {"type": "Blocks", "direction": "inward", "key": "TEST-2", "status": "Open"},
+            {"type": "Blocks", "direction": "outward", "key": "TEST-3", "status": "Done"},
+        ]
+        assert "fields=issuelinks" in mock_requests.get.call_args.args[0]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_missing_status_defaults_to_empty(self, mock_requests, client):
+        mock_requests.get.return_value = self._resp(
+            {
+                "fields": {
+                    "issuelinks": [{"type": {"name": "Relates"}, "outwardIssue": {"key": "TEST-9"}}]
+                }
+            }
+        )
+
+        links = client.get_issue_links("TEST-1")
+        assert links == [{"type": "Relates", "direction": "outward", "key": "TEST-9", "status": ""}]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_no_links_returns_empty(self, mock_requests, client):
+        mock_requests.get.return_value = self._resp({"fields": {}})
+        assert client.get_issue_links("TEST-1") == []
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_null_issuelinks_returns_empty(self, mock_requests, client):
+        mock_requests.get.return_value = self._resp({"fields": {"issuelinks": None}})
+        assert client.get_issue_links("TEST-1") == []
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_api_error_raises(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 404
+        resp.text = "not found"
+        mock_requests.get.return_value = resp
+
+        with pytest.raises(JiraError):
+            client.get_issue_links("TEST-1")
+
+
 class TestEditLabels:
     @patch("agentic_ci.jira.client.requests")
     def test_add_labels(self, mock_requests, client):


### PR DESCRIPTION
## Summary

Adds a public `JiraClient.get_issue_links()` method so downstream pipelines can read an issue's Jira links through a stable, public API instead of reaching into the client's private internals.

This is the `agentic-ci` half of [autofix MR !1421](https://gitlab.com/redhat/rhel-ai/agentic-ci/autofix/-/merge_requests/1421). An AI review on that MR flagged that autofix's `get_issue_links()` helper was calling four private `JiraClient` methods (`_api_url`, `_request`, `_headers`, `_check`) — fragile coupling to agentic-ci internals across a pinned PyPI dependency. Per autofix's own decision rule ("could another SDLC pipeline use this? if yes, it belongs in agentic-ci"), the generic Jira read belongs here.

## What it returns

A curated, agentic-ci-owned shape rather than the raw Atlassian wire format, consistent with every other read method on `JiraClient`:

```python
[{"type": "Blocks", "direction": "inward", "key": "PROJ-123", "status": "Open"}]
```

`direction` (`inward`/`outward`) encapsulates the inward/outward branching that consumers would otherwise have to decode from the raw JSON. Fields were scoped to exactly what the consumer needs (YAGNI); additional fields can be added later without a breaking change.

## Tests

`TestGetIssueLinks`: inward+outward normalisation, missing status, no links, `null` issuelinks, and API error.

## Follow-up (separate, not in this PR)

Once this lands and `agentic-ci` is released, autofix MR !1421 will bump its pinned dependency and change its helper to delegate to `client.get_issue_links()`, dropping the private-method access. The two can't land atomically because of the pinned-release boundary.

## Verification

`tox -e py313` (809 passed), `tox -e lint`, `tox -e check-format`, `tox -e typecheck` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving linked issues from Jira.
  * Linked issue details now include relationship type, direction, issue key, and status.
  * Issues without links are handled gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->