### PR TITLE
fix: clean up Renovate config for internally-built base images

### DIFF
--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -121,7 +121,7 @@ RUN curl -fsSL -o /tmp/vale.tar.gz \
     && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.23~stable-1
+ARG ACLI_VERSION=1.3.29~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -71,7 +71,7 @@ RUN curl -fsSL -o /tmp/vale.tar.gz \
     && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.23~stable-1
+ARG ACLI_VERSION=1.3.29~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/images/runner/opencode/Containerfile.openshell
+++ b/images/runner/opencode/Containerfile.openshell
@@ -21,7 +21,7 @@
 #
 # x86_64 only.
 
-ARG OPENCODE_BASE_IMAGE=quay.io/aipcc/base-images/agentic/opencode:latest@sha256:e18cac063ab3a5a01d4a0fec352b6d80796d6d44b8c3a0899ff964c3030c42b8
+ARG OPENCODE_BASE_IMAGE=quay.io/aipcc/base-images/agentic/opencode:0.0.1-1787087831@sha256:e18cac063ab3a5a01d4a0fec352b6d80796d6d44b8c3a0899ff964c3030c42b8
 FROM ${OPENCODE_BASE_IMAGE}
 
 ARG UV_VERSION=0.12.2

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,6 @@
     "commands": ["python3 scripts/bump-versions.py --sync"],
     "fileFilters": [
       "images/runner/shared/Containerfile.base",
-      "images/runner/shared/Containerfile.openshell-base",
       "images/runner/claude-code/Containerfile",
       "images/runner/claude-code/Containerfile.openshell",
       "images/runner/opencode/Containerfile",
@@ -31,7 +30,15 @@
     },
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["quay.io/aipcc/base-images/agentic/opencode"],
+      "matchPackageNames": [
+        "quay.io/aipcc/base-images/agentic/opencode",
+        "quay.io/aipcc/base-images/agentic/claude-code"
+      ],
+      "minimumReleaseAge": "0 days"
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/opendatahub/odh-openshell-cli"],
       "minimumReleaseAge": "0 days"
     }
   ],
@@ -40,7 +47,6 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
@@ -55,7 +61,6 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ARG SHELLCHECK_VERSION=(?<currentValue>[^\\n]+)"],
@@ -68,7 +73,6 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
@@ -83,7 +87,6 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
@@ -114,7 +117,8 @@
       ],
       "matchStrings": ["ARG OPENSHELL_IMAGE_TAG=(?<currentValue>[^\\n]+)"],
       "depNameTemplate": "quay.io/opendatahub/odh-openshell-cli",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-rhaiv\\.(?<build>\\d+)$"
     },
     {
       "customType": "regex",
@@ -143,30 +147,7 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^images/runner/claude-code/Containerfile$",
-        "^images/runner/claude-code/Containerfile\\.openshell$"
-      ],
-      "matchStrings": ["ARG CLAUDE_VERSION=(?<currentValue>[^\\n]+)"],
-      "depNameTemplate": "@anthropic-ai/claude-code",
-      "datasourceTemplate": "npm",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^images/runner/opencode/Containerfile$"
-      ],
-      "matchStrings": ["ARG OPENCODE_VERSION=(?<currentValue>[^\\n]+)"],
-      "depNameTemplate": "anomalyco/opencode",
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver",
-      "extractVersionTemplate": "^v?(?<version>.+)$"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ruff==(?<currentValue>[^\\s]+)"],
@@ -177,7 +158,6 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/shared/Containerfile\\.openshell-base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
@@ -199,10 +179,20 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^images/runner/claude-code/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG CLAUDE_CODE_BASE_IMAGE=(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ARG OPENCODE_BASE_IMAGE=(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
     }
   ]
 }

--- a/scripts/bump-versions.py
+++ b/scripts/bump-versions.py
@@ -26,7 +26,6 @@ BASE_CF = REPO_ROOT / "images" / "runner" / "shared" / "Containerfile.base"
 CLAUDE_CF = REPO_ROOT / "images" / "runner" / "claude-code" / "Containerfile"
 OPENCODE_CF = REPO_ROOT / "images" / "runner" / "opencode" / "Containerfile"
 CI_CF = REPO_ROOT / "images" / "ci" / "Containerfile.podman"
-OPENSHELL_BASE_CF = REPO_ROOT / "images" / "runner" / "shared" / "Containerfile.openshell-base"
 OPENSHELL_CLAUDE_CF = REPO_ROOT / "images" / "runner" / "claude-code" / "Containerfile.openshell"
 OPENSHELL_OPENCODE_CF = REPO_ROOT / "images" / "runner" / "opencode" / "Containerfile.openshell"
 OPENSHELL_CI_CF = REPO_ROOT / "images" / "ci" / "Containerfile.openshell"
@@ -110,7 +109,7 @@ def bump_uv(check_only):
 
     result = {"tool": "uv", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "UV_VERSION", version)
                 _update_arg(cf, "UV_SHA256", sha)
@@ -127,7 +126,7 @@ def bump_shellcheck(check_only):
 
     result = {"tool": "shellcheck", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "SHELLCHECK_VERSION", version)
                 _update_arg(cf, "SHELLCHECK_SHA256", sha)
