### PR TITLE
Let callers size the OpenShell sandbox (memory, cpu, gpu)

### DIFF
--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -151,9 +151,11 @@ openshell provider create \
 
 ### Sandbox Resources
 
-By default the sandbox uses OpenShell's own resource limits, which include a
-memory ceiling of roughly 4Gi regardless of how large the CI runner is. Pass
-`memory`, `cpu` and `gpu` to size it to the machine:
+When these are omitted, no `--memory`, `--cpu` or `--gpu` flag is passed and the
+effective limits come from the compute driver and host configuration rather than
+from agentic-ci. That limit can sit far below what the host has: a sandbox created
+without `--memory` on a 16 GB host was OOM-killed by its memory cgroup at under
+4 GiB. Pass `memory`, `cpu` and `gpu` to size the sandbox explicitly:
 
 ```python
 backend = create_backend(
@@ -168,12 +170,17 @@ backend = create_backend(
 All three default to `None`, which passes no flag and leaves current behavior
 unchanged.
 
+Resource limits are fixed when the sandbox is created. `setup()` reuses an
+existing sandbox rather than recreating it, so these values do not apply to one
+that already exists; the backend logs a warning saying so. Delete the sandbox to
+apply new values.
+
 Two failure modes worth recognizing, because neither says what it is:
 
-- **Exceeding the memory ceiling** does not raise. The cgroup OOM-kills the
-  process, the supervisor log stops mid-line, and the next command reports
-  `sandbox is not ready`. The kernel is the only witness — `journalctl -k` on the
-  host shows `Memory cgroup out of memory: Killed process`.
+- **Exceeding a memory limit** does not raise. The cgroup OOM-kills the process,
+  the supervisor log stops mid-line, and the next command reports `sandbox is not
+  ready`. The kernel is the only witness — `journalctl -k` on the host shows
+  `Memory cgroup out of memory: Killed process`.
 - **Not requesting a GPU** leaves the accelerator invisible to the agent even
   when the host has one and the container running agentic-ci can see it.
   `nvidia-smi -L` inside the sandbox returns nothing.

--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -149,17 +149,52 @@ openshell provider create \
     L7 inspection in a follow-up rather than changing only Codex here.
 <!-- markdownlint-enable MD046 -->
 
+### Sandbox Resources
+
+By default the sandbox uses OpenShell's own resource limits, which include a
+memory ceiling of roughly 4Gi regardless of how large the CI runner is. Pass
+`memory`, `cpu` and `gpu` to size it to the machine:
+
+```python
+backend = create_backend(
+    "openshell",
+    harness=harness,
+    memory="8Gi",  # accepts 512Mi, 4Gi, 8G
+    cpu="4",  # accepts 500m, 1, 2.5
+    gpu=1,  # GPU count
+)
+```
+
+All three default to `None`, which passes no flag and leaves current behavior
+unchanged.
+
+Two failure modes worth recognizing, because neither says what it is:
+
+- **Exceeding the memory ceiling** does not raise. The cgroup OOM-kills the
+  process, the supervisor log stops mid-line, and the next command reports
+  `sandbox is not ready`. The kernel is the only witness — `journalctl -k` on the
+  host shows `Memory cgroup out of memory: Killed process`.
+- **Not requesting a GPU** leaves the accelerator invisible to the agent even
+  when the host has one and the container running agentic-ci can see it.
+  `nvidia-smi -L` inside the sandbox returns nothing.
+
 ### Sandbox Lifecycle
 
 ```bash
 openshell sandbox get ci                         # check if exists
 
-# Create sandbox with the provider attached
+# Create sandbox with the provider attached.
+# --memory / --cpu / --gpu are only passed when the caller sets them.
 openshell sandbox create \
   --name ci \
   --no-tty \
+  --no-auto-providers \
   --provider ci-gcp \
   --from <SANDBOX_IMAGE> \
+  --memory 8Gi \
+  --cpu 4 \
+  --gpu 1 \
+  --detach \
   -- sleep infinity
 
 # Keep the sandbox's main process alive; agent commands run via exec.

--- a/src/agentic_ci/backends/__init__.py
+++ b/src/agentic_ci/backends/__init__.py
@@ -45,6 +45,9 @@ def create_backend(name: str, *, harness: Harness, **kwargs: Any) -> Backend:
             policy=kwargs.get("policy"),
             extra_env=kwargs.get("extra_env"),
             approval_mode=kwargs.get("approval_mode"),
+            memory=kwargs.get("memory"),
+            cpu=kwargs.get("cpu"),
+            gpu=kwargs.get("gpu"),
             harness=harness,
         )
     else:

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -179,6 +179,7 @@ class OpenShellBackend(Backend):
                 )
             if existing_auth_mode == auth_mode and identity == expected_identity:
                 log.section("Sandbox already exists")
+                self._warn_unapplied_resources()
                 return
 
             if existing_auth_mode != auth_mode:
@@ -216,6 +217,31 @@ class OpenShellBackend(Backend):
 
         self._upload_sandbox_config(otel_enabled=otel_port is not None)
         _save_sandbox_identity(_sandbox_identity(self.harness.name, self.image, auth_mode))
+
+    def _warn_unapplied_resources(self):
+        """Say so when a reused sandbox keeps an allocation the caller did not ask for.
+
+        Resource limits are fixed when the sandbox is created, so reuse silently
+        discards whatever ``memory``, ``cpu`` or ``gpu`` this backend was given.
+        Left unsaid, that is the same failure the limits themselves cause: work
+        runs against a ceiling nobody chose and the symptom appears somewhere else
+        entirely.
+
+        A warning rather than an error, because reuse is a deliberate feature and
+        the existing allocation may already be correct. Verifying that would mean
+        parsing ``openshell sandbox get`` and comparing units -- ``1``, ``1000m``
+        and ``1.0`` are the same CPU -- which is a contract worth adding only once
+        something needs to depend on it.
+        """
+        requested = {"memory": self.memory, "cpu": self.cpu, "gpu": self.gpu}
+        asked_for = {k: v for k, v in requested.items() if v}
+        if not asked_for:
+            return
+        values = ", ".join(f"{k}={v}" for k, v in asked_for.items())
+        log.info(
+            f"WARNING: {values} not applied -- resource limits are set at creation "
+            f"and this sandbox already exists. Delete it to apply new values."
+        )
 
     def _upload_sandbox_config(self, otel_enabled=False):
         """Write harness-specific config and upload it to the sandbox."""

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -125,6 +125,9 @@ class OpenShellBackend(Backend):
         policy=None,
         extra_env=None,
         approval_mode=None,
+        memory=None,
+        cpu=None,
+        gpu=None,
         *,
         harness: Harness,
     ):
@@ -132,6 +135,9 @@ class OpenShellBackend(Backend):
         self.policy_path = policy
         self._extra_env = extra_env or {}
         self.approval_mode = approval_mode
+        self.memory = memory
+        self.cpu = cpu
+        self.gpu = gpu
 
     def _merged_env(self):
         return {**os.environ, **self._extra_env}
@@ -198,6 +204,9 @@ class OpenShellBackend(Backend):
             workdir=self.workdir,
             approval_mode=self.approval_mode,
             auth_mode=auth_mode,