@@ -141,7 +140,7 @@ def bump_gh(check_only):
 
     result = {"tool": "gh", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "GH_VERSION", version)
                 _update_arg(cf, "GH_SHA256", sha)
@@ -161,7 +160,7 @@ def bump_glab(check_only):
 
     result = {"tool": "glab", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 _update_arg(cf, "GLAB_VERSION", version)
                 _update_arg(cf, "GLAB_SHA256", sha)
@@ -177,7 +176,7 @@ def bump_claude(check_only):
 
     result = {"tool": "claude", "version": version, "sha256": sha}
     if not check_only:
-        for cf in [CLAUDE_CF, OPENSHELL_CLAUDE_CF]:
+        for cf in [CLAUDE_CF]:
             if cf.exists():
                 _update_arg(cf, "CLAUDE_VERSION", version)
                 _update_arg(cf, "CLAUDE_SHA256", sha)
@@ -309,7 +308,7 @@ def bump_ruff(check_only):
 
     result = {"tool": "ruff", "version": version}
     if not check_only:
-        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, OPENSHELL_OPENCODE_CF]:
             if cf.exists():
                 text = cf.read_text()
                 text = re.sub(r"ruff==[\d.]+", f"ruff=={version}", text)
@@ -324,7 +323,7 @@ def bump_agentic_ci(check_only):
     result = {"tool": "agentic-ci", "version": version}
     if not check_only:
         # CI images install from local source; only bump runner base images.
-        for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
+        for cf in [BASE_CF, OPENSHELL_OPENCODE_CF]:
             if not cf.exists():
                 continue
             text = cf.read_text()
@@ -361,7 +360,7 @@ def _current_value(path, arg_name):
 
 def sync_uv():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "UV_VERSION")
@@ -383,7 +382,7 @@ def sync_uv():
 
 def sync_shellcheck():
     versions = {}
-    for cf in [BASE_CF, OPENSHELL_BASE_CF, OPENSHELL_OPENCODE_CF]:
+    for cf in [BASE_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "SHELLCHECK_VERSION")
@@ -404,7 +403,7 @@ def sync_shellcheck():
 
 def sync_gh():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "GH_VERSION")
@@ -425,7 +424,7 @@ def sync_gh():
 
 def sync_glab():
     versions = {}
-    for cf in [BASE_CF, CI_CF, OPENSHELL_BASE_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
+    for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF, OPENSHELL_OPENCODE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "GLAB_VERSION")
@@ -488,7 +487,7 @@ def sync_vale():
 
 def sync_claude():
     versions = {}
-    for cf in [CLAUDE_CF, OPENSHELL_CLAUDE_CF]:
+    for cf in [CLAUDE_CF]:
         if not cf.exists():
             continue
         version = _current_value(cf, "CLAUDE_VERSION")
@@ -698,7 +697,6 @@ def main():
                     CLAUDE_CF,
                     OPENCODE_CF,
                     CI_CF,
-                    OPENSHELL_BASE_CF,
                     OPENSHELL_CLAUDE_CF,
                     OPENSHELL_OPENCODE_CF,
                     OPENSHELL_CI_CF,
@@ -711,7 +709,7 @@ def main():
                 print(f"  {name:15s} {current or '?':20s} → {latest}{changed}")
             elif name in pip_packages:
                 current = "?"
-                for cf in [BASE_CF, OPENSHELL_BASE_CF, CI_CF, OPENSHELL_CI_CF]:
+                for cf in [BASE_CF, CI_CF, OPENSHELL_CI_CF]:
                     if not cf.exists():
                         continue
                     match = re.search(rf"{re.escape(name)}==([\d.]+)", cf.read_text())


### PR DESCRIPTION
## Summary
- Remove orphaned Renovate managers for direct `@anthropic-ai/claude-code` (npm) and `anomalyco/opencode` (github-releases) installs, which are no longer relevant since both agents now come from internally-built quay.io base images
- Remove all dead `Containerfile.openshell-base` references (file no longer exists)
- Add `CLAUDE_CODE_BASE_IMAGE` custom manager and update `OPENCODE_BASE_IMAGE` manager with `regex` versioning for the `0.0.1-<timestamp>` tag scheme
- Add `regex` versioning to `OPENSHELL_IMAGE_TAG` manager to filter to only `-rhaiv.N` tags
- Switch opencode `Containerfile.openshell` from `latest` tag to `0.0.1-1787087831` (same digest) so Renovate can track versioned tags
- Clean up `bump-versions.py`: remove dead `OPENSHELL_BASE_CF` refs, stop targeting openshell claude Containerfile for `CLAUDE_VERSION` bumps

Fixes the issue where PRs like #345 are opened for orphaned version tracking.

## Test plan
- [ ] Verify Renovate no longer opens PRs for `@anthropic-ai/claude-code` npm or `anomalyco/opencode` github-releases
- [ ] Verify Renovate picks up new `0.0.1-<timestamp>` tags for claude-code and opencode base images
- [ ] Verify Renovate picks up new `v*-rhaiv.*` tags for openshell and ignores other tag formats
- [ ] Run `python3 scripts/bump-versions.py --check` to confirm no errors from removed paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the Atlassian CLI to version 1.3.29.
  * Pinned the OpenCode image to a specific release for more consistent environments.

* **Chores**
  * Improved automated image version tracking and update rules.
  * Streamlined version synchronization for supported container images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->