+            memory=self.memory,
+            cpu=self.cpu,
+            gpu=self.gpu,
         )
 
         self._run_setup_steps()

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -45,12 +45,35 @@ def create(
     workdir=".",
     approval_mode=None,
     auth_mode=None,
-):
+    memory: str | None = None,
+    cpu: str | None = None,
+    gpu: int | None = None,
+) -> None:
     """Create a persistent sandbox with the CI provider attached.
 
     The sandbox is created first, then the network policy is applied
     via ``openshell policy update --wait`` to ensure the supervisor
     has compiled and activated the rules before the agent starts.
+
+    ``memory``, ``cpu`` and ``gpu`` size the sandbox. All three default to
+    ``None``, which leaves OpenShell's own defaults in place -- notably a
+    memory ceiling of roughly 4Gi, which applies no matter how large the CI
+    runner is. An agent that exceeds it is OOM-killed by the cgroup, and from
+    inside the sandbox that looks like the sandbox simply vanishing: the
+    supervisor's log stops mid-line and the next command reports
+    ``sandbox is not ready``.
+
+    Args:
+        image: Sandbox image to create from.
+        policy_path: Path to a network policy file to merge in.
+        otel_port: Port for the OTEL collector on the host.
+        workdir: Directory the policy file is resolved relative to.
+        approval_mode: Enables agent policy proposals when set.
+        memory: Memory limit, e.g. ``"8Gi"``. None uses OpenShell's default.
+        cpu: CPU limit, e.g. ``"4"`` or ``"2.5"``. None uses OpenShell's default.
+        gpu: GPU count to request, e.g. ``1``. None requests no GPU, which
+            means an accelerator on the host is not visible to the agent even
+            when the container running this can see it.
     """
     args = [
         "openshell",
@@ -67,6 +90,12 @@ def create(
         args.extend(["--approval-mode", approval_mode])
     if image:
         args.extend(["--from", image])
+    if memory:
+        args.extend(["--memory", str(memory)])
+    if cpu:
+        args.extend(["--cpu", str(cpu)])
+    if gpu:
+        args.extend(["--gpu", str(gpu)])
     # The trailing argv becomes the sandbox's canonical main process.
     # Use a persistent process so the supervisor stays alive to accept
     # policy updates; --detach returns control to the caller immediately.

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -111,3 +111,23 @@ def test_apply_policy_allows_hummingbird_binary_aliases():
         if argument == "--binary"
     ]
     assert binary_paths == list(sandbox.AGENT_BINARY_PATHS)
+
+
+class TestExistingSandboxKeepsItsAllocation:
+    """Resource limits are fixed at creation, so reuse cannot apply new ones."""
+
+    def test_a_reused_sandbox_says_the_request_was_not_applied(self):
+        backend = create_backend("openshell", harness=mock.Mock(), memory="8Gi", gpu=1)
+        with mock.patch("agentic_ci.backends.openshell.log.info") as logged:
+            backend._warn_unapplied_resources()
+
+        warning = logged.call_args.args[0]
+        assert "memory=8Gi" in warning and "gpu=1" in warning
+        assert "Delete it" in warning
+
+    def test_nothing_is_said_when_nothing_was_requested(self):
+        backend = create_backend("openshell", harness=mock.Mock())
+        with mock.patch("agentic_ci.backends.openshell.log.info") as logged:
+            backend._warn_unapplied_resources()
+
+        logged.assert_not_called()

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -2,7 +2,86 @@
 
 from unittest import mock
 
+import pytest
+
+from agentic_ci.backends import create_backend
 from agentic_ci.backends.openshell import sandbox
+from agentic_ci.backends.openshell.provider import PROVIDER_NAME
+
+
+@pytest.fixture
+def created():
+    """Create a sandbox and return the argv passed to OpenShell."""
+
+    def _create(**kwargs):
+        with (
+            mock.patch.object(sandbox, "_run") as run,
+            mock.patch.object(sandbox, "_apply_policy"),
+        ):
+            sandbox.create(**kwargs)
+        return run.call_args_list[0].args[0]
+
+    return _create
+
+
+class TestCreateResourceFlags:
+    def test_no_resource_flags_by_default(self, created):
+        assert created() == [
+            "openshell",
+            "sandbox",
+            "create",
+            "--name",
+            sandbox.SANDBOX_NAME,
+            "--no-tty",
+            "--no-auto-providers",
+            "--provider",
+            PROVIDER_NAME,
+            "--detach",
+            "--",
+            "sleep",
+            "infinity",
+        ]
+
+    def test_resource_limits_are_passed(self, created):
+        args = created(memory="8Gi", cpu="2.5", gpu=1)
+        assert args[args.index("--memory") + 1] == "8Gi"
+        assert args[args.index("--cpu") + 1] == "2.5"
+        assert args[args.index("--gpu") + 1] == "1"
+
+    def test_resource_flags_precede_the_command_terminator(self, created):
+        args = created(memory="8Gi", cpu="4", gpu=1)
+        terminator = args.index("--")
+        for flag in ("--memory", "--cpu", "--gpu"):
+            assert args.index(flag) < terminator
+
+    def test_resource_flags_combine_with_image_and_approval_mode(self, created):
+        args = created(image="quay.io/example/sandbox:1", approval_mode="ask", memory="8Gi")
+        assert args[args.index("--from") + 1] == "quay.io/example/sandbox:1"
+        assert args[args.index("--approval-mode") + 1] == "ask"
+        assert args[args.index("--memory") + 1] == "8Gi"
+
+    @pytest.mark.parametrize("value", [None, "", 0])
+    def test_falsy_values_leave_the_flag_off(self, created, value):
+        args = created(memory=value, cpu=value, gpu=value)
+        assert "--memory" not in args
+        assert "--cpu" not in args
+        assert "--gpu" not in args
+
+
+class TestBackendPassesResourcesThrough:
+    def test_create_backend_accepts_resource_kwargs(self):
+        backend = create_backend(
+            "openshell",
+            harness=mock.Mock(),
+            memory="8Gi",
+            cpu="4",
+            gpu=1,
+        )
+        assert (backend.memory, backend.cpu, backend.gpu) == ("8Gi", "4", 1)
+
+    def test_defaults_to_no_resource_request(self):
+        backend = create_backend("openshell", harness=mock.Mock())
+        assert (backend.memory, backend.cpu, backend.gpu) == (None, None, None)
 
 
 def test_create_uses_detached_persistent_main_process():


### PR DESCRIPTION
## Problem

`sandbox.create()` builds the `openshell sandbox create` argv as a fixed list and
passes none of the resource flags OpenShell accepts, so every sandbox runs at
OpenShell's defaults no matter how large the host is. Two of those defaults are worth
naming, because neither failure looks like what it is.

**The memory ceiling is roughly 4Gi.** Exceeding it does not raise. The cgroup
OOM-kills the process, the supervisor log stops mid-line, and the next command reports
`sandbox is not ready`. Nothing inside the sandbox or in agentic-ci records the reason —
`journalctl -k` on the host is the only witness:

```
oom-kill:constraint=CONSTRAINT_MEMCG,task=python3
Memory cgroup out of memory: Killed process 7026 (python3) anon-rss:3390368kB
```

An agent doing anything memory-hungry on a 16 GB host hits this with 12 GB sitting
unused. Worse than the crash is the quiet case: an agent that interprets its own
`exit 137` as a property of the software it is testing will report a confident and
wrong conclusion.

**No GPU is requested**, so an accelerator is invisible to the agent even when the host
has one and the container running agentic-ci can see it. `nvidia-smi -L` inside the
sandbox returns nothing while the same command one layer out lists the card.

## Change

`create()` takes `memory`, `cpu` and `gpu`, plumbed through `OpenShellBackend` and
`create_backend` so the setting is reachable from where backends are configured.

```python
backend = create_backend(
    "openshell",
    harness=harness,
    memory="8Gi",
    cpu="4",
    gpu=1,
)
```

All three default to `None` and pass no flag, so **behavior is unchanged unless a
caller opts in**.

Two details worth flagging for review:

- **The flags go before the `--` terminator.** After it they are arguments to the
  sandbox command rather than to OpenShell, which accepts and ignores them — a silent
  no-op indistinguishable from the flag not working. There is a test pinning the
  ordering.
- **Falsy values pass nothing rather than being forwarded.** `--gpu 0` is not "no GPU"
  and `--memory ''` is not a smaller sandbox; both are malformed requests standing in
  for a caller who meant to say nothing.

The signature gained type annotations because `tox -e docs` runs griffe in strict mode
and rejects documented parameters without them.

## Testing

`tox -e py313` (823 passed), `lint`, `check-format`, `typecheck` and `docs` all pass.

New unit tests in `tests/test_openshell_sandbox.py` cover both ends: the argv `create()`
builds for each flag and combination, and that the backend forwards what it was given —
a setting accepted and silently dropped is worse than one rejected, since the caller has
no way to tell it did nothing.

**No e2e test.** Exercising this needs a host with a GPU and a sandbox that can be
driven into an OOM kill, which the existing e2e suite is not set up for. Happy to add
one if there is an appetite for that fixture.

## Docs

`docs/backends/openshell.md` gains a "Sandbox Resources" section covering the options
and both failure modes above, since neither is guessable from the symptom.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable memory, CPU, and GPU resource settings for OpenShell sandboxes.
  * Resource options are applied only when specified; existing defaults remain unchanged.
  * Added OpenAI provider support for Codex sandboxes.
  * Existing sandboxes now warn when requested resource limits cannot be applied.
* **Documentation**
  * Documented sandbox resource limits, configuration examples, GPU visibility, and lifecycle behavior.
  * Updated lifecycle examples to show resource configuration flags and persistent sandbox execution.
  * Revised OpenShell artifact build details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->