### PR TITLE
Add Codex CLI harness

### DIFF
--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -20,10 +20,6 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: Plugin env var wasn't being passed through to the sandbox environment. Fixed by explicitly forwarding it.
 - **Where to look**: `backends/openshell/sandbox.py` env var injection, `harness.py`
 
-### OpenShell E2E hangs at "Requesting compute" during sandbox creation
-- **Likely cause**: The initial `openshell sandbox create` command does not terminate. OpenShell keeps the sandbox by default, so use a short-lived initial command such as `true`; agent commands run later through `sandbox exec`.
-- **Where to look**: `backends/openshell/sandbox.py` sandbox creation command
-
 ## Skill engine
 
 ### Verdict file missing but agent exited 0

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -54,6 +54,22 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: For OpenShell backend, OTEL host networking wasn't configured. Fixed to set up OTEL endpoint forwarding.
 - **Where to look**: `otel.py` collector setup, `backends/openshell/` network config
 
+### Codex starts but plugins or OTEL data are missing
+- **Likely cause**: Codex was launched with `--ignore-user-config`, which suppresses plugin state and user-level OTel configuration, or the per-run `otel.*` exporter overrides were not passed.
+- **Where to look**: `harness.py` Codex arguments, `plugins.py`, backend `otel_endpoint` argument wiring
+
+### Codex OpenShell setup creates an Anthropic provider
+- **Likely cause**: Codex was classified as generic `api-key` auth and OpenShell selected its Anthropic provider. Codex must use the `openai` auth mode and the OpenAI network endpoints.
+- **Where to look**: `harness.py` auth mode, `backends/openshell/provider.py`, `backends/openshell/policy.py`
+
+### OpenShell harness cannot reach its model API, or can reach another harness's API
+- **Likely cause**: The sandbox policy was resolved without the harness auth mode. Authentication endpoints are scoped to `vertex`, `api-key`, or `openai`; only common forge and package endpoints are shared.
+- **Where to look**: `backends/openshell/policy.py`, `backends/openshell/sandbox.py` auth mode wiring
+
+### Codex exits before local or Podman execution with "credentials not found"
+- **Likely cause**: None of `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or `OPENAI_API_KEY` is available. Local runs may instead use `$CODEX_HOME/auth.json`; Podman runs require a forwarded environment credential.
+- **Where to look**: `CodexHarness.validate_credentials()`, backend `setup()`, CI secret injection, and `CODEX_HOME`
+
 ## Jira client
 
 ### Markdown formatting lost in ADF roundtrip

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -20,6 +20,10 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: Plugin env var wasn't being passed through to the sandbox environment. Fixed by explicitly forwarding it.
 - **Where to look**: `backends/openshell/sandbox.py` env var injection, `harness.py`
 
+### OpenShell E2E hangs at "Requesting compute" during sandbox creation
+- **Likely cause**: The initial `openshell sandbox create` command does not terminate. OpenShell keeps the sandbox by default, so use a short-lived initial command such as `true`; agent commands run later through `sandbox exec`.
+- **Where to look**: `backends/openshell/sandbox.py` sandbox creation command
+
 ## Skill engine
 
 ### Verdict file missing but agent exited 0

--- a/.github/workflows/images-dev.yml
+++ b/.github/workflows/images-dev.yml
@@ -148,6 +148,53 @@ jobs:
           podman push "${IMAGE_NAME}:${DEV_TAG}"
 
   # --------------------------------------------------------------------------
+  # codex-runner
+  # --------------------------------------------------------------------------
+  build-codex-runner:
+    name: Build codex-runner (dev)
+    needs: compute-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@da4ab030ff46fde1666bb22e53e0f32242a33255 # v1 (node24)
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build base image
+        env:
+          DEV_TAG: ${{ needs.compute-tag.outputs.dev_tag }}
+        run: |
+          podman build --no-cache -t localhost/base:latest \
+            --build-arg AGENTIC_CI_VERSION="${DEV_TAG}" \
+            -f images/runner/shared/Containerfile.base \
+            .
+
+      - name: Build and push codex-runner
+        env:
+          DEV_TAG: ${{ needs.compute-tag.outputs.dev_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-runner"
+          podman build --no-cache \
+            -t "${IMAGE_NAME}:${DEV_TAG}" \
+            -f images/runner/codex/Containerfile \
+            .
+          podman push "${IMAGE_NAME}:${DEV_TAG}"
+
+  # --------------------------------------------------------------------------
   # ci-podman
   # --------------------------------------------------------------------------
   build-ci-podman:
@@ -258,6 +305,44 @@ jobs:
           podman build --no-cache \
             -t "${IMAGE_NAME}:${DEV_TAG}" \
             -f images/runner/opencode/Containerfile.openshell \
+            .
+          podman push "${IMAGE_NAME}:${DEV_TAG}"
+
+  # --------------------------------------------------------------------------
+  # codex-sandbox (OpenShell)
+  # --------------------------------------------------------------------------
+  build-codex-sandbox:
+    name: Build codex-sandbox (dev)
+    needs: compute-tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
+      - name: Log in to quay.io
+        uses: redhat-actions/podman-login@da4ab030ff46fde1666bb22e53e0f32242a33255 # v1 (node24)
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push codex-sandbox
+        env:
+          DEV_TAG: ${{ needs.compute-tag.outputs.dev_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-sandbox"
+          podman build --no-cache \
+            -t "${IMAGE_NAME}:${DEV_TAG}" \
+            -f images/runner/codex/Containerfile.openshell \
             .
           podman push "${IMAGE_NAME}:${DEV_TAG}"
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -230,6 +230,90 @@ jobs:
         run: podman push "${IMAGE_PREFIX}/opencode-runner:${VERSION_TAG}"
 
   # --------------------------------------------------------------------------
+  # codex-runner: requires the shared base image built first
+  # --------------------------------------------------------------------------
+  build-codex-runner:
+    name: Build codex-runner
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/codex-runner:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@da4ab030ff46fde1666bb22e53e0f32242a33255 # v1 (node24)
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build base image
+        run: |
+          VERSION_ARGS=()
+          if [[ -n "${VERSION_TAG}" ]]; then
+            VERSION_ARGS=(--build-arg "AGENTIC_CI_VERSION=${VERSION_TAG}")
+          fi
+          podman build -t localhost/base:latest \
+            "${VERSION_ARGS[@]}" \
+            -f images/runner/shared/Containerfile.base \
+            .
+
+      - name: Build codex-runner
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-runner"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          VERSION_ARGS=()
+          if [[ -n "${VERSION_TAG}" ]]; then
+            VERSION_ARGS=(-t "${IMAGE_NAME}:${VERSION_TAG}")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            "${VERSION_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/codex/Containerfile \
+            .
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/codex-runner:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-runner"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+      - name: Push version tag
+        if: env.VERSION_TAG != ''
+        run: podman push "${IMAGE_PREFIX}/codex-runner:${VERSION_TAG}"
+
+  # --------------------------------------------------------------------------
   # ci-podman: standalone, no base image dependency
   # --------------------------------------------------------------------------
   build-ci-podman:
@@ -451,6 +535,80 @@ jobs:
         run: podman push "${IMAGE_PREFIX}/opencode-sandbox:${VERSION_TAG}"
 
   # --------------------------------------------------------------------------
+  # codex-sandbox: OpenShell sandbox, builds on the agentic base image
+  # (quay.io/aipcc/base-images/agentic/codex)
+  # --------------------------------------------------------------------------
+  build-codex-sandbox:
+    name: Build codex-sandbox
+    runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.meta.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup podman
+        uses: ./.github/actions/setup-podman
+
+      - name: Image metadata
+        id: meta
+        run: echo "image=${IMAGE_PREFIX}/codex-sandbox:${CI_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Log in to quay.io
+        if: env.HAS_SECRETS == 'true'
+        uses: redhat-actions/podman-login@da4ab030ff46fde1666bb22e53e0f32242a33255 # v1 (node24)
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build codex-sandbox
+        run: |
+          set -euo pipefail
+
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-sandbox"
+          EPOCH=$(date +%s)
+
+          LABEL_ARGS=()
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            LABEL_ARGS=(--label "quay.expires-after=3d")
+          fi
+
+          VERSION_ARGS=()
+          if [[ -n "${VERSION_TAG}" ]]; then
+            VERSION_ARGS=(-t "${IMAGE_NAME}:${VERSION_TAG}")
+          fi
+
+          podman build \
+            "${LABEL_ARGS[@]}" \
+            "${VERSION_ARGS[@]}" \
+            -t "${IMAGE_NAME}:${CI_TAG}" \
+            -t "${IMAGE_NAME}:latest" \
+            -t "${IMAGE_NAME}:${EPOCH}" \
+            -f images/runner/codex/Containerfile.openshell \
+            .
+
+          echo "EPOCH=${EPOCH}" >> "$GITHUB_ENV"
+
+      - name: Push ci-sha tag
+        if: env.HAS_SECRETS == 'true'
+        run: podman push "${IMAGE_PREFIX}/codex-sandbox:${CI_TAG}"
+
+      - name: Push release tags
+        if: env.PUSH_RELEASE_TAGS == 'true'
+        run: |
+          set -euo pipefail
+          IMAGE_NAME="${IMAGE_PREFIX}/codex-sandbox"
+          podman push "${IMAGE_NAME}:latest"
+          podman push "${IMAGE_NAME}:${EPOCH}"
+
+      - name: Push version tag
+        if: env.VERSION_TAG != ''
+        run: podman push "${IMAGE_PREFIX}/codex-sandbox:${VERSION_TAG}"
+
+  # --------------------------------------------------------------------------
   # ci-openshell: standalone CI image with OpenShell gateway
   # --------------------------------------------------------------------------
   build-ci-openshell:
@@ -615,9 +773,35 @@ jobs:
           OPENCODE_CONTAINER_IMAGE: ${{ needs.build-opencode-runner.outputs.image }}
         run: bash tests/e2e/e2e-opencode-runner.sh
 
+  e2e-codex-runner:
+    name: E2E codex-runner
+    needs: [build-codex-runner, build-ci-podman]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ needs.build-ci-podman.outputs.image }}
+      options: --privileged
+      credentials:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install agentic-ci from repo
+        run: uv tool install .
+
+      - name: Run e2e tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_CONTAINER_IMAGE: ${{ needs.build-codex-runner.outputs.image }}
+        run: bash tests/e2e/e2e-codex-runner.sh
+
   e2e-openshell-sandbox:
     name: E2E openshell-sandbox
-    needs: [build-claude-sandbox, build-opencode-sandbox, build-ci-openshell]
+    needs: [build-claude-sandbox, build-opencode-sandbox, build-codex-sandbox, build-ci-openshell]
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     container:
@@ -639,6 +823,8 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
           GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_SANDBOX_IMAGE: ${{ needs.build-claude-sandbox.outputs.image }}
           OPENCODE_SANDBOX_IMAGE: ${{ needs.build-opencode-sandbox.outputs.image }}
+          CODEX_SANDBOX_IMAGE: ${{ needs.build-codex-sandbox.outputs.image }}
         run: bash tests/e2e/e2e-openshell-sandbox.sh

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -26,14 +26,17 @@
 #               .github/actions/setup-podman/, .github/workflows/images*.yml):
 #     - Build claude-runner
 #     - Build opencode-runner
+#     - Build codex-runner
 #     - Build ci-podman
 #     - Build claude-sandbox
 #     - Build opencode-sandbox
+#     - Build codex-sandbox
 #     - Build ci-openshell
 #     - Lint image scripts
 #     - Test image scripts
 #     - E2E claude-runner        (skipped on fork PRs, no secrets)
 #     - E2E opencode-runner      (skipped on fork PRs, no secrets)
+#     - E2E codex-runner         (skipped on fork PRs, no secrets)
 #     - E2E openshell-sandbox    (skipped on fork PRs, no secrets)
 #
 # Path overlap between the two image workflows:
@@ -70,9 +73,11 @@ merge_protections:
       # images.yml (builds)
       - check-success = Build claude-runner
       - check-success = Build opencode-runner
+      - check-success = Build codex-runner
       - check-success = Build ci-podman
       - check-success = Build claude-sandbox
       - check-success = Build opencode-sandbox
+      - check-success = Build codex-sandbox
       - check-success = Build ci-openshell
       # images.yml (lint + unit tests)
       - check-success = Lint image scripts
@@ -80,6 +85,7 @@ merge_protections:
       # images.yml (e2e)
       - check-success = E2E claude-runner
       - check-success = E2E opencode-runner
+      - check-success = E2E codex-runner
       - check-success = E2E openshell-sandbox
       - -draft
       - -conflict
@@ -143,9 +149,11 @@ merge_protections:
       # images.yml (builds)
       - check-success = Build claude-runner
       - check-success = Build opencode-runner
+      - check-success = Build codex-runner
       - check-success = Build ci-podman
       - check-success = Build claude-sandbox
       - check-success = Build opencode-sandbox
+      - check-success = Build codex-sandbox
       - check-success = Build ci-openshell
       # images.yml (lint + unit tests)
       - check-success = Lint image scripts
@@ -153,6 +161,7 @@ merge_protections:
       # images.yml (e2e)
       - check-success = E2E claude-runner
       - check-success = E2E opencode-runner
+      - check-success = E2E codex-runner
       - check-success = E2E openshell-sandbox
       - -draft
       - -conflict
@@ -209,9 +218,11 @@ merge_protections:
       # images.yml (builds)
       - check-success = Build claude-runner
       - check-success = Build opencode-runner
+      - check-success = Build codex-runner
       - check-success = Build ci-podman
       - check-success = Build claude-sandbox
       - check-success = Build opencode-sandbox
+      - check-success = Build codex-sandbox
       - check-success = Build ci-openshell
       # images.yml (lint + unit tests)
       - check-success = Lint image scripts
@@ -219,6 +230,7 @@ merge_protections:
       # images.yml (e2e)
       - check-success = E2E claude-runner
       - check-success = E2E opencode-runner
+      - check-success = E2E codex-runner
       - check-success = E2E openshell-sandbox
       - -draft
       - -conflict
@@ -272,9 +284,11 @@ merge_protections:
       # images.yml (builds)
       - check-success = Build claude-runner
       - check-success = Build opencode-runner
+      - check-success = Build codex-runner
       - check-success = Build ci-podman
       - check-success = Build claude-sandbox
       - check-success = Build opencode-sandbox
+      - check-success = Build codex-sandbox
       - check-success = Build ci-openshell
       # images.yml (lint + unit tests)
       - check-success = Lint image scripts
@@ -282,6 +296,7 @@ merge_protections:
       # images.yml (e2e)
       - check-success = E2E claude-runner
       - check-success = E2E opencode-runner
+      - check-success = E2E codex-runner
       - check-success = E2E openshell-sandbox
       - -draft
       - -conflict
@@ -336,9 +351,11 @@ merge_protections:
       # images.yml (builds)
       - check-success = Build claude-runner
       - check-success = Build opencode-runner
+      - check-success = Build codex-runner
       - check-success = Build ci-podman
       - check-success = Build claude-sandbox
       - check-success = Build opencode-sandbox
+      - check-success = Build codex-sandbox
       - check-success = Build ci-openshell
       # images.yml (lint + unit tests)
       - check-success = Lint image scripts
@@ -346,6 +363,7 @@ merge_protections:
       # images.yml (e2e)
       - check-success = E2E claude-runner
       - check-success = E2E opencode-runner
+      - check-success = E2E codex-runner
       - check-success = E2E openshell-sandbox
       - -draft
       - -conflict

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ Three **backends** provide execution environments:
 - **Podman** (default): Runs the agent in a Podman container. Simple, widely available.
 - **OpenShell**: Runs the agent in an [OpenShell](https://github.com/NVIDIA/OpenShell) sandbox with network policy enforcement and filesystem isolation.
 
-Two **harnesses** define which agent CLI to run:
+Three **harnesses** define which agent CLI to run:
 - **claude-code** (default): [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `stream-json` output format.
 - **opencode**: [OpenCode](https://github.com/anomalyco/opencode) with JSON event output format.
+- **codex**: [OpenAI Codex](https://developers.openai.com/codex/cli) with JSONL event output and native OpenTelemetry export. Unlike Claude Code and OpenCode, Codex has no project-provided image or build target; container runs must supply an image containing the `codex` binary through `--image` or `CODEX_CONTAINER_IMAGE`.
 
 ## Architecture
 
@@ -20,7 +21,7 @@ Two **harnesses** define which agent CLI to run:
 src/agentic_ci/
     cli.py              # Entry point, backend/harness selection, OTEL orchestration
     backend.py          # Backend ABC + shared stream processing
-    harness.py          # Harness ABC + ClaudeCode/OpenCode implementations
+    harness.py          # Harness ABC + ClaudeCode/OpenCode/Codex implementations
     backends/
         __init__.py     # Backend factory (create_backend)
         local.py        # LocalBackend — direct execution (no container)
@@ -32,7 +33,7 @@ src/agentic_ci/
             policy.py   # Policy resolution + built-in default
     config.py           # Project config loader (.agentic-ci/config.yml)
     plugins.py          # Plugin/skill install (build-time) and filtering (runtime)
-    stream.py           # Stream parsers for Claude Code and OpenCode output
+    stream.py           # Stream parsers for Claude Code, OpenCode, and Codex output
     otel.py             # OTLP collector + token/cost summary
 ```
 
@@ -40,9 +41,9 @@ src/agentic_ci/
 
 - **`backend.py`**: Abstract `Backend` class with `setup()` and `run()` methods. Shared `_process_stream()` helper reads output from a subprocess through the harness's stream processor. When `output_file` is set on the backend, `_process_stream()` tees every raw output line to disk for transcript capture.
 
-- **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`.
+- **`harness.py`**: Abstract `Harness` class encapsulating agent-specific CLI args, env vars, credential paths, and stream parsing. Implementations: `ClaudeCodeHarness`, `OpenCodeHarness`, `CodexHarness`.
 
-- **`plugins.py`**: Build-time plugin installation (`install_claude_plugins`, `install_opencode_skills`) and runtime filtering (`enable_plugins`). At build time, installs skills from the skills-registry marketplace into the container image and writes a plugin-to-skill manifest. At runtime, `AGENT_ENABLED_PLUGINS` controls which plugins are active: Claude Code disables plugins in `settings.json`; OpenCode deletes unwanted skill directories from disk (since `permission.skill.deny` doesn't prevent loading with `--dangerously-skip-permissions`).
+- **`plugins.py`**: Build-time plugin installation (`install_claude_plugins`, `install_opencode_skills`, `install_codex_plugins`) and runtime filtering (`enable_plugins`). At build time, installs plugins or skills from the skills-registry marketplace into the container image and writes a plugin-to-skill manifest. At runtime, `AGENT_ENABLED_PLUGINS` controls which plugins are active: Claude Code disables plugins in `settings.json`; OpenCode deletes unwanted skill directories from disk; Codex removes unwanted native plugins and manifest-managed compatibility skills while preserving unmanaged personal skills.
 
 - **`backends/podman.py`**: `PodmanBackend` — runs the agent in a `podman run` container. Bind-mounts the workdir into the container at `/workspace`, so changes are visible on the host immediately. Mounts gcloud credentials as read-only volumes. Uses `--network host` when OTEL is enabled.
 
@@ -50,14 +51,14 @@ src/agentic_ci/
 
 - **`backends/openshell/`**: `OpenShellBackend` — runs the agent in an OpenShell sandbox. Uploads the workdir into the sandbox on `setup()` and downloads it back after `run()` completes. Only changes inside the workdir are reflected back to the host; files written elsewhere in the sandbox are not retrieved. Manages gateway lifecycle, sandbox creation with network policy, credential injection, and setup steps. Submodules: `gateway.py`, `sandbox.py`, `policy.py`.
 
-- **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. Both produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
+- **`stream.py`**: `ClaudeCodeStreamProcessor` parses Claude Code's `stream-json` output. `OpenCodeStreamProcessor` parses OpenCode's JSON event output. `CodexStreamProcessor` parses Codex JSONL events. All produce human-readable CI logs with colored ANSI output, tool call summaries, and token display.
 
 - **`otel.py`**: Lightweight OTLP HTTP/JSON receiver (stdlib `http.server`) that logs payloads to JSONL, tracks token usage over a sliding window, and prints a token/cost summary.
 
 ### Key
 
-- **Authentication** is auto-detected: if `ANTHROPIC_API_KEY` is set, direct API auth is used (no gcloud credentials needed); otherwise Vertex AI with gcloud ADC files.
-- **OTEL collector runs on the host**, not inside the sandbox/container. Currently only Claude Code emits OTEL metrics; OpenCode provides token/cost data via its JSON output.
+- **Authentication** is harness-specific: Claude Code uses `ANTHROPIC_API_KEY` when set and otherwise Vertex AI with gcloud ADC files; Codex uses `OPENAI_API_KEY` or local `$CODEX_HOME/auth.json` login state. The OpenShell backend requires `OPENAI_API_KEY`.
+- **OTEL collector runs on the host**, not inside the sandbox/container. Claude Code and Codex export OTEL data; OpenCode provides token/cost data via its JSON output.
 
 ## Container images
 
@@ -171,7 +172,7 @@ When fixing a bug or adding a feature that changes failure modes, update `.claud
 When investigating this repo specifically, focus on these areas by symptom:
 
 - **Container failed**: Check `backends/podman.py` or `backends/openshell/` for container launch logic. Check `harness.py` for agent CLI argument construction. Check `cli.py` for credential and OTEL setup. Check `stream.py` if output parsing failed.
-- **Skills not found / wrong skills loaded**: Check `plugins.py` for install-time skill discovery (`install_opencode_skills` fallback dirs, manifest generation) and runtime filtering (`enable_plugins` reads `AGENT_ENABLED_PLUGINS`). Check `harness.py` `build_env_args()` and `build_env_script_lines()` for env var forwarding to the container. For OpenCode, filtering deletes unwanted skill directories from disk; for Claude Code, it disables plugins in `settings.json`.
+- **Skills not found / wrong skills loaded**: Check `plugins.py` for install-time skill discovery (`install_opencode_skills` fallback dirs, `install_codex_plugins` native/compatibility paths, manifest generation) and runtime filtering (`enable_plugins` reads `AGENT_ENABLED_PLUGINS`). Check `harness.py` `build_env_args()` and `build_env_script_lines()` for env var forwarding to the container. Claude Code disables unwanted plugins in `settings.json`; OpenCode deletes unwanted skill directories; Codex removes unwanted native plugins and only manifest-managed compatibility skills.
 - **Skill engine failure**: Check `skill.py` for the `run_skill()` flow: pre-gates, container launch, post-gates, verdict loading. Check which phase returned an error.
 - **MR/PR operations failed**: Check `forge.py` and the `forge` CLI subcommands. Check `git.py` for clone/push/branch operations. Check error handling in `ForgeError`.
 - **Gate framework issues**: Check `gates.py` for the gate registry and execution order. Check if a gate was added or changed that altered behavior. Gates run as pre/post hooks around the agent; the wiring is in the calling repo (autofix), but the gate implementations may be here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Three **backends** provide execution environments:
 Three **harnesses** define which agent CLI to run:
 - **claude-code** (default): [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `stream-json` output format.
 - **opencode**: [OpenCode](https://github.com/anomalyco/opencode) with JSON event output format.
-- **codex**: [OpenAI Codex](https://developers.openai.com/codex/cli) with JSONL event output and native OpenTelemetry export. Unlike Claude Code and OpenCode, Codex has no project-provided image or build target; container runs must supply an image containing the `codex` binary through `--image` or `CODEX_CONTAINER_IMAGE`.
+- **codex**: [OpenAI Codex](https://developers.openai.com/codex/cli) with JSONL event output and native OpenTelemetry export.
 
 ## Architecture
 
@@ -80,6 +80,10 @@ images/
       Containerfile.openshell       — OpenCode sandbox image (OpenShell); builds
                                       on the agentic base image
       opencode.json                 — Seed config for CI headless mode
+    codex/
+      Containerfile                 — Codex runner image
+      Containerfile.openshell       — Codex sandbox image (OpenShell); builds
+                                      on the agentic base image
   ci/
     Containerfile.podman            — CI environment image (podman + tools, UBI10)
     Containerfile.openshell         — CI environment image (OpenShell + podman, UBI9)
@@ -94,17 +98,18 @@ runtime from `quay.io/opendatahub/odh-openshell-supervisor`. The
 OpenShell-path sandbox images (`Containerfile.openshell`) are UBI9; the
 podman-path images stay on UBI10.
 
-Both sandbox images build `FROM` their respective agentic base images
-(`quay.io/aipcc/base-images/agentic/claude-code` and
-`quay.io/aipcc/base-images/agentic/opencode`, pinned by digest). These
+All three sandbox images build `FROM` their respective agentic base images
+(`quay.io/aipcc/base-images/agentic/claude-code`,
+`quay.io/aipcc/base-images/agentic/opencode`, and
+`quay.io/aipcc/base-images/agentic/codex`, pinned by digest). These
 base images ship the agent binary and Node on UBI9; the Containerfiles
 layer the agentic-ci tooling (Python, uv, forge CLIs, agentic-ci, skills)
 on top.
 
 The runner-base Containerfile (`images/runner/shared/Containerfile.base`)
-is pre-built as `localhost/base:latest` before building the Claude and
-OpenCode runner images. It is NOT published to any registry as a
-standalone image. Do not add a CI job to push runner-base separately.
+is pre-built as `localhost/base:latest` before building the Claude,
+OpenCode, and Codex runner images. It is NOT published to any registry as
+a standalone image. Do not add a CI job to push runner-base separately.
 
 ### Building locally
 
@@ -115,9 +120,11 @@ Log in before building them: `podman login quay.io`
 make base-build              # build runner base image locally
 make claude-build            # build Claude Code runner image (includes base)
 make opencode-build          # build OpenCode runner image (includes base)
+make codex-build             # build Codex runner image (includes base)
 make ci-build                # build CI podman image
 make openshell-claude-build  # build Claude sandbox (builds on the agentic base image)
 make openshell-opencode-build # build OpenCode sandbox (builds on the agentic base image)
+make openshell-codex-build   # build Codex sandbox (builds on the agentic base image)
 make openshell-ci-build      # build OpenShell CI image
 make image-lint              # shellcheck + ruff on image scripts
 make image-test              # run image unit tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ full execution path with real containers and API calls:
 
 - `e2e-claude-runner.sh` -- Claude Code runner (podman backend)
 - `e2e-opencode-runner.sh` -- OpenCode runner (podman backend)
-- `e2e-local-runner.sh` -- Local backend (no container)
+- `e2e-local-runner.sh` -- Local backend, including Codex when credentials are available
 - `e2e-openshell-sandbox.sh` -- OpenShell sandbox backend
 - `test_mlflow_e2e.py` -- MLflow integration
 
@@ -62,7 +62,7 @@ Update the relevant docs when your PR changes user-facing behavior:
 
 ## Harness and Backend Parity
 
-agentic-ci supports multiple harnesses (Claude Code, OpenCode) and
+agentic-ci supports multiple harnesses (Claude Code, OpenCode, Codex) and
 backends (local, podman, OpenShell). When making changes to one, you
 must update the others to keep feature parity:
 
@@ -72,12 +72,14 @@ If you add a feature or fix to one harness, apply the equivalent
 change to all harnesses. For example:
 
 - A new CLI argument added to `ClaudeCodeHarness.build_args()` needs
-  the equivalent in `OpenCodeHarness.build_args()`.
+  the equivalent in `OpenCodeHarness.build_args()` and
+  `CodexHarness.build_args()` when the CLIs support it.
 - A new env var handled in one harness's `build_env_args()` must be
   handled in all.
 - Stream processor changes in `ClaudeCodeStreamProcessor` should have
-  the corresponding update in `OpenCodeStreamProcessor` when the
-  feature applies to both (e.g., token display, tool call summaries).
+  corresponding updates in `OpenCodeStreamProcessor` and
+  `CodexStreamProcessor` when the feature applies (e.g., token display,
+  tool call summaries).
 
 ### Backends
 
@@ -88,12 +90,15 @@ and all implementations must stay consistent:
   supported by the others, or explicitly documented as backend-specific
   with a clear reason.
 - Container image changes (Containerfiles) must be applied to both
-  Claude and OpenCode variants, plus their OpenShell sandbox variants.
+  repository-provided Claude and OpenCode variants, plus their OpenShell
+  sandbox variants. Codex images are user-supplied until a Codex runner
+  exists in `images/runner/`.
 
 ### Container images
 
-Runner images come in pairs (Claude + OpenCode) and optionally in
-OpenShell sandbox variants. When changing `images/runner/`:
+Repository-provided runner images come in pairs (Claude + OpenCode) and
+optionally in OpenShell sandbox variants. Codex runner images are currently
+user-supplied. When changing `images/runner/`:
 
 - Changes to `shared/Containerfile.base` affect all runners.
 - Changes specific to one runner (e.g., `claude-code/Containerfile`)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ bump-versions: ## Bump pinned dependency versions in Containerfiles
 check-versions: ## Check for available dependency updates
 	python3 scripts/bump-versions.py --check
 
+.PHONY: update-cost-map
+update-cost-map: ## Update bundled OpenAI pricing from LiteLLM main
+	uv run python scripts/update_litellm_cost_map.py
+
 .PHONY: image-lint
 image-lint: ## Run linting checks on image scripts
 	shellcheck --severity=warning images/runner/shared/*.sh tests/images/*.sh tests/e2e/*.sh

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ claude-build: base-build ## Build the Claude Code runner image locally
 opencode-build: base-build ## Build the OpenCode runner image locally
 	podman build -t localhost/opencode-runner:latest -f images/runner/opencode/Containerfile .
 
+.PHONY: codex-build
+codex-build: base-build ## Build the Codex runner image locally
+	podman build -t localhost/codex-runner:latest -f images/runner/codex/Containerfile .
+
 .PHONY: ci-build
 ci-build: ## Build the CI podman image locally
 	podman build -t ci-podman:latest -f images/ci/Containerfile.podman .
@@ -29,6 +33,10 @@ openshell-claude-build: ## Build the OpenShell Claude sandbox image locally (bui
 .PHONY: openshell-opencode-build
 openshell-opencode-build: ## Build the OpenShell OpenCode sandbox image locally (builds on the agentic base image, not openshell-base)
 	podman build -t localhost/opencode-sandbox:latest -f images/runner/opencode/Containerfile.openshell .
+
+.PHONY: openshell-codex-build
+openshell-codex-build: ## Build the OpenShell Codex sandbox image locally (builds on the agentic base image)
+	podman build -t localhost/codex-sandbox:latest -f images/runner/codex/Containerfile.openshell .
 
 .PHONY: openshell-ci-build
 openshell-ci-build: ## Build the OpenShell CI image locally
@@ -62,6 +70,10 @@ e2e-claude: ## Run Claude Code runner e2e tests
 .PHONY: e2e-opencode
 e2e-opencode: ## Run OpenCode runner e2e tests
 	bash tests/e2e/e2e-opencode-runner.sh
+
+.PHONY: e2e-codex
+e2e-codex: ## Run Codex runner e2e tests
+	bash tests/e2e/e2e-codex-runner.sh
 
 .PHONY: e2e-openshell
 e2e-openshell: ## Run OpenShell sandbox e2e tests

--- a/README.md
+++ b/README.md
@@ -237,6 +237,16 @@ invocation. An existing login under `CODEX_HOME` is also supported by the local
 backend. When an API key is present, agentic-ci uses Codex's non-interactive
 `login --with-api-key` flow before executing the prompt.
 
+Codex runs use `--approve-for-me` by default; they do not enable the dangerous
+approval/sandbox bypass or ephemeral mode. Sessions therefore remain available
+for follow-up turns. Pass additional Codex arguments after `--` and before the
+prompt is sent to Codex, for example:
+
+```bash
+agentic-ci run --backend local --harness codex \
+    "What unique fact did you remember?" -- resume --last
+```
+
 OpenShell currently follows agentic-ci's existing L4 API-key pattern: the real
 key is written into the sandbox environment and Codex login state. This matches
 the existing backend behavior but does not provide OpenShell's stronger L7

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![Docs](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://opendatahub-io.github.io/agentic-ci/)
 
 Run AI coding agents in sandboxed CI environments with streaming output
-and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode,
+and Codex)
 and isolation backends so you can choose the right tradeoff between
 simplicity and security.
 
@@ -25,7 +26,8 @@ Good for: running inside an existing CI container (e.g. a Prow step
 image) where the agent CLI is pre-installed and an extra isolation
 layer is unnecessary.
 
-Requires: the agent CLI on PATH (e.g. `claude`).
+Requires: the selected agent CLI on PATH (for example `claude`,
+`opencode`, or `codex`).
 
 ### Podman (default)
 
@@ -112,10 +114,10 @@ agentic-ci {setup,run,stop} [options]
 | Flag | Default | Description |
 |---|---|---|
 | `--backend` | `podman` | Sandbox backend to use |
-| `--harness` | `claude-code` | Agent harness (`claude-code` or `opencode`) |
+| `--harness` | `claude-code` | Agent harness (`claude-code`, `opencode`, or `codex`) |
 | `--workdir PATH` | `.` | Working directory to mount |
 | `--image IMAGE` | — | Container or sandbox base image |
-| `--model MODEL` | harness-dependent | Agent model (`run` only). Defaults to `claude-opus-4-6` for Claude Code, `google-vertex/claude-opus-4-6@default` for OpenCode |
+| `--model MODEL` | harness-dependent | Agent model (`run` only). Defaults to `claude-opus-4-6` for Claude Code, `google-vertex/claude-opus-4-6@default` for OpenCode, and `gpt-5.6-sol` for Codex |
 | `--keep` | off | Keep the sandbox running after the run completes (`run` only) |
 | `--no-streaming` | off | Disable parsed stream output; agent output is printed raw (`run` only) |
 | `--no-otel` | off | Disable OTEL telemetry collection (`run` only) |
@@ -124,7 +126,7 @@ agentic-ci {setup,run,stop} [options]
 | `--policy PATH` | — | OpenShell policy file override (`openshell` backend only) |
 | `--timeout SECS` | `1200` | Container timeout (`podman` backend only) |
 
-Extra arguments after the prompt are passed through to the Claude CLI.
+Extra arguments after the prompt are passed through to the selected agent CLI.
 
 ### Examples
 
@@ -195,8 +197,10 @@ every missing variable and which gate needs it.
 
 ## Credentials
 
-Two authentication modes are supported. The mode is auto-detected
-and logged at startup.
+Anthropic, Vertex AI, and OpenAI authentication are supported. The auth family
+follows the selected harness — Claude Code auto-detects Anthropic API key vs
+Vertex AI, while Codex always uses OpenAI — and the resolved mode is logged at
+startup.
 
 ### Anthropic API key (direct)
 
@@ -226,6 +230,34 @@ The **openshell** backend uploads the local ADC file
 (`~/.config/gcloud/application_default_credentials.json` or
 `GOOGLE_APPLICATION_CREDENTIALS`) into the sandbox.
 
+### OpenAI Codex
+
+For non-interactive Codex runs, set `OPENAI_API_KEY` for the single job or
+invocation. An existing login under `CODEX_HOME` is also supported by the local
+backend. When an API key is present, agentic-ci uses Codex's non-interactive
+`login --with-api-key` flow before executing the prompt.
+
+OpenShell currently follows agentic-ci's existing L4 API-key pattern: the real
+key is written into the sandbox environment and Codex login state. This matches
+the existing backend behavior but does not provide OpenShell's stronger L7
+credential isolation. A future change should migrate API-key providers together
+to profile-backed L7 inspection so sandboxes receive only opaque placeholders.
+
+```bash
+export OPENAI_API_KEY=...
+agentic-ci run --backend local --harness codex "Fix the bug"
+```
+
+Codex user configuration remains enabled so installed plugins and skills are
+available. During telemetry-enabled runs, agentic-ci supplies per-run Codex
+configuration overrides that export logs, metrics, and traces to its local
+OTLP collector. The completion summary estimates Codex cost from a generated
+snapshot of LiteLLM's OpenAI price map. Run `make update-cost-map` to resolve
+LiteLLM `main` to its current commit SHA and regenerate the bundled snapshot
+from that immutable revision. Set `AGENTIC_CI_LITELLM_COST_MAP` to a
+LiteLLM-format JSON price map to override the bundled data; unknown models still
+report token usage but do not produce a dollar estimate.
+
 ## Environment Variables
 
 | Variable | Default | Description |
@@ -235,6 +267,11 @@ The **openshell** backend uploads the local ADC file
 | `CLAUDE_CONTAINER_IMAGE` | — | Default container image for Claude Code harness |
 | `OPENCODE_MODEL` | `google-vertex/claude-opus-4-6@default` | Default model for OpenCode harness (overridden by `--model`) |
 | `OPENCODE_CONTAINER_IMAGE` | — | Default container image for OpenCode harness |
+| `OPENAI_API_KEY` | — | OpenAI API key scoped to a non-interactive Codex run |
+| `CODEX_HOME` | `~/.codex` | Codex configuration, authentication, plugins, and skills directory |
+| `CODEX_MODEL` | `gpt-5.6-sol` | Default model for Codex harness (overridden by `--model`) |
+| `CODEX_CONTAINER_IMAGE` | — | Default container image for Codex harness |
+| `AGENTIC_CI_LITELLM_COST_MAP` | — | Optional path to a LiteLLM-format JSON model-price map for Codex cost estimates |
 | `ANTHROPIC_VERTEX_PROJECT_ID` | — | Vertex AI project ID |
 | `GCP_PROJECT_ID` | — | Fallback for `ANTHROPIC_VERTEX_PROJECT_ID` |
 | `GOOGLE_CLOUD_PROJECT` | — | GCP project ID (OpenCode uses this before falling back to `ANTHROPIC_VERTEX_PROJECT_ID`) |
@@ -454,4 +491,3 @@ Or to preview with live reload:
 ```bash
 uv run --with '.[docs]' mkdocs serve
 ```
-

--- a/docs/backends/openshell.md
+++ b/docs/backends/openshell.md
@@ -12,7 +12,7 @@ a **provider** (credentials), and a **sandbox** (isolated execution
 environment). On each `agentic-ci run --backend openshell`, it:
 
 1. Starts the OpenShell gateway with TLS and mTLS auth
-2. Creates a GCP or Anthropic credential provider
+2. Creates a GCP, Anthropic, or OpenAI credential provider
 3. Creates a sandbox container from the specified image
 4. Applies a network policy and waits for it to activate
 5. Runs setup steps on the host (if configured in `.agentic-ci/config.yml`)
@@ -127,6 +127,28 @@ openshell provider create \
   --credential ANTHROPIC_API_KEY
 ```
 
+For Codex, agentic-ci creates an OpenAI provider and uses `OPENAI_API_KEY`.
+The current backend follows the same L4 pattern as its existing API-key path:
+the sandbox environment script contains the real key, and Codex's
+`login --with-api-key` command writes its login state before execution.
+
+```bash
+openshell provider create \
+  --name ci-gcp \
+  --type openai \
+  --credential OPENAI_API_KEY
+```
+
+<!-- markdownlint-disable MD046 -->
+!!! warning "L4 API-key exposure"
+
+    L4 CONNECT policy cannot replace credentials at the HTTP layer, so the
+    real API key is available inside the sandbox. This preserves the backend's
+    existing behavior but does not provide OpenShell's L7 credential-isolation
+    benefit. API-key providers should be migrated together to profile-backed
+    L7 inspection in a follow-up rather than changing only Codex here.
+<!-- markdownlint-enable MD046 -->
+
 ### Sandbox Lifecycle
 
 ```bash
@@ -138,7 +160,9 @@ openshell sandbox create \
   --no-tty \
   --provider ci-gcp \
   --from <SANDBOX_IMAGE> \
-  -- true
+  -- sleep infinity
+
+# Keep the sandbox's main process alive; agent commands run via exec.
 
 # Apply network policy and wait for the supervisor to compile and load it.
 # Built-in defaults are always included. If .agentic-ci/openshell-policy.yml

--- a/docs/image/skills.md
+++ b/docs/image/skills.md
@@ -3,7 +3,7 @@
 Skills from the
 [opendatahub-io/skills-registry](https://github.com/opendatahub-io/skills-registry)
 are pre-installed into every runner and sandbox image at build time. Each
-harness (Claude Code, OpenCode) uses a different installation mechanism
+harness (Claude Code, OpenCode, Codex) uses a different installation mechanism
 that matches the tool's native plugin system.
 
 ## Claude Code: plugin seed
@@ -88,8 +88,9 @@ RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registr
 2. Copies skill directories to `~/.config/opencode/skills/`.
    Uses explicit `skills` paths from the marketplace entry when present
    (e.g. `"skills": ["./helpers/skills"]` for `odh-ai-helpers`), otherwise
-   falls back to standard paths (`.claude/skills/`, `.opencode/skills/`,
-   `skills/`).
+   falls back to standard paths (`.claude/skills/`, `.agents/skills/`,
+   `.opencode/skills/`, `skills/`). The `.agents/skills/` fallback applies
+   to OpenCode installs as well as Codex compatibility installs.
 3. Records the plugin→skill mapping in the
    [plugin-skills manifest](#plugin-skills-manifest).
 
@@ -110,6 +111,22 @@ RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registr
 All skills are flat in one directory — no plugin namespacing. OpenCode
 discovers them by scanning for `SKILL.md` files.
 
+## Codex: native plugins with legacy compatibility
+
+Codex has a native plugin and marketplace system. At build time,
+`agentic-ci install-plugins --harness codex --marketplace-json <path>` adds the
+marketplace with `codex plugin marketplace add`, installs its native Codex
+plugins, and records their bundled skills in the plugin-skills manifest.
+
+The existing skills registry also contains legacy Claude-compatible
+marketplaces whose packages do not yet include Codex plugin manifests. If
+Codex reports no native packages for such a marketplace, agentic-ci clones the
+entries and installs their skills under `$CODEX_HOME/skills`.
+
+agentic-ci does not yet provide an `images/runner/codex` image. Codex runner
+images are user-supplied through `--image` or `CODEX_CONTAINER_IMAGE` and must
+include the `codex` binary until that directory exists.
+
 ## Plugin-skills manifest
 
 Both install scripts generate a manifest at
@@ -125,8 +142,8 @@ plugin names to the skills they contain:
 ```
 
 For Claude Code, the manifest is informational (debugging, auditing).
-For OpenCode, the manifest is functional — `enable-plugins` uses it to
-apply per-skill filtering at runtime (see below).
+For OpenCode and Codex, the manifest is functional — `enable-plugins` uses it
+to apply per-skill filtering at runtime (see below).
 
 ## Filtering plugins at runtime
 
@@ -154,9 +171,13 @@ to use:
 reads this at startup and skips disabled plugins.
 
 **OpenCode** (`AGENT_TOOL=opencode`): Reads the plugin-skills manifest
-to find which skills belong to unwanted plugins, then writes
-`"skill-name": "deny"` entries to `opencode.json`'s `permission.skill`
-section. OpenCode hides denied skills from the agent.
+to find which skills belong to unwanted plugins, then removes unwanted skill
+directories from the ephemeral runtime filesystem before OpenCode starts.
+
+**Codex** (`AGENT_TOOL=codex`): Uses `codex plugin list/remove` for native
+plugins and removes only manifest-managed compatibility skills for unwanted
+plugins from `$CODEX_HOME/skills`. Personal skills that are not managed by the
+manifest are left intact.
 
 ### Error handling
 
@@ -175,7 +196,7 @@ Plugin installation and filtering are `agentic-ci` subcommands
 
 | Command | When | Purpose |
 |---------|------|---------|
-| `agentic-ci install-plugins` | Build time | Install plugins for Claude Code (reads seed dir) or OpenCode (`--harness opencode --marketplace-json <path>`) |
+| `agentic-ci install-plugins` | Build time | Install plugins for Claude Code (reads seed dir), OpenCode, or Codex (`--marketplace-json <path>`) |
 | `agentic-ci enable-plugins` | Runtime | Filter active plugins based on `AGENT_ENABLED_PLUGINS` |
 
 The container entrypoint (`images/runner/shared/entrypoint.sh`) calls

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,15 @@
 # agentic-ci
 
 Run AI coding agents in sandboxed CI environments with streaming output
-and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode)
+and telemetry. Supports multiple agent harnesses (Claude Code, OpenCode,
+and Codex)
 and isolation backends so you can choose the right tradeoff between
 simplicity and security.
 
 ## Features
 
 - **Multiple backends**: Local (direct execution), Podman containers, or OpenShell sandboxes with network policy enforcement
-- **Multiple harnesses**: Claude Code and OpenCode agent CLIs
+- **Multiple harnesses**: Claude Code, OpenCode, and Codex agent CLIs
 - **Setup steps**: Pre-sandbox dependency installation for repos that need it
 - **Streaming output**: Colored, parsed CI logs with tool call summaries and token tracking
 - **OTEL telemetry**: Token usage, cost tracking, and metrics collection

--- a/docs/otel-architecture.md
+++ b/docs/otel-architecture.md
@@ -259,6 +259,14 @@ token volume (input + output + cache). Each span gets an
 MLflow aggregates these into `mlflow.trace.cost`. The per-span split is
 an approximation; the session total is exact.
 
+Codex emits token counts in `codex.sse_event` `response.completed` log events,
+but does not emit a dollar amount. The collector estimates Codex cost with a
+generated snapshot of LiteLLM's OpenAI pricing map, including cache and
+service-tier rates. `make update-cost-map` refreshes the snapshot from an exact
+LiteLLM commit and stores that source SHA with the data. Deployments can point
+`AGENTIC_CI_LITELLM_COST_MAP` at another LiteLLM-format map. Unknown models
+retain token reporting but are omitted from the cost table.
+
 #### Query source
 
 Claude tags each API call with a `query_source` (e.g., `"sdk"`,

--- a/docs/otel-configuration.md
+++ b/docs/otel-configuration.md
@@ -52,6 +52,35 @@ via `write_sandbox_config()`.
 - `OTEL_METRIC_EXPORT_INTERVAL` — no OTel metrics to export
 - `OTEL_LOG_USER_PROMPTS` / `OTEL_LOG_TOOL_*` — Claude-specific flags
 
+## Codex
+
+Codex configures OTel through its `[otel]` configuration rather than standard
+OTel environment variables. For each run, the Codex harness passes `-c`
+overrides for three OTLP/HTTP JSON exporters:
+
+| Signal | Endpoint |
+|--------|----------|
+| Logs | `http://...:{port}/v1/logs` |
+| Metrics | `http://...:{port}/v1/metrics` |
+| Traces | `http://...:{port}/v1/traces` |
+
+The log stream includes API requests, response events with token counts, tool
+decisions/results, and redacted prompt metadata. User prompt content remains
+disabled by default. The metrics stream includes Codex API, streaming, and tool
+counters and duration histograms. Exporters flush when Codex shuts down.
+
+Codex reports token usage rather than dollar cost. agentic-ci estimates USD
+cost from a generated snapshot of LiteLLM's OpenAI model-price map, including
+cache and `priority`/`flex` service-tier rates. `make update-cost-map` resolves
+LiteLLM `main` to an immutable commit SHA, fetches the map from that revision,
+and records the SHA alongside the generated pricing data. Set
+`AGENTIC_CI_LITELLM_COST_MAP` to a path containing a LiteLLM-format JSON map to
+override the bundled snapshot. Token usage is still shown when a model has no
+known price; the cost table omits that model.
+
+The endpoint host is backend-specific: loopback for local and host-networked
+Podman runs, and `host.openshell.internal` for OpenShell.
+
 ## Sandbox config
 
 The `opencode.json` config is written by `write_sandbox_config()` and
@@ -60,5 +89,6 @@ mounted into the container by the backend:
 - **Podman**: mounted as a read-only volume via `sandbox_config_mounts()`
 - **OpenShell**: uploaded and moved into place via `_upload_sandbox_config()`
 
-Claude Code does not require sandbox config for OTel — env vars are
-sufficient.
+Claude Code and Codex do not require a mounted sandbox config for OTel.
+Claude Code uses environment variables; Codex receives per-run CLI config
+overrides.

--- a/images/runner/codex/Containerfile
+++ b/images/runner/codex/Containerfile
@@ -1,0 +1,27 @@
+FROM localhost/base:latest
+
+ARG CODEX_VERSION=0.147.0
+
+USER root
+
+# nodejs is needed by Codex CLI
+RUN microdnf install -y --nodocs nodejs npm && microdnf clean all
+
+RUN npm install -g @openai/codex@${CODEX_VERSION} \
+    && ln -sf /usr/local/lib/node_modules/@openai/codex/bin/codex.js /usr/local/bin/codex \
+    && chmod +x /usr/local/bin/codex
+
+RUN mkdir -p /home/agent-ci/.codex \
+    && chown -R agent-ci:agent-ci /home/agent-ci/.codex
+
+USER agent-ci
+RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registry.git /tmp/skills-registry \
+    && agentic-ci install-plugins --harness codex \
+       --marketplace-json /tmp/skills-registry/.claude-plugin/marketplace.json \
+    && rm -rf /tmp/skills-registry
+
+ENV AGENT_TOOL=codex
+ENV CODEX_HOME=/home/agent-ci/.codex
+WORKDIR /home/agent-ci
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["codex"]

--- a/images/runner/codex/Containerfile.openshell
+++ b/images/runner/codex/Containerfile.openshell
@@ -1,0 +1,118 @@
+# Codex sandbox image for OpenShell.
+#
+# Use with: agentic-ci run --backend openshell --image <this-image> ...
+# Or:       openshell sandbox create --from <this-image> --provider ...
+#
+# Builds on the agentic base image
+# (quay.io/aipcc/base-images/agentic/codex), which provides the Codex CLI
+# (installed via npm at /usr/local/bin/codex) and Node on UBI9 with the
+# /sandbox layout, the sandbox user with a non-root primary group, and iproute
+# for OpenShell's netns setup. This Containerfile layers the agentic-ci tooling
+# (Python, uv, forge CLIs, agentic-ci) on top. The base image is pinned by
+# digest (Renovate keeps it current).
+#
+# Build:
+#   podman build -t openshell-codex -f images/runner/codex/Containerfile.openshell .
+#
+# x86_64 only.
+
+ARG CODEX_BASE_IMAGE=quay.io/aipcc/base-images/agentic/codex:0.0.1-1787088146@sha256:48b98c000cf4cd981b6db678a8a8974dcd8e0eab40d581f76fffbff56a8801f1
+FROM ${CODEX_BASE_IMAGE}
+
+ARG UV_VERSION=0.12.3
+ARG UV_SHA256=0643b9fb8c9fb27458e709ce6ff939695013c41975ff7b02d3f3b138d8d4bdb3
+
+ARG SHELLCHECK_VERSION=0.11.0
+ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
+
+ARG GH_VERSION=2.97.0
+ARG GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
+
+ARG GLAB_VERSION=1.113.0
+ARG GLAB_SHA256=c265589fb2018f310b6a27df9356efee42991f858e7e3a5fa232228a13b47467
+
+USER root
+
+# System packages the base image doesn't provide. The base already ships
+# git, node, tar, curl, gzip, findutils, shadow-utils and iproute.
+RUN microdnf install -y --nodocs \
+        python3.12 \
+        python3.12-pip \
+        jq \
+        make \
+        which \
+        xz \
+    && microdnf clean all
+
+# UBI9 defaults python3 to 3.9; agentic-ci needs 3.10+, so make 3.12 the
+# default python3/python via /usr/local/bin (ahead of /usr/bin on PATH).
+RUN ln -sf /usr/bin/python3.12 /usr/local/bin/python3 \
+    && ln -sf /usr/bin/python3.12 /usr/local/bin/python
+
+# uv (pinned)
+RUN curl -fsSL -o /tmp/uv.tar.gz \
+        "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-musl.tar.gz" \
+    && echo "${UV_SHA256}  /tmp/uv.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/uv.tar.gz -C /tmp \
+    && mv /tmp/uv-x86_64-unknown-linux-musl/uv /usr/local/bin/uv \
+    && chmod +x /usr/local/bin/uv \
+    && rm -rf /tmp/uv.tar.gz /tmp/uv-x86_64-unknown-linux-musl
+
+# GitHub CLI (pinned)
+RUN curl -fsSL -o /tmp/gh.tar.gz \
+        "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GH_SHA256}  /tmp/gh.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/gh.tar.gz -C /tmp \
+    && mv /tmp/gh_${GH_VERSION}_linux_amd64/bin/gh /usr/local/bin/gh \
+    && chmod +x /usr/local/bin/gh \
+    && rm -rf /tmp/gh.tar.gz /tmp/gh_${GH_VERSION}_linux_amd64
+
+# GitLab CLI (pinned)
+RUN curl -fsSL -o /tmp/glab.tar.gz \
+        "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/glab_${GLAB_VERSION}_linux_amd64.tar.gz" \
+    && echo "${GLAB_SHA256}  /tmp/glab.tar.gz" | sha256sum -c - \
+    && tar -xzf /tmp/glab.tar.gz -C /tmp \
+    && mv /tmp/bin/glab /usr/local/bin/glab \
+    && chmod +x /usr/local/bin/glab \
+    && rm -rf /tmp/glab.tar.gz /tmp/bin
+
+# ShellCheck (pinned)
+RUN curl -fsSL -o /tmp/shellcheck.tar.xz \
+        "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+    && echo "${SHELLCHECK_SHA256}  /tmp/shellcheck.tar.xz" | sha256sum -c - \
+    && tar -xJf /tmp/shellcheck.tar.xz -C /tmp \
+    && mv /tmp/shellcheck-v${SHELLCHECK_VERSION}/shellcheck /usr/local/bin/shellcheck \
+    && chmod +x /usr/local/bin/shellcheck \
+    && rm -rf /tmp/shellcheck.tar.xz /tmp/shellcheck-v${SHELLCHECK_VERSION}
+
+COPY images/runner/shared/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY pyproject.toml README.md /tmp/agentic-ci/
+COPY src/ /tmp/agentic-ci/src/
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && uv pip install --system --python python3.12 --no-cache /tmp/agentic-ci ruff==0.16.3 \
+    && rm -rf /tmp/agentic-ci \
+    && install -d -m 755 -o sandbox -g sandbox /usr/local/share/agentic-ci
+
+# Sandbox home directories. The base image provides the sandbox user
+# (uid 1001, with the dedicated sandbox group) and /sandbox home;
+# create the dirs agentic-ci and Codex expect.
+USER sandbox
+RUN mkdir -p /sandbox/.local/bin /sandbox/.codex /sandbox/.claude /sandbox/.agents
+COPY --chown=sandbox:sandbox images/runner/shared/AGENTS.openshell.md /sandbox/AGENTS.md
+RUN ln -s AGENTS.md /sandbox/CLAUDE.md \
+    && ln -s ../AGENTS.md /sandbox/.claude/CLAUDE.md
+ENV PATH="/sandbox/.local/bin:${PATH}"
+
+ENV AGENT_TOOL=codex
+ENV CODEX_HOME=/sandbox/.codex
+
+# Install skills from the skills-registry marketplace into Codex's
+# skills/plugins dir and write the plugin manifest.
+RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registry.git /tmp/skills-registry \
+    && agentic-ci install-plugins --harness codex \
+       --marketplace-json /tmp/skills-registry/.claude-plugin/marketplace.json \
+    && rm -rf /tmp/skills-registry
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["codex"]
+WORKDIR /sandbox

--- a/images/runner/shared/entrypoint.sh
+++ b/images/runner/shared/entrypoint.sh
@@ -69,6 +69,10 @@ _detect_tool() {
         opencode)
             export OPENCODE_DISABLE_AUTOUPDATE=1
             ;;
+        codex)
+            # Codex has no auto-update env var. CodexHarness passes the native
+            # check_for_update_on_startup=false CLI config override instead.
+            ;;
         *)
             if [[ "${AGENT_TOOL:-}" == "claude" ]]; then
                 export DISABLE_AUTOUPDATER=1
@@ -108,7 +112,7 @@ agentic-ci enable-plugins
 # the entrypoint to prepend the tool command (matching the runner image
 # behavior where the entrypoint always prepends the agent command).
 case "${1:-}" in
-    claude|claude-code|opencode|bash|sh|true)
+    claude|claude-code|opencode|codex|bash|sh|true)
         exec "$@"
         ;;
     *)

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,8 @@
       "images/runner/claude-code/Containerfile.openshell",
       "images/runner/opencode/Containerfile",
       "images/runner/opencode/Containerfile.openshell",
+      "images/runner/codex/Containerfile",
+      "images/runner/codex/Containerfile.openshell",
       "images/ci/Containerfile.podman",
       "images/ci/Containerfile.openshell"
     ],
@@ -32,7 +34,8 @@
       "matchDatasources": ["docker"],
       "matchPackageNames": [
         "quay.io/aipcc/base-images/agentic/opencode",
-        "quay.io/aipcc/base-images/agentic/claude-code"
+        "quay.io/aipcc/base-images/agentic/claude-code",
+        "quay.io/aipcc/base-images/agentic/codex"
       ],
       "minimumReleaseAge": "0 days"
     },
@@ -48,6 +51,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -61,7 +65,8 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/opencode/Containerfile\\.openshell$"
+        "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ARG SHELLCHECK_VERSION=(?<currentValue>[^\\n]+)"],
       "depNameTemplate": "koalaman/shellcheck",
@@ -74,6 +79,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -88,6 +94,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -148,7 +155,8 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
-        "^images/runner/opencode/Containerfile\\.openshell$"
+        "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ruff==(?<currentValue>[^\\s]+)"],
       "depNameTemplate": "ruff",
@@ -159,6 +167,7 @@
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
         "^images/runner/opencode/Containerfile\\.openshell$",
+        "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
         "^images/ci/Containerfile\\.openshell$"
       ],
@@ -191,6 +200,15 @@
         "^images/runner/opencode/Containerfile\\.openshell$"
       ],
       "matchStrings": ["ARG OPENCODE_BASE_IMAGE=(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^images/runner/codex/Containerfile\\.openshell$"
+      ],
+      "matchStrings": ["ARG CODEX_BASE_IMAGE=(?<depName>[^:@\\s]+):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]+)"],
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-(?<build>\\d+)$"
     }

--- a/scripts/update_litellm_cost_map.py
+++ b/scripts/update_litellm_cost_map.py
@@ -109,6 +109,14 @@ def write_snapshot(snapshot: dict[str, Any], output: Path) -> None:
     )
 
 
+def display_output_path(output: Path) -> Path:
+    """Return a concise output path without rejecting external destinations."""
+    try:
+        return output.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        return output
+
+
 def main() -> None:
     """Generate the bundled cost map."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -120,7 +128,7 @@ def main() -> None:
     snapshot = build_snapshot(fetch_cost_map(commit), commit)
     write_snapshot(snapshot, args.output)
     print(
-        f"Updated {args.output.relative_to(REPO_ROOT)} from LiteLLM {commit} "
+        f"Updated {display_output_path(args.output)} from LiteLLM {commit} "
         f"({len(snapshot['models'])} OpenAI models)"
     )
 

--- a/scripts/update_litellm_cost_map.py
+++ b/scripts/update_litellm_cost_map.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Generate agentic-ci's bundled OpenAI pricing snapshot from LiteLLM."""
+
+import argparse
+import json
+import os
+import re
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+import requests
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_OUTPUT = REPO_ROOT / "src" / "agentic_ci" / "data" / "litellm_openai_cost_map.json"
+LITELLM_REPOSITORY = "BerriAI/litellm"
+LITELLM_COST_MAP_PATH = "model_prices_and_context_window.json"
+GITHUB_API_ROOT = "https://api.github.com"
+RAW_GITHUB_ROOT = "https://raw.githubusercontent.com"
+MINIMUM_SOURCE_MODELS = 1_000
+MINIMUM_OPENAI_MODELS = 100
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+def _request_json(url: str) -> Any:
+    """Fetch and decode a JSON document."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "agentic-ci-cost-map-generator/1.0",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and url.startswith(GITHUB_API_ROOT):
+        headers["Authorization"] = f"Bearer {token}"
+    response = requests.get(url, headers=headers, timeout=30)
+    response.raise_for_status()
+    return response.json()
+
+
+def resolve_commit(ref: str) -> str:
+    """Resolve a LiteLLM branch, tag, or SHA to an immutable commit SHA."""
+    encoded_ref = urllib.parse.quote(ref, safe="")
+    document = _request_json(f"{GITHUB_API_ROOT}/repos/{LITELLM_REPOSITORY}/commits/{encoded_ref}")
+    commit = document.get("sha") if isinstance(document, dict) else None
+    if not isinstance(commit, str) or SHA_PATTERN.fullmatch(commit) is None:
+        raise ValueError(f"GitHub returned an invalid commit SHA for LiteLLM ref {ref!r}")
+    return commit
+
+
+def fetch_cost_map(commit: str) -> dict[str, Any]:
+    """Fetch LiteLLM's cost map from an immutable commit."""
+    if SHA_PATTERN.fullmatch(commit) is None:
+        raise ValueError(f"Invalid LiteLLM commit SHA: {commit!r}")
+    document = _request_json(
+        f"{RAW_GITHUB_ROOT}/{LITELLM_REPOSITORY}/{commit}/{LITELLM_COST_MAP_PATH}"
+    )
+    if not isinstance(document, dict) or len(document) < MINIMUM_SOURCE_MODELS:
+        raise ValueError("LiteLLM cost map is missing or unexpectedly small")
+    return document
+
+
+def build_snapshot(source_map: dict[str, Any], commit: str) -> dict[str, Any]:
+    """Build a compact snapshot containing every OpenAI pricing entry."""
+    models: dict[str, dict[str, Any]] = {}
+    aliases: dict[str, dict[str, Any]] = {}
+
+    for model, raw_entry in source_map.items():
+        if not isinstance(raw_entry, dict) or raw_entry.get("litellm_provider") != "openai":
+            continue
+
+        entry = {
+            key: value
+            for key, value in raw_entry.items()
+            if "cost" in key or key in {"aliases", "litellm_provider"}
+        }
+        if not any(key.endswith("cost_per_token") or "cost_per_token_" in key for key in entry):
+            continue
+        models[model] = entry
+
+        raw_aliases = raw_entry.get("aliases", [])
+        if isinstance(raw_aliases, list):
+            for alias in raw_aliases:
+                if isinstance(alias, str) and alias not in source_map:
+                    aliases.setdefault(alias, entry)
+
+    for alias, entry in aliases.items():
+        models.setdefault(alias, entry)
+
+    if len(models) < MINIMUM_OPENAI_MODELS:
+        raise ValueError("LiteLLM cost map contains unexpectedly few OpenAI pricing entries")
+
+    return {
+        "source": {
+            "repository": f"https://github.com/{LITELLM_REPOSITORY}",
+            "path": LITELLM_COST_MAP_PATH,
+            "commit": commit,
+            "url": (f"{RAW_GITHUB_ROOT}/{LITELLM_REPOSITORY}/{commit}/{LITELLM_COST_MAP_PATH}"),
+        },
+        "models": models,
+    }
+
+
+def write_snapshot(snapshot: dict[str, Any], output: Path) -> None:
+    """Write the generated snapshot deterministically."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(snapshot, indent=2, sort_keys=True, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    """Generate the bundled cost map."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ref", default="main", help="LiteLLM branch, tag, or commit")
+    parser.add_argument("--output", type=Path, default=DEFAULT_OUTPUT)
+    args = parser.parse_args()
+
+    commit = resolve_commit(args.ref)
+    snapshot = build_snapshot(fetch_cost_map(commit), commit)
+    write_snapshot(snapshot, args.output)
+    print(
+        f"Updated {args.output.relative_to(REPO_ROOT)} from LiteLLM {commit} "
+        f"({len(snapshot['models'])} OpenAI models)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agentic_ci/backends/local.py
+++ b/src/agentic_ci/backends/local.py
@@ -27,6 +27,8 @@ class LocalBackend(Backend):
         self._extra_env = extra_env or {}
 
     def setup(self, otel_port=None):
+        env = {**os.environ, **self._extra_env}
+        self.harness.validate_credentials(env, allow_auth_file=True)
         log.section("Local backend (direct execution)")
         self._run_setup_steps()
 
@@ -45,14 +47,19 @@ class LocalBackend(Backend):
     ):
         log.section(f"Executing {self.harness.name} locally")
 
+        base_env = {**os.environ, **self._extra_env}
         env = {
-            **os.environ,
-            **self.harness.build_local_env(otel_port, otel_rate_file, traceparent=traceparent),
+            **base_env,
+            **self.harness.build_local_env(
+                otel_port,
+                otel_rate_file,
+                traceparent=traceparent,
+                env=base_env,
+            ),
             "AGENT_MODEL": model,
-            **self._extra_env,
         }
-
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        otel_endpoint = f"http://127.0.0.1:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         proc = subprocess.Popen(
             agent_args,

--- a/src/agentic_ci/backends/openshell/__init__.py
+++ b/src/agentic_ci/backends/openshell/__init__.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import shutil
 import subprocess
 import tempfile
 import threading
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from agentic_ci import log
@@ -63,6 +65,38 @@ def _token_keepalive(stop: threading.Event) -> None:
 _DEFAULT_MAX_RETRIES = "20"
 
 _OPENSHELL_HOST = "host.openshell.internal"
+_OPENAI_CREDENTIAL_ENV_VARS = frozenset({"OPENAI_API_KEY"})
+_OPENSHELL_STATE_ENV = "AGENTIC_CI_OPENSHELL_STATE"
+_DEFAULT_OPENSHELL_STATE = Path.home() / ".config" / "agentic-ci" / "openshell-sandbox.json"
+
+
+def _openshell_state_path() -> Path:
+    return Path(os.environ.get(_OPENSHELL_STATE_ENV, _DEFAULT_OPENSHELL_STATE))
+
+
+def _load_sandbox_identity() -> dict | None:
+    try:
+        data = json.loads(_openshell_state_path().read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _save_sandbox_identity(identity: dict) -> None:
+    state_path = _openshell_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(json.dumps(identity, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _clear_sandbox_identity() -> None:
+    try:
+        _openshell_state_path().unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _sandbox_identity(harness_name: str, image: str | None, auth_mode: str) -> dict:
+    return {"auth_mode": auth_mode, "harness": harness_name, "image": image}
 
 
 class OpenShellBackend(Backend):
@@ -99,19 +133,60 @@ class OpenShellBackend(Backend):
         self._extra_env = extra_env or {}
         self.approval_mode = approval_mode
 
+    def _merged_env(self):
+        return {**os.environ, **self._extra_env}
+
     def setup(self, otel_port=None):
+        env = self._merged_env()
+        auth_mode = self.harness.auth_mode_for_env(env)
+        provider.validate_credentials(auth_mode, env)
+
         if not gateway.is_running():
             log.section("Starting OpenShell gateway")
             gateway.start()
         else:
             log.section("OpenShell gateway already running")
 
-        log.section("Configuring provider")
-        provider.setup(auth_mode=self.harness.auth_mode)
+        sandbox_exists = sandbox.exists()
+        existing_provider = provider.provider_exists()
+        existing_auth_mode = None
+        if existing_provider:
+            existing_auth_mode = provider.auth_mode()
+            if existing_auth_mode is None:
+                raise RuntimeError(
+                    "Could not determine the existing OpenShell provider auth mode; "
+                    "run agentic-ci stop before switching harnesses"
+                )
 
-        if sandbox.exists():
-            log.section("Sandbox already exists")
-            return
+        if sandbox_exists:
+            if not existing_provider:
+                raise RuntimeError(
+                    "The existing OpenShell sandbox has no identifiable provider; "
+                    "run agentic-ci stop before switching harnesses"
+                )
+            identity = _load_sandbox_identity()
+            expected_identity = _sandbox_identity(self.harness.name, self.image, auth_mode)
+            if identity is None:
+                raise RuntimeError(
+                    "Could not determine the existing OpenShell sandbox identity; "
+                    "run agentic-ci stop before switching harnesses"
+                )
+            if existing_auth_mode == auth_mode and identity == expected_identity:
+                log.section("Sandbox already exists")
+                return
+
+            if existing_auth_mode != auth_mode:
+                log.section("Auth mode changed; recreating OpenShell sandbox and provider")
+            else:
+                log.section("Sandbox identity changed; recreating OpenShell sandbox")
+            sandbox.delete()
+            _clear_sandbox_identity()
+
+        if existing_provider and existing_auth_mode != auth_mode:
+            provider.delete()
+
+        log.section("Configuring provider")
+        provider.setup(auth_mode=auth_mode, env=env)
 
         image_info = f", image: {self.image}" if self.image else ""
         log.section(f"Creating sandbox ({image_info.lstrip(', ') or 'default image'})")
@@ -122,6 +197,7 @@ class OpenShellBackend(Backend):
             otel_port=otel_port,
             workdir=self.workdir,
             approval_mode=self.approval_mode,
+            auth_mode=auth_mode,
         )
 
         self._run_setup_steps()
@@ -130,6 +206,7 @@ class OpenShellBackend(Backend):
         sandbox.upload(self.workdir)
 
         self._upload_sandbox_config(otel_enabled=otel_port is not None)
+        _save_sandbox_identity(_sandbox_identity(self.harness.name, self.image, auth_mode))
 
     def _upload_sandbox_config(self, otel_enabled=False):
         """Write harness-specific config and upload it to the sandbox."""
@@ -149,8 +226,10 @@ class OpenShellBackend(Backend):
         try:
             if gateway.is_running() and sandbox.exists():
                 sandbox.delete()
+                _clear_sandbox_identity()
                 log.section("Sandbox deleted")
             else:
+                _clear_sandbox_identity()
                 log.section("No sandbox to stop")
         finally:
             gateway.stop()
@@ -166,8 +245,18 @@ class OpenShellBackend(Backend):
         extra_args=None,
         traceparent=None,
     ):
-        self._write_env_script(model, otel_port, otel_rate_file, traceparent=traceparent)
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        env = self._merged_env()
+        auth_mode = self.harness.auth_mode_for_env(env)
+        self._write_env_script(
+            model,
+            otel_port,
+            otel_rate_file,
+            traceparent=traceparent,
+            env=env,
+            auth_mode=auth_mode,
+        )
+        otel_endpoint = f"http://{_OPENSHELL_HOST}:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         workdir_name = os.path.basename(self.workdir)
         sandbox_workdir = f"/sandbox/{workdir_name}"
@@ -184,7 +273,7 @@ class OpenShellBackend(Backend):
 
         # The token-lapse race only affects the OpenShell gateway's minted
         # Vertex credential; the API-key auth path is unaffected.
-        if self.harness.auth_mode == "vertex":
+        if auth_mode == "vertex":
             log.section("Starting GCP token keepalive")
             keepalive = threading.Thread(
                 target=_token_keepalive, args=(stop_keepalive,), daemon=True
@@ -207,7 +296,15 @@ class OpenShellBackend(Backend):
             if keepalive:
                 keepalive.join(timeout=5)
 
-    def _write_env_script(self, model, otel_port=None, otel_rate_file=None, traceparent=None):
+    def _write_env_script(
+        self,
+        model,
+        otel_port=None,
+        otel_rate_file=None,
+        traceparent=None,
+        env=None,
+        auth_mode=None,
+    ):
         """Write env vars to a script inside the sandbox, sourced before the agent runs.
 
         Uses the harness's native env script (Vertex AI vars, API key, and
@@ -215,7 +312,13 @@ class OpenShellBackend(Backend):
         directly. The harness handles OTEL endpoint configuration using the
         gateway host address.
         """
-        lines = self.harness.build_env_script_lines(otel_port=otel_port, traceparent=traceparent)
+        env = self._merged_env() if env is None else env
+        auth_mode = self.harness.auth_mode_for_env(env) if auth_mode is None else auth_mode
+        lines = self.harness.build_env_script_lines(
+            otel_port=otel_port,
+            traceparent=traceparent,
+            env=env,
+        )
         if otel_port:
             # The harness sets the OTel endpoint to 10.200.0.1 (the gateway IP
             # used by the Podman backend). OpenShell sandboxes can't reach that
@@ -224,16 +327,24 @@ class OpenShellBackend(Backend):
         if not otel_port and self.harness.name == "Claude Code":
             lines.append("export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1")
 
-        if self.harness.auth_mode == "vertex":
-            max_retries = os.environ.get("CLAUDE_CODE_MAX_RETRIES", _DEFAULT_MAX_RETRIES)
+        if auth_mode == "vertex":
+            max_retries = env.get("CLAUDE_CODE_MAX_RETRIES", _DEFAULT_MAX_RETRIES)
             lines.append(f"export CLAUDE_CODE_MAX_RETRIES={shlex.quote(max_retries)}")
 
         for key, val in self._extra_env.items():
+            if auth_mode == "openai" and key in _OPENAI_CREDENTIAL_ENV_VARS:
+                continue
             lines.append(f"export {key}={shlex.quote(val)}")
 
         lines.append(f"export AGENT_MODEL={shlex.quote(model)}")
 
-        lines.append("agentic-ci enable-plugins")
+        lines.extend(
+            [
+                "if command -v agentic-ci >/dev/null 2>&1; then",
+                "    agentic-ci enable-plugins",
+                "fi",
+            ]
+        )
 
         script = "\n".join(lines) + "\n"
 

--- a/src/agentic_ci/backends/openshell/policy.py
+++ b/src/agentic_ci/backends/openshell/policy.py
@@ -21,11 +21,24 @@ DEFAULT_ENDPOINTS = [
     "*.gitlab.com:443:full",
     "pypi.org:443:read-only",
     "files.pythonhosted.org:443:read-only",
-    "aiplatform.googleapis.com:443:read-write",
-    "*.aiplatform.googleapis.com:443:read-write",
-    "oauth2.googleapis.com:443:read-write",
-    "api.anthropic.com:443:read-write",
 ]
+
+AUTH_ENDPOINTS = {
+    "vertex": [
+        "aiplatform.googleapis.com:443:read-write",
+        "*.aiplatform.googleapis.com:443:read-write",
+        "oauth2.googleapis.com:443:read-write",
+    ],
+    "api-key": [
+        "api.anthropic.com:443:read-write",
+    ],
+    "openai": [
+        "api.openai.com:443:read-write",
+        # Codex's ChatGPT backend API is served under chatgpt.com/backend-api.
+        # OpenShell policies match hosts, not URL paths.
+        "chatgpt.com:443:read-write",
+    ],
+}
 
 
 def _load_endpoints_from_file(path):
@@ -40,11 +53,11 @@ def _load_endpoints_from_file(path):
     return [str(ep) for ep in endpoints]
 
 
-def resolve_endpoints(flag_path=None, workdir="."):
+def resolve_endpoints(flag_path=None, workdir=".", auth_mode=None):
     """Resolve the endpoint list to use for policy update.
 
-    Merges the built-in defaults with extra endpoints from, in priority
-    order:
+    Merges the built-in defaults and endpoints required by *auth_mode* with
+    extra endpoints from, in priority order:
 
     1. Explicit ``--policy`` flag path
     2. ``.agentic-ci/openshell-policy.yml`` in *workdir*
@@ -66,6 +79,7 @@ def resolve_endpoints(flag_path=None, workdir="."):
     print(f"  Policy source: {source}", flush=True)
 
     endpoints = list(DEFAULT_ENDPOINTS)
+    endpoints.extend(AUTH_ENDPOINTS.get(auth_mode, []))
     seen = set(endpoints)
     for ep in extra:
         if ep not in seen:

--- a/src/agentic_ci/backends/openshell/provider.py
+++ b/src/agentic_ci/backends/openshell/provider.py
@@ -1,8 +1,9 @@
-"""OpenShell provider setup for GCP credential injection."""
+"""OpenShell credential provider setup."""
 
 import json
 import os
 import subprocess
+from collections.abc import Mapping
 
 from agentic_ci import log
 from agentic_ci.gcp import adc_path as _adc_path
@@ -11,7 +12,15 @@ from agentic_ci.gcp import read_credential_type as _adc_credential_type
 
 PROVIDER_NAME = "ci-gcp"
 
-_SECRET_PREFIXES = ("private_key=", "GCP_SA_ACCESS_TOKEN=")
+_SECRET_PREFIXES = ("private_key=", "GCP_SA_ACCESS_TOKEN=", "OPENAI_API_KEY=")
+_PROVIDER_AUTH_MODES = {
+    "google-cloud": "vertex",
+    "google-vertex-ai": "vertex",
+    "anthropic": "api-key",
+    "claude": "api-key",
+    "openai": "openai",
+    "codex": "openai",
+}
 
 
 def _run(args, **kwargs):
@@ -27,7 +36,7 @@ def _run(args, **kwargs):
     return subprocess.run(args, **kwargs)
 
 
-def setup(auth_mode):
+def setup(auth_mode, env: Mapping[str, str] | None = None):
     """Configure the OpenShell provider.
 
     Creates a google-cloud provider that injects GCP credentials into the
@@ -39,17 +48,27 @@ def setup(auth_mode):
     the provider is created bare and refresh is configured separately with
     the service account's email and private key.
 
-    For API key auth, creates an anthropic provider instead.
+    For Anthropic or OpenAI API key auth, creates the corresponding provider.
     """
+    credential_env = env if env is not None else os.environ
     if provider_exists():
         # NOTE: switching auth modes (e.g. Vertex → API key) between runs
         # is not supported. The existing provider is reused regardless of
         # its type. To switch, tear down the environment and start fresh.
         print(f"  Provider '{PROVIDER_NAME}' already exists", flush=True)
     elif auth_mode == "api-key":
-        _create_anthropic_provider()
+        _create_anthropic_provider(credential_env)
+    elif auth_mode == "openai":
+        _create_openai_provider(credential_env)
     else:
-        _create_gcp_provider()
+        _create_gcp_provider(credential_env)
+
+
+def validate_credentials(auth_mode, env: Mapping[str, str] | None = None):
+    """Validate credentials supported by the OpenShell provider."""
+    credential_env = env if env is not None else os.environ
+    if auth_mode == "openai" and not credential_env.get("OPENAI_API_KEY"):
+        raise RuntimeError("OpenShell Codex runs require OPENAI_API_KEY")
 
 
 def provider_exists():
@@ -62,8 +81,49 @@ def provider_exists():
     return result.returncode == 0
 
 
-def _create_anthropic_provider():
+def auth_mode():
+    """Return the auth mode represented by the persisted provider, if known."""
+    result = _run(
+        ["openshell", "provider", "list", "-o", "json"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode != 0:
+        return None
+
+    try:
+        provider_data = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError):
+        return None
+
+    if isinstance(provider_data, dict):
+        providers = provider_data.get("providers", provider_data.get("items", []))
+    else:
+        providers = provider_data
+    if not isinstance(providers, list):
+        return None
+
+    for persisted_provider in providers:
+        if not isinstance(persisted_provider, dict):
+            continue
+        if persisted_provider.get("name") != PROVIDER_NAME:
+            continue
+        provider_type = persisted_provider.get("type") or persisted_provider.get("provider_type")
+        return _PROVIDER_AUTH_MODES.get(provider_type)
+    return None
+
+
+def delete():
+    """Delete the persistent OpenShell provider."""
+    _run(["openshell", "provider", "delete", PROVIDER_NAME], check=True)
+
+
+def _create_anthropic_provider(env: Mapping[str, str] | None = None):
     print("  Creating Anthropic API key provider", flush=True)
+    kwargs: dict[str, object] = {"check": True}
+    if env is not None:
+        kwargs["env"] = {**os.environ, **env}
     _run(
         [
             "openshell",
@@ -76,21 +136,47 @@ def _create_anthropic_provider():
             "--credential",
             "ANTHROPIC_API_KEY",
         ],
+        **kwargs,
+    )
+
+
+def _create_openai_provider(env: Mapping[str, str] | None = None):
+    credential_env = env if env is not None else os.environ
+    api_key = credential_env.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OpenShell Codex runs require OPENAI_API_KEY")
+
+    print("  Creating OpenAI API key provider", flush=True)
+    process_env = {**os.environ, **credential_env}
+    _run(
+        [
+            "openshell",
+            "provider",
+            "create",
+            "--name",
+            PROVIDER_NAME,
+            "--type",
+            "openai",
+            "--credential",
+            "OPENAI_API_KEY",
+        ],
         check=True,
+        env=process_env,
     )
 
 
-def _create_gcp_provider():
-    project = os.environ.get(
+def _create_gcp_provider(env: Mapping[str, str] | None = None):
+    credential_env = env if env is not None else os.environ
+    project = credential_env.get(
         "GOOGLE_CLOUD_PROJECT",
-        os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+        credential_env.get("ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")),
     )
-    region = os.environ.get(
+    region = credential_env.get(
         "VERTEX_LOCATION",
-        os.environ.get("CLOUD_ML_REGION", "global"),
+        credential_env.get("CLOUD_ML_REGION", "global"),
     )
 
-    source = ensure_adc()
+    source = ensure_adc(credential_env)
     cred_type = _adc_credential_type()
 
     print(

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -58,8 +58,10 @@ def create(
         args.extend(["--approval-mode", approval_mode])
     if image:
         args.extend(["--from", image])
-    # Keep the sandbox's main process alive; agent commands run via exec.
-    args.extend(["--", "sleep", "infinity"])
+    # OpenShell keeps the sandbox after the initial command exits unless
+    # --no-keep is supplied.  Use a terminating command so `sandbox create`
+    # returns before subsequent commands are run via `sandbox exec`.
+    args.extend(["--", "true"])
     _run(args, check=True)
 
     if approval_mode:

--- a/src/agentic_ci/backends/openshell/sandbox.py
+++ b/src/agentic_ci/backends/openshell/sandbox.py
@@ -29,7 +29,14 @@ def exists():
     return result.returncode == 0
 
 
-def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_mode=None):
+def create(
+    image=None,
+    policy_path=None,
+    otel_port=None,
+    workdir=".",
+    approval_mode=None,
+    auth_mode=None,
+):
     """Create a persistent sandbox with the CI provider attached.
 
     The sandbox is created first, then the network policy is applied
@@ -51,7 +58,8 @@ def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_m
         args.extend(["--approval-mode", approval_mode])
     if image:
         args.extend(["--from", image])
-    args.extend(["--", "true"])
+    # Keep the sandbox's main process alive; agent commands run via exec.
+    args.extend(["--", "sleep", "infinity"])
     _run(args, check=True)
 
     if approval_mode:
@@ -69,10 +77,15 @@ def create(image=None, policy_path=None, otel_port=None, workdir=".", approval_m
             check=True,
         )
 
-    _apply_policy(policy_path, otel_port=otel_port, workdir=workdir)
+    _apply_policy(
+        policy_path,
+        otel_port=otel_port,
+        workdir=workdir,
+        auth_mode=auth_mode,
+    )
 
 
-def _apply_policy(policy_path, otel_port=None, workdir="."):
+def _apply_policy(policy_path, otel_port=None, workdir=".", auth_mode=None):
     """Apply network policy endpoints and wait for activation.
 
     Two-step process:
@@ -83,7 +96,7 @@ def _apply_policy(policy_path, otel_port=None, workdir="."):
        The google-cloud provider profile is endpointless, so the gateway
        withholds credentials unless the sandbox policy explicitly binds them.
     """
-    endpoints = resolve_endpoints(policy_path, workdir=workdir)
+    endpoints = resolve_endpoints(policy_path, workdir=workdir, auth_mode=auth_mode)
     if otel_port:
         endpoints.append(f"host.openshell.internal:{otel_port}:read-write")
     if not endpoints:
@@ -98,6 +111,8 @@ def _apply_policy(policy_path, otel_port=None, workdir="."):
         "/usr/local/bin/claude",
         "--binary",
         "/usr/local/bin/opencode",
+        "--binary",
+        "/usr/local/bin/codex",
     ]
     for ep in endpoints:
         args.extend(["--add-endpoint", ep])

--- a/src/agentic_ci/backends/podman.py
+++ b/src/agentic_ci/backends/podman.py
@@ -16,6 +16,9 @@ if TYPE_CHECKING:
     from agentic_ci.harness import Harness
 
 
+_OPENAI_CREDENTIAL_ENV_VARS = frozenset({"OPENAI_API_KEY"})
+
+
 class PodmanBackend(Backend):
     """Runs an AI agent inside a persistent Podman container.
 
@@ -41,8 +44,11 @@ class PodmanBackend(Backend):
         self._extra_env = extra_env or {}
 
     def setup(self, otel_port=None):
+        env = {**os.environ, **self._extra_env}
+        auth_mode = self.harness.auth_mode_for_env(env)
+        self.harness.validate_credentials(env)
         self._resolve_image()
-        if self.harness.auth_mode == "vertex":
+        if auth_mode == "vertex":
             self._resolve_credentials()
         self._resolve_sandbox_config(otel_enabled=otel_port is not None)
         self._run_setup_steps()
@@ -62,7 +68,7 @@ class PodmanBackend(Backend):
         else:
             log.detail("Container user", "rootless (userns keep-id)")
 
-        env_args = self._build_env_args()
+        env_args = self._build_env_args(env)
         vol_args = self._build_vol_args()
 
         user_args = (
@@ -105,7 +111,7 @@ class PodmanBackend(Backend):
             f"sleep {self.timeout}",
         ]
 
-        subprocess.run(cmd, check=True, capture_output=True)
+        subprocess.run(cmd, check=True, capture_output=True, env=env)
         log.section("Podman container started")
 
     def run(
@@ -119,11 +125,12 @@ class PodmanBackend(Backend):
         traceparent=None,
     ):
         if not self.is_running():
-            self.setup()
+            self.setup(otel_port=otel_port)
 
         log.section(f"Executing {self.harness.name} in container")
         otel_env = self.harness.build_otel_exec_env(otel_port, traceparent=traceparent)
-        agent_args = self.harness.build_args(prompt, model, extra_args)
+        otel_endpoint = f"http://127.0.0.1:{otel_port}" if otel_port else None
+        agent_args = self.harness.build_args(prompt, model, extra_args, otel_endpoint=otel_endpoint)
 
         proc = subprocess.Popen(
             [
@@ -226,10 +233,16 @@ class PodmanBackend(Backend):
 
         log.section(f"Credentials staged ({creds_source})")
 
-    def _build_env_args(self):
-        args = list(self.harness.build_env_args())
+    def _build_env_args(self, env=None):
+        args = list(self.harness.build_env_args(env))
+        credential_env = os.environ if env is None else env
+        openai_mode = self.harness.auth_mode_for_env(credential_env) == "openai"
         for key, val in self._extra_env.items():
-            args.extend(["--env", f"{key}={val}"])
+            if key in _OPENAI_CREDENTIAL_ENV_VARS:
+                if openai_mode and key not in args:
+                    args.extend(["--env", key])
+            else:
+                args.extend(["--env", f"{key}={val}"])
         return args
 
     def _resolve_sandbox_config(self, otel_enabled=False):

--- a/src/agentic_ci/cli.py
+++ b/src/agentic_ci/cli.py
@@ -70,6 +70,12 @@ def cmd_install_plugins(args):
             sys.exit(1)
         manifest = Path(args.manifest) if args.manifest else None
         plugins.install_opencode_skills(Path(args.marketplace_json), manifest_path=manifest)
+    elif harness_name == "codex":
+        if not args.marketplace_json:
+            print("ERROR: --marketplace-json is required for codex", file=sys.stderr)
+            sys.exit(1)
+        manifest = Path(args.manifest) if args.manifest else None
+        plugins.install_codex_plugins(Path(args.marketplace_json), manifest_path=manifest)
     else:
         print(f"ERROR: unknown harness {harness_name!r}", file=sys.stderr)
         sys.exit(1)
@@ -236,7 +242,7 @@ def main():
     common.add_argument("--image", default=None, metavar="IMAGE", help="Container/sandbox image")
     common.add_argument(
         "--harness",
-        choices=["claude-code", "opencode"],
+        choices=["claude-code", "opencode", "codex"],
         default="claude-code",
         help="AI agent harness (default: claude-code)",
     )
@@ -328,7 +334,7 @@ def main():
     )
     p_install.add_argument(
         "--harness",
-        choices=["claude-code", "opencode"],
+        choices=["claude-code", "opencode", "codex"],
         default=None,
         help="Harness to install for (default: from AGENT_TOOL env or claude-code)",
     )
@@ -374,7 +380,12 @@ def main():
 
     log.section(f"Backend: {args.backend}")
     log.detail("Harness", harness.name)
-    log.detail("Auth", "API key" if harness.auth_mode == "api-key" else "Vertex AI")
+    auth_label = {
+        "api-key": "Anthropic API key",
+        "openai": "OpenAI",
+        "vertex": "Vertex AI",
+    }.get(harness.auth_mode, harness.auth_mode)
+    log.detail("Auth", auth_label)
     log.detail("Workdir", os.path.abspath(args.workdir))
     backend = create_backend(
         args.backend,

--- a/src/agentic_ci/cost.py
+++ b/src/agentic_ci/cost.py
@@ -1,0 +1,154 @@
+"""Model pricing helpers for telemetry-derived cost estimates."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from functools import lru_cache
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+_CUSTOM_COST_MAP_ENV = "AGENTIC_CI_LITELLM_COST_MAP"
+_LARGE_CONTEXT_THRESHOLD = 272_000
+_BUNDLED_COST_MAP = "data/litellm_openai_cost_map.json"
+
+
+def _as_rate(value: Any) -> float | None:
+    """Convert a LiteLLM map value to a non-negative rate."""
+    if isinstance(value, bool):
+        return None
+    try:
+        rate = float(value)
+    except (TypeError, ValueError):
+        return None
+    return rate if rate >= 0 else None
+
+
+@lru_cache(maxsize=1)
+def _load_bundled_map() -> Mapping[str, Any]:
+    """Load the generated LiteLLM OpenAI pricing snapshot."""
+    try:
+        document = json.loads(files("agentic_ci").joinpath(_BUNDLED_COST_MAP).read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+    models = document.get("models") if isinstance(document, dict) else None
+    return models if isinstance(models, dict) else {}
+
+
+@lru_cache(maxsize=4)
+def _load_custom_map(path: str | None) -> Mapping[str, Any]:
+    """Load an optional LiteLLM-format model cost map."""
+    if not path:
+        return {}
+    try:
+        with Path(path).open(encoding="utf-8") as cost_file:
+            loaded = json.load(cost_file)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return loaded if isinstance(loaded, dict) else {}
+
+
+def _model_candidates(model: str) -> list[str]:
+    """Return likely LiteLLM keys for a Codex model name."""
+    candidates = [model]
+    if model.startswith("openai/"):
+        candidates.append(model.removeprefix("openai/"))
+    else:
+        candidates.append(f"openai/{model}")
+    if model.startswith("chatgpt/"):
+        candidates.append(model.removeprefix("chatgpt/"))
+    return list(dict.fromkeys(candidates))
+
+
+def _get_model_pricing(model: str) -> Mapping[str, Any] | None:
+    """Resolve a model from the optional map, then the bundled snapshot."""
+    custom_map = _load_custom_map(os.environ.get(_CUSTOM_COST_MAP_ENV))
+    for candidate in _model_candidates(model):
+        entry = custom_map.get(candidate)
+        if isinstance(entry, dict):
+            return entry
+
+    bundled_map = _load_bundled_map()
+    for candidate in _model_candidates(model):
+        entry = bundled_map.get(candidate)
+        if isinstance(entry, dict):
+            return entry
+    return None
+
+
+def _rate(
+    pricing: Mapping[str, Any],
+    field: str,
+    service_tier: str | None,
+    prompt_tokens: float,
+) -> float | None:
+    """Select a standard, service-tier, and context-length-specific rate."""
+    tier = service_tier.lower() if service_tier else ""
+    tier_suffix = f"_{tier}" if tier in ("priority", "flex") else ""
+    large_suffix = "_above_272k_tokens" if prompt_tokens > _LARGE_CONTEXT_THRESHOLD else ""
+
+    for name in (
+        f"{field}{large_suffix}{tier_suffix}",
+        f"{field}{tier_suffix}",
+        f"{field}{large_suffix}",
+        field,
+    ):
+        rate = _as_rate(pricing.get(name))
+        if rate is not None:
+            return rate
+    return None
+
+
+def estimate_cost(
+    model: str,
+    input_tokens: float,
+    output_tokens: float,
+    cached_input_tokens: float = 0,
+    cache_creation_input_tokens: float = 0,
+    service_tier: str | None = None,
+) -> float | None:
+    """Estimate USD cost from Codex response usage.
+
+    ``input_tokens`` is the fresh input count. Codex's response event reports
+    the inclusive input count separately; callers should subtract cache-read
+    and cache-write counts before passing it here. ``None`` means the model has
+    no known price in the configured or bundled LiteLLM map.
+    """
+    counts = (input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens)
+    if any(value < 0 for value in counts):
+        return None
+
+    pricing = _get_model_pricing(model)
+    if pricing is None:
+        return None
+
+    prompt_tokens = input_tokens + cached_input_tokens + cache_creation_input_tokens
+    input_rate = _rate(pricing, "input_cost_per_token", service_tier, prompt_tokens)
+    output_rate = _rate(pricing, "output_cost_per_token", service_tier, prompt_tokens)
+    cache_read_rate = _rate(pricing, "cache_read_input_token_cost", service_tier, prompt_tokens)
+    cache_creation_rate = _rate(
+        pricing,
+        "cache_creation_input_token_cost",
+        service_tier,
+        prompt_tokens,
+    )
+
+    if input_tokens and input_rate is None:
+        return None
+    if output_tokens and output_rate is None:
+        return None
+    if cached_input_tokens and cache_read_rate is None:
+        return None
+    if cache_creation_input_tokens and cache_creation_rate is None:
+        return None
+
+    return sum(
+        (
+            input_tokens * (input_rate or 0),
+            output_tokens * (output_rate or 0),
+            cached_input_tokens * (cache_read_rate or 0),
+            cache_creation_input_tokens * (cache_creation_rate or 0),
+        )
+    )

--- a/src/agentic_ci/data/litellm_openai_cost_map.json
+++ b/src/agentic_ci/data/litellm_openai_cost_map.json
@@ -1,0 +1,1649 @@
+{
+  "models": {
+    "chat-latest": {
+      "cache_read_input_token_cost": 5e-07,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "chatgpt-4o-latest": {
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05
+    },
+    "chatgpt-image-latest": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 1e-05,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 4e-05
+    },
+    "codex-mini-latest": {
+      "cache_read_input_token_cost": 3.75e-07,
+      "input_cost_per_token": 1.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-06
+    },
+    "daybreak-blue-latest": {
+      "cache_creation_input_token_cost": 6.25e-06,
+      "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_above_272k_tokens": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05,
+      "output_cost_per_token_above_272k_tokens": 4.5e-05
+    },
+    "daybreak-red-latest": {
+      "cache_creation_input_token_cost": 1.5625e-05,
+      "cache_creation_input_token_cost_above_272k_tokens": 3.125e-05,
+      "cache_read_input_token_cost": 1.25e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 2.5e-06,
+      "input_cost_per_token": 1.25e-05,
+      "input_cost_per_token_above_272k_tokens": 2.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 7.5e-05,
+      "output_cost_per_token_above_272k_tokens": 0.0001125
+    },
+    "ft:gpt-3.5-turbo": {
+      "input_cost_per_token": 3e-06,
+      "input_cost_per_token_batches": 1.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-06,
+      "output_cost_per_token_batches": 3e-06
+    },
+    "ft:gpt-3.5-turbo-0125": {
+      "input_cost_per_token": 3e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-06
+    },
+    "ft:gpt-3.5-turbo-0613": {
+      "input_cost_per_token": 3e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-06
+    },
+    "ft:gpt-3.5-turbo-1106": {
+      "input_cost_per_token": 3e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-06
+    },
+    "ft:gpt-4-0613": {
+      "input_cost_per_token": 3e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "ft:gpt-4.1-2025-04-14": {
+      "cache_read_input_token_cost": 7.5e-07,
+      "input_cost_per_token": 3e-06,
+      "input_cost_per_token_batches": 1.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.2e-05,
+      "output_cost_per_token_batches": 6e-06
+    },
+    "ft:gpt-4.1-mini-2025-04-14": {
+      "cache_read_input_token_cost": 2e-07,
+      "input_cost_per_token": 8e-07,
+      "input_cost_per_token_batches": 4e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3.2e-06,
+      "output_cost_per_token_batches": 1.6e-06
+    },
+    "ft:gpt-4.1-nano-2025-04-14": {
+      "cache_read_input_token_cost": 5e-08,
+      "input_cost_per_token": 2e-07,
+      "input_cost_per_token_batches": 1e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-07,
+      "output_cost_per_token_batches": 4e-07
+    },
+    "ft:gpt-4o-2024-08-06": {
+      "cache_read_input_token_cost": 1.875e-06,
+      "input_cost_per_token": 3.75e-06,
+      "input_cost_per_token_batches": 1.875e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05,
+      "output_cost_per_token_batches": 7.5e-06
+    },
+    "ft:gpt-4o-2024-11-20": {
+      "cache_creation_input_token_cost": 1.875e-06,
+      "input_cost_per_token": 3.75e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05
+    },
+    "ft:gpt-4o-mini-2024-07-18": {
+      "cache_read_input_token_cost": 1.5e-07,
+      "input_cost_per_token": 3e-07,
+      "input_cost_per_token_batches": 1.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.2e-06,
+      "output_cost_per_token_batches": 6e-07
+    },
+    "ft:o4-mini-2025-04-16": {
+      "cache_read_input_token_cost": 1e-06,
+      "input_cost_per_token": 4e-06,
+      "input_cost_per_token_batches": 2e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.6e-05,
+      "output_cost_per_token_batches": 8e-06
+    },
+    "gpt-3.5-turbo": {
+      "input_cost_per_token": 5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-06
+    },
+    "gpt-3.5-turbo-0125": {
+      "input_cost_per_token": 5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-06
+    },
+    "gpt-3.5-turbo-1106": {
+      "input_cost_per_token": 1e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 2e-06
+    },
+    "gpt-3.5-turbo-16k": {
+      "input_cost_per_token": 3e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-06
+    },
+    "gpt-4": {
+      "input_cost_per_token": 3e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "gpt-4-0125-preview": {
+      "input_cost_per_token": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "gpt-4-0314": {
+      "input_cost_per_token": 3e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "gpt-4-0613": {
+      "input_cost_per_token": 3e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "gpt-4-1106-preview": {
+      "input_cost_per_token": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "gpt-4-turbo": {
+      "input_cost_per_token": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "gpt-4-turbo-2024-04-09": {
+      "input_cost_per_token": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "gpt-4-turbo-preview": {
+      "input_cost_per_token": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05
+    },
+    "gpt-4.1": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_priority": 8.75e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_batches": 1e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_batches": 4e-06,
+      "output_cost_per_token_priority": 1.4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.025,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.025
+      }
+    },
+    "gpt-4.1-2025-04-14": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_priority": 8.75e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_batches": 1e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_batches": 4e-06,
+      "output_cost_per_token_priority": 1.4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.025,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.025
+      }
+    },
+    "gpt-4.1-mini": {
+      "cache_read_input_token_cost": 1e-07,
+      "cache_read_input_token_cost_priority": 1.75e-07,
+      "input_cost_per_token": 4e-07,
+      "input_cost_per_token_batches": 2e-07,
+      "input_cost_per_token_priority": 7e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.6e-06,
+      "output_cost_per_token_batches": 8e-07,
+      "output_cost_per_token_priority": 2.8e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.025,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.025
+      }
+    },
+    "gpt-4.1-mini-2025-04-14": {
+      "cache_read_input_token_cost": 1e-07,
+      "cache_read_input_token_cost_priority": 1.75e-07,
+      "input_cost_per_token": 4e-07,
+      "input_cost_per_token_batches": 2e-07,
+      "input_cost_per_token_priority": 7e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.6e-06,
+      "output_cost_per_token_batches": 8e-07,
+      "output_cost_per_token_priority": 2.8e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.025,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.025
+      }
+    },
+    "gpt-4.1-nano": {
+      "cache_read_input_token_cost": 2.5e-08,
+      "cache_read_input_token_cost_priority": 5e-08,
+      "input_cost_per_token": 1e-07,
+      "input_cost_per_token_batches": 5e-08,
+      "input_cost_per_token_priority": 2e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-07,
+      "output_cost_per_token_batches": 2e-07,
+      "output_cost_per_token_priority": 8e-07
+    },
+    "gpt-4.1-nano-2025-04-14": {
+      "cache_read_input_token_cost": 2.5e-08,
+      "cache_read_input_token_cost_priority": 5e-08,
+      "input_cost_per_token": 1e-07,
+      "input_cost_per_token_batches": 5e-08,
+      "input_cost_per_token_priority": 2e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-07,
+      "output_cost_per_token_batches": 2e-07,
+      "output_cost_per_token_priority": 8e-07
+    },
+    "gpt-4o": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "cache_read_input_token_cost_priority": 2.125e-06,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "input_cost_per_token_priority": 4.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_batches": 5e-06,
+      "output_cost_per_token_priority": 1.7e-05
+    },
+    "gpt-4o-2024-05-13": {
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_batches": 2.5e-06,
+      "input_cost_per_token_priority": 8.75e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05,
+      "output_cost_per_token_batches": 7.5e-06,
+      "output_cost_per_token_priority": 2.625e-05
+    },
+    "gpt-4o-2024-08-06": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "cache_read_input_token_cost_priority": 2.125e-06,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "input_cost_per_token_priority": 4.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_batches": 5e-06,
+      "output_cost_per_token_priority": 1.7e-05
+    },
+    "gpt-4o-2024-11-20": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "cache_read_input_token_cost_priority": 2.125e-06,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "input_cost_per_token_priority": 4.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_batches": 5e-06,
+      "output_cost_per_token_priority": 1.7e-05
+    },
+    "gpt-4o-audio-preview": {
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-audio-preview-2024-12-17": {
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-audio-preview-2025-06-03": {
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-mini": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "cache_read_input_token_cost_priority": 1.25e-07,
+      "input_cost_per_token": 1.5e-07,
+      "input_cost_per_token_batches": 7.5e-08,
+      "input_cost_per_token_priority": 2.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-07,
+      "output_cost_per_token_batches": 3e-07,
+      "output_cost_per_token_priority": 1e-06
+    },
+    "gpt-4o-mini-2024-07-18": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "cache_read_input_token_cost_priority": 1.25e-07,
+      "input_cost_per_token": 1.5e-07,
+      "input_cost_per_token_batches": 7.5e-08,
+      "input_cost_per_token_priority": 2.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-07,
+      "output_cost_per_token_batches": 3e-07,
+      "output_cost_per_token_priority": 1e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.03,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.0275
+      }
+    },
+    "gpt-4o-mini-audio-preview": {
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 1.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 6e-07
+    },
+    "gpt-4o-mini-audio-preview-2024-12-17": {
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 1.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 6e-07
+    },
+    "gpt-4o-mini-realtime-preview": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_token_cost": 3e-07,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-4o-mini-realtime-preview-2024-12-17": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_token_cost": 3e-07,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-4o-mini-search-preview": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "input_cost_per_token": 1.5e-07,
+      "input_cost_per_token_batches": 7.5e-08,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-07,
+      "output_cost_per_token_batches": 3e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.03,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.0275
+      }
+    },
+    "gpt-4o-mini-search-preview-2025-03-11": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "input_cost_per_token": 1.5e-07,
+      "input_cost_per_token_batches": 7.5e-08,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-07,
+      "output_cost_per_token_batches": 3e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.03,
+        "search_context_size_low": 0.025,
+        "search_context_size_medium": 0.0275
+      }
+    },
+    "gpt-4o-mini-transcribe": {
+      "input_cost_per_audio_token": 1.25e-06,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 5e-06
+    },
+    "gpt-4o-mini-transcribe-2025-03-20": {
+      "input_cost_per_audio_token": 1.25e-06,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 5e-06
+    },
+    "gpt-4o-mini-transcribe-2025-12-15": {
+      "input_cost_per_audio_token": 1.25e-06,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 5e-06
+    },
+    "gpt-4o-mini-tts": {
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 1.2e-05,
+      "output_cost_per_second": 0.00025,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-mini-tts-2025-03-20": {
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 1.2e-05,
+      "output_cost_per_second": 0.00025,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-mini-tts-2025-12-15": {
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 1.2e-05,
+      "output_cost_per_second": 0.00025,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-realtime-preview": {
+      "cache_read_input_token_cost": 2.5e-06,
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 2e-05
+    },
+    "gpt-4o-realtime-preview-2024-12-17": {
+      "cache_read_input_token_cost": 2.5e-06,
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 2e-05
+    },
+    "gpt-4o-realtime-preview-2025-06-03": {
+      "cache_read_input_token_cost": 2.5e-06,
+      "input_cost_per_audio_token": 4e-05,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 8e-05,
+      "output_cost_per_token": 2e-05
+    },
+    "gpt-4o-search-preview": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_batches": 5e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.05,
+        "search_context_size_low": 0.03,
+        "search_context_size_medium": 0.035
+      }
+    },
+    "gpt-4o-search-preview-2025-03-11": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_batches": 5e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.05,
+        "search_context_size_low": 0.03,
+        "search_context_size_medium": 0.035
+      }
+    },
+    "gpt-4o-transcribe": {
+      "input_cost_per_audio_token": 2.5e-06,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-4o-transcribe-diarize": {
+      "input_cost_per_audio_token": 2.5e-06,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-5": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_flex": 6.25e-08,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_flex": 6.25e-07,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_flex": 5e-06,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-2025-08-07": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_flex": 6.25e-08,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_flex": 6.25e-07,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_flex": 5e-06,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-chat": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-5-chat-latest": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-5-codex": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-mini": {
+      "cache_read_input_token_cost": 2.5e-08,
+      "cache_read_input_token_cost_flex": 1.25e-08,
+      "cache_read_input_token_cost_priority": 4.5e-08,
+      "input_cost_per_token": 2.5e-07,
+      "input_cost_per_token_flex": 1.25e-07,
+      "input_cost_per_token_priority": 4.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 2e-06,
+      "output_cost_per_token_flex": 1e-06,
+      "output_cost_per_token_priority": 3.6e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-mini-2025-08-07": {
+      "cache_read_input_token_cost": 2.5e-08,
+      "cache_read_input_token_cost_flex": 1.25e-08,
+      "cache_read_input_token_cost_priority": 4.5e-08,
+      "input_cost_per_token": 2.5e-07,
+      "input_cost_per_token_flex": 1.25e-07,
+      "input_cost_per_token_priority": 4.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 2e-06,
+      "output_cost_per_token_flex": 1e-06,
+      "output_cost_per_token_priority": 3.6e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-nano": {
+      "cache_read_input_token_cost": 5e-09,
+      "cache_read_input_token_cost_flex": 2.5e-09,
+      "input_cost_per_token": 5e-08,
+      "input_cost_per_token_flex": 2.5e-08,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-07,
+      "output_cost_per_token_flex": 2e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-nano-2025-08-07": {
+      "cache_read_input_token_cost": 5e-09,
+      "cache_read_input_token_cost_flex": 2.5e-09,
+      "input_cost_per_token": 5e-08,
+      "input_cost_per_token_flex": 2.5e-08,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-07,
+      "output_cost_per_token_flex": 2e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-pro": {
+      "input_cost_per_token": 1.5e-05,
+      "input_cost_per_token_batches": 7.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00012,
+      "output_cost_per_token_batches": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-pro-2025-10-06": {
+      "input_cost_per_token": 1.5e-05,
+      "input_cost_per_token_batches": 7.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00012,
+      "output_cost_per_token_batches": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-search-api": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5-search-api-2025-10-14": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1-2025-11-13": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1-chat-latest": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1-codex": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "cache_read_input_token_cost_priority": 2.5e-07,
+      "input_cost_per_token": 1.25e-06,
+      "input_cost_per_token_priority": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "output_cost_per_token_priority": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1-codex-max": {
+      "cache_read_input_token_cost": 1.25e-07,
+      "input_cost_per_token": 1.25e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.1-codex-mini": {
+      "cache_read_input_token_cost": 2.5e-08,
+      "cache_read_input_token_cost_priority": 4.5e-08,
+      "input_cost_per_token": 2.5e-07,
+      "input_cost_per_token_priority": 4.5e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 2e-06,
+      "output_cost_per_token_priority": 3.6e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2-2025-12-11": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2-chat-latest": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2-codex": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2-pro": {
+      "input_cost_per_token": 2.1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.000168,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.2-pro-2025-12-11": {
+      "input_cost_per_token": 2.1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.000168,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.3-chat-latest": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.3-codex": {
+      "cache_read_input_token_cost": 1.75e-07,
+      "cache_read_input_token_cost_priority": 3.5e-07,
+      "input_cost_per_token": 1.75e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.4e-05,
+      "output_cost_per_token_priority": 2.8e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4": {
+      "cache_read_input_token_cost": 2.5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+      "cache_read_input_token_cost_flex": 1.3e-07,
+      "cache_read_input_token_cost_priority": 5e-07,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_above_272k_tokens": 5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "input_cost_per_token_flex": 1.25e-06,
+      "input_cost_per_token_priority": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05,
+      "output_cost_per_token_above_272k_tokens": 2.25e-05,
+      "output_cost_per_token_batches": 7.5e-06,
+      "output_cost_per_token_flex": 7.5e-06,
+      "output_cost_per_token_priority": 3e-05
+    },
+    "gpt-5.4-2026-03-05": {
+      "cache_read_input_token_cost": 2.5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 5e-07,
+      "cache_read_input_token_cost_flex": 1.3e-07,
+      "cache_read_input_token_cost_priority": 5e-07,
+      "input_cost_per_token": 2.5e-06,
+      "input_cost_per_token_above_272k_tokens": 5e-06,
+      "input_cost_per_token_batches": 1.25e-06,
+      "input_cost_per_token_flex": 1.25e-06,
+      "input_cost_per_token_priority": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.5e-05,
+      "output_cost_per_token_above_272k_tokens": 2.25e-05,
+      "output_cost_per_token_batches": 7.5e-06,
+      "output_cost_per_token_flex": 7.5e-06,
+      "output_cost_per_token_priority": 3e-05
+    },
+    "gpt-5.4-mini": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "cache_read_input_token_cost_flex": 3.75e-08,
+      "cache_read_input_token_cost_priority": 1.5e-07,
+      "input_cost_per_token": 7.5e-07,
+      "input_cost_per_token_batches": 3.75e-07,
+      "input_cost_per_token_flex": 3.75e-07,
+      "input_cost_per_token_priority": 1.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.5e-06,
+      "output_cost_per_token_batches": 2.25e-06,
+      "output_cost_per_token_flex": 2.25e-06,
+      "output_cost_per_token_priority": 9e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4-mini-2026-03-17": {
+      "cache_read_input_token_cost": 7.5e-08,
+      "cache_read_input_token_cost_flex": 3.75e-08,
+      "cache_read_input_token_cost_priority": 1.5e-07,
+      "input_cost_per_token": 7.5e-07,
+      "input_cost_per_token_batches": 3.75e-07,
+      "input_cost_per_token_flex": 3.75e-07,
+      "input_cost_per_token_priority": 1.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.5e-06,
+      "output_cost_per_token_batches": 2.25e-06,
+      "output_cost_per_token_flex": 2.25e-06,
+      "output_cost_per_token_priority": 9e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4-nano": {
+      "cache_read_input_token_cost": 2e-08,
+      "cache_read_input_token_cost_flex": 1e-08,
+      "input_cost_per_token": 2e-07,
+      "input_cost_per_token_batches": 1e-07,
+      "input_cost_per_token_flex": 1e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.25e-06,
+      "output_cost_per_token_batches": 6.25e-07,
+      "output_cost_per_token_flex": 6.25e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4-nano-2026-03-17": {
+      "cache_read_input_token_cost": 2e-08,
+      "cache_read_input_token_cost_flex": 1e-08,
+      "input_cost_per_token": 2e-07,
+      "input_cost_per_token_batches": 1e-07,
+      "input_cost_per_token_flex": 1e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.25e-06,
+      "output_cost_per_token_batches": 6.25e-07,
+      "output_cost_per_token_flex": 6.25e-07,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4-pro": {
+      "cache_read_input_token_cost": 3e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+      "input_cost_per_token": 3e-05,
+      "input_cost_per_token_above_272k_tokens": 6e-05,
+      "input_cost_per_token_batches": 1.5e-05,
+      "input_cost_per_token_flex": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00018,
+      "output_cost_per_token_above_272k_tokens": 0.00027,
+      "output_cost_per_token_batches": 9e-05,
+      "output_cost_per_token_flex": 9e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.4-pro-2026-03-05": {
+      "cache_read_input_token_cost": 3e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+      "input_cost_per_token": 3e-05,
+      "input_cost_per_token_above_272k_tokens": 6e-05,
+      "input_cost_per_token_batches": 1.5e-05,
+      "input_cost_per_token_flex": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00018,
+      "output_cost_per_token_above_272k_tokens": 0.00027,
+      "output_cost_per_token_batches": 9e-05,
+      "output_cost_per_token_flex": 9e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.5": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 1e-06,
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_above_272k_tokens": 1e-05,
+      "input_cost_per_token_batches": 2.5e-06,
+      "input_cost_per_token_flex": 2.5e-06,
+      "input_cost_per_token_priority": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05,
+      "output_cost_per_token_above_272k_tokens": 4.5e-05,
+      "output_cost_per_token_batches": 1.5e-05,
+      "output_cost_per_token_flex": 1.5e-05,
+      "output_cost_per_token_priority": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.5-2026-04-23": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 1e-06,
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_above_272k_tokens": 1e-05,
+      "input_cost_per_token_batches": 2.5e-06,
+      "input_cost_per_token_flex": 2.5e-06,
+      "input_cost_per_token_priority": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05,
+      "output_cost_per_token_above_272k_tokens": 4.5e-05,
+      "output_cost_per_token_batches": 1.5e-05,
+      "output_cost_per_token_flex": 1.5e-05,
+      "output_cost_per_token_priority": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.5-pro": {
+      "cache_read_input_token_cost": 3e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+      "input_cost_per_token": 3e-05,
+      "input_cost_per_token_above_272k_tokens": 6e-05,
+      "input_cost_per_token_batches": 1.5e-05,
+      "input_cost_per_token_flex": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00018,
+      "output_cost_per_token_above_272k_tokens": 0.00027,
+      "output_cost_per_token_batches": 9e-05,
+      "output_cost_per_token_flex": 9e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.5-pro-2026-04-23": {
+      "cache_read_input_token_cost": 3e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 6e-06,
+      "input_cost_per_token": 3e-05,
+      "input_cost_per_token_above_272k_tokens": 6e-05,
+      "input_cost_per_token_batches": 1.5e-05,
+      "input_cost_per_token_flex": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.00018,
+      "output_cost_per_token_above_272k_tokens": 0.00027,
+      "output_cost_per_token_batches": 9e-05,
+      "output_cost_per_token_flex": 9e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.6": {
+      "cache_creation_input_token_cost": 6.25e-06,
+      "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+      "cache_creation_input_token_cost_above_272k_tokens_flex": 6.25e-06,
+      "cache_creation_input_token_cost_flex": 3.125e-06,
+      "cache_creation_input_token_cost_priority": 1.25e-05,
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+      "cache_read_input_token_cost_above_272k_tokens_flex": 5e-07,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 1e-06,
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_above_272k_tokens": 1e-05,
+      "input_cost_per_token_above_272k_tokens_flex": 5e-06,
+      "input_cost_per_token_batches": 2.5e-06,
+      "input_cost_per_token_flex": 2.5e-06,
+      "input_cost_per_token_priority": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05,
+      "output_cost_per_token_above_272k_tokens": 4.5e-05,
+      "output_cost_per_token_above_272k_tokens_flex": 2.25e-05,
+      "output_cost_per_token_batches": 1.5e-05,
+      "output_cost_per_token_flex": 1.5e-05,
+      "output_cost_per_token_priority": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.6-cyber": {
+      "cache_creation_input_token_cost": 1.5625e-05,
+      "cache_creation_input_token_cost_above_272k_tokens": 3.125e-05,
+      "cache_read_input_token_cost": 1.25e-06,
+      "cache_read_input_token_cost_above_272k_tokens": 2.5e-06,
+      "input_cost_per_token": 1.25e-05,
+      "input_cost_per_token_above_272k_tokens": 2.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 7.5e-05,
+      "output_cost_per_token_above_272k_tokens": 0.0001125
+    },
+    "gpt-5.6-luna": {
+      "cache_creation_input_token_cost": 2.5e-07,
+      "cache_creation_input_token_cost_above_272k_tokens": 5e-07,
+      "cache_creation_input_token_cost_above_272k_tokens_flex": 2.5e-07,
+      "cache_creation_input_token_cost_flex": 1.25e-07,
+      "cache_creation_input_token_cost_priority": 5e-07,
+      "cache_read_input_token_cost": 2e-08,
+      "cache_read_input_token_cost_above_272k_tokens": 4e-08,
+      "cache_read_input_token_cost_above_272k_tokens_flex": 2e-08,
+      "cache_read_input_token_cost_flex": 1e-08,
+      "cache_read_input_token_cost_priority": 4e-08,
+      "input_cost_per_token": 2e-07,
+      "input_cost_per_token_above_272k_tokens": 4e-07,
+      "input_cost_per_token_above_272k_tokens_flex": 2e-07,
+      "input_cost_per_token_batches": 1e-07,
+      "input_cost_per_token_flex": 1e-07,
+      "input_cost_per_token_priority": 4e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.2e-06,
+      "output_cost_per_token_above_272k_tokens": 1.8e-06,
+      "output_cost_per_token_above_272k_tokens_flex": 9e-07,
+      "output_cost_per_token_batches": 6e-07,
+      "output_cost_per_token_flex": 6e-07,
+      "output_cost_per_token_priority": 2.4e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.6-sol": {
+      "cache_creation_input_token_cost": 6.25e-06,
+      "cache_creation_input_token_cost_above_272k_tokens": 1.25e-05,
+      "cache_creation_input_token_cost_above_272k_tokens_flex": 6.25e-06,
+      "cache_creation_input_token_cost_flex": 3.125e-06,
+      "cache_creation_input_token_cost_priority": 1.25e-05,
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 1e-06,
+      "cache_read_input_token_cost_above_272k_tokens_flex": 5e-07,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 1e-06,
+      "input_cost_per_token": 5e-06,
+      "input_cost_per_token_above_272k_tokens": 1e-05,
+      "input_cost_per_token_above_272k_tokens_flex": 5e-06,
+      "input_cost_per_token_batches": 2.5e-06,
+      "input_cost_per_token_flex": 2.5e-06,
+      "input_cost_per_token_priority": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 3e-05,
+      "output_cost_per_token_above_272k_tokens": 4.5e-05,
+      "output_cost_per_token_above_272k_tokens_flex": 2.25e-05,
+      "output_cost_per_token_batches": 1.5e-05,
+      "output_cost_per_token_flex": 1.5e-05,
+      "output_cost_per_token_priority": 6e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-5.6-terra": {
+      "cache_creation_input_token_cost": 2.5e-06,
+      "cache_creation_input_token_cost_above_272k_tokens": 5e-06,
+      "cache_creation_input_token_cost_above_272k_tokens_flex": 2.5e-06,
+      "cache_creation_input_token_cost_flex": 1.25e-06,
+      "cache_creation_input_token_cost_priority": 5e-06,
+      "cache_read_input_token_cost": 2e-07,
+      "cache_read_input_token_cost_above_272k_tokens": 4e-07,
+      "cache_read_input_token_cost_above_272k_tokens_flex": 2e-07,
+      "cache_read_input_token_cost_flex": 1e-07,
+      "cache_read_input_token_cost_priority": 4e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_above_272k_tokens": 4e-06,
+      "input_cost_per_token_above_272k_tokens_flex": 2e-06,
+      "input_cost_per_token_batches": 1e-06,
+      "input_cost_per_token_flex": 1e-06,
+      "input_cost_per_token_priority": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 1.2e-05,
+      "output_cost_per_token_above_272k_tokens": 1.8e-05,
+      "output_cost_per_token_above_272k_tokens_flex": 9e-06,
+      "output_cost_per_token_batches": 6e-06,
+      "output_cost_per_token_flex": 6e-06,
+      "output_cost_per_token_priority": 2.4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "gpt-audio": {
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-audio-1.5": {
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-audio-2025-08-28": {
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_token": 2.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-audio-mini": {
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-audio-mini-2025-10-06": {
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-audio-mini-2025-12-15": {
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-image-1": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 1e-05,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 4e-05
+    },
+    "gpt-image-1-mini": {
+      "cache_read_input_token_cost": 2e-07,
+      "input_cost_per_image_token": 2.5e-06,
+      "input_cost_per_token": 2e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 8e-06
+    },
+    "gpt-image-1.5": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 8e-06,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 3.2e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-image-1.5-2025-12-16": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 8e-06,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 3.2e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-image-2": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 8e-06,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 3e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-image-2-2026-04-21": {
+      "cache_read_input_token_cost": 1.25e-06,
+      "input_cost_per_image_token": 8e-06,
+      "input_cost_per_token": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_image_token": 3e-05,
+      "output_cost_per_token": 1e-05
+    },
+    "gpt-realtime": {
+      "cache_creation_input_audio_token_cost": 4e-07,
+      "cache_read_input_token_cost": 4e-07,
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_image": 5e-06,
+      "input_cost_per_token": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1.6e-05
+    },
+    "gpt-realtime-1.5": {
+      "cache_creation_input_audio_token_cost": 4e-07,
+      "cache_read_input_token_cost": 4e-07,
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_image": 5e-06,
+      "input_cost_per_token": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1.6e-05
+    },
+    "gpt-realtime-2": {
+      "cache_creation_input_audio_token_cost": 4e-07,
+      "cache_read_input_token_cost": 4e-07,
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_image": 5e-06,
+      "input_cost_per_token": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1.6e-05
+    },
+    "gpt-realtime-2.1": {
+      "cache_creation_input_audio_token_cost": 4e-07,
+      "cache_read_input_audio_token_cost": 4e-07,
+      "cache_read_input_token_cost": 4e-07,
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_image": 5e-06,
+      "input_cost_per_token": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 2.4e-05
+    },
+    "gpt-realtime-2.1-mini": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_audio_token_cost": 3e-07,
+      "cache_read_input_token_cost": 6e-08,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_image": 8e-07,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-realtime-2025-08-28": {
+      "cache_creation_input_audio_token_cost": 4e-07,
+      "cache_read_input_token_cost": 4e-07,
+      "input_cost_per_audio_token": 3.2e-05,
+      "input_cost_per_image": 5e-06,
+      "input_cost_per_token": 4e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 6.4e-05,
+      "output_cost_per_token": 1.6e-05
+    },
+    "gpt-realtime-mini": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_audio_token_cost": 3e-07,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-realtime-mini-2025-10-06": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_audio_token_cost": 3e-07,
+      "cache_read_input_token_cost": 6e-08,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_image": 8e-07,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "gpt-realtime-mini-2025-12-15": {
+      "cache_creation_input_audio_token_cost": 3e-07,
+      "cache_read_input_audio_token_cost": 3e-07,
+      "cache_read_input_token_cost": 6e-08,
+      "input_cost_per_audio_token": 1e-05,
+      "input_cost_per_image": 8e-07,
+      "input_cost_per_token": 6e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_audio_token": 2e-05,
+      "output_cost_per_token": 2.4e-06
+    },
+    "o1": {
+      "cache_read_input_token_cost": 7.5e-06,
+      "input_cost_per_token": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "o1-2024-12-17": {
+      "cache_read_input_token_cost": 7.5e-06,
+      "input_cost_per_token": 1.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 6e-05
+    },
+    "o1-pro": {
+      "input_cost_per_token": 0.00015,
+      "input_cost_per_token_batches": 7.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0006,
+      "output_cost_per_token_batches": 0.0003
+    },
+    "o1-pro-2025-03-19": {
+      "input_cost_per_token": 0.00015,
+      "input_cost_per_token_batches": 7.5e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0006,
+      "output_cost_per_token_batches": 0.0003
+    },
+    "o3": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 8.75e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_flex": 1e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_flex": 4e-06,
+      "output_cost_per_token_priority": 1.4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o3-2025-04-16": {
+      "cache_read_input_token_cost": 5e-07,
+      "cache_read_input_token_cost_flex": 2.5e-07,
+      "cache_read_input_token_cost_priority": 8.75e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_flex": 1e-06,
+      "input_cost_per_token_priority": 3.5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_flex": 4e-06,
+      "output_cost_per_token_priority": 1.4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o3-deep-research": {
+      "cache_read_input_token_cost": 2.5e-06,
+      "input_cost_per_token": 1e-05,
+      "input_cost_per_token_batches": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-05,
+      "output_cost_per_token_batches": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o3-deep-research-2025-06-26": {
+      "cache_read_input_token_cost": 2.5e-06,
+      "input_cost_per_token": 1e-05,
+      "input_cost_per_token_batches": 5e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4e-05,
+      "output_cost_per_token_batches": 2e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o3-mini": {
+      "cache_read_input_token_cost": 5.5e-07,
+      "input_cost_per_token": 1.1e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.4e-06
+    },
+    "o3-mini-2025-01-31": {
+      "cache_read_input_token_cost": 5.5e-07,
+      "input_cost_per_token": 1.1e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.4e-06
+    },
+    "o3-pro": {
+      "input_cost_per_token": 2e-05,
+      "input_cost_per_token_batches": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-05,
+      "output_cost_per_token_batches": 4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o3-pro-2025-06-10": {
+      "input_cost_per_token": 2e-05,
+      "input_cost_per_token_batches": 1e-05,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-05,
+      "output_cost_per_token_batches": 4e-05,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o4-mini": {
+      "cache_read_input_token_cost": 2.75e-07,
+      "cache_read_input_token_cost_flex": 1.375e-07,
+      "cache_read_input_token_cost_priority": 5e-07,
+      "input_cost_per_token": 1.1e-06,
+      "input_cost_per_token_flex": 5.5e-07,
+      "input_cost_per_token_priority": 2e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.4e-06,
+      "output_cost_per_token_flex": 2.2e-06,
+      "output_cost_per_token_priority": 8e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o4-mini-2025-04-16": {
+      "cache_read_input_token_cost": 2.75e-07,
+      "cache_read_input_token_cost_flex": 1.375e-07,
+      "cache_read_input_token_cost_priority": 5e-07,
+      "input_cost_per_token": 1.1e-06,
+      "input_cost_per_token_flex": 5.5e-07,
+      "input_cost_per_token_priority": 2e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 4.4e-06,
+      "output_cost_per_token_flex": 2.2e-06,
+      "output_cost_per_token_priority": 8e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o4-mini-deep-research": {
+      "cache_read_input_token_cost": 5e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_batches": 1e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_batches": 4e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "o4-mini-deep-research-2025-06-26": {
+      "cache_read_input_token_cost": 5e-07,
+      "input_cost_per_token": 2e-06,
+      "input_cost_per_token_batches": 1e-06,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 8e-06,
+      "output_cost_per_token_batches": 4e-06,
+      "search_context_cost_per_query": {
+        "search_context_size_high": 0.01,
+        "search_context_size_low": 0.01,
+        "search_context_size_medium": 0.01
+      }
+    },
+    "omni-moderation-2024-09-26": {
+      "input_cost_per_token": 0.0,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    },
+    "omni-moderation-latest": {
+      "input_cost_per_token": 0.0,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    },
+    "text-embedding-3-large": {
+      "input_cost_per_token": 1.3e-07,
+      "input_cost_per_token_batches": 6.5e-08,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0,
+      "output_cost_per_token_batches": 0.0
+    },
+    "text-embedding-3-small": {
+      "input_cost_per_token": 2e-08,
+      "input_cost_per_token_batches": 1e-08,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0,
+      "output_cost_per_token_batches": 0.0
+    },
+    "text-embedding-ada-002": {
+      "input_cost_per_token": 1e-07,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    },
+    "text-embedding-ada-002-v2": {
+      "input_cost_per_token": 1e-07,
+      "input_cost_per_token_batches": 5e-08,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0,
+      "output_cost_per_token_batches": 0.0
+    },
+    "text-moderation-007": {
+      "input_cost_per_token": 0.0,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    },
+    "text-moderation-latest": {
+      "input_cost_per_token": 0.0,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    },
+    "text-moderation-stable": {
+      "input_cost_per_token": 0.0,
+      "litellm_provider": "openai",
+      "output_cost_per_token": 0.0
+    }
+  },
+  "source": {
+    "commit": "418c7c6012d7c39a9d4a28c72cabe1995595ad2b",
+    "path": "model_prices_and_context_window.json",
+    "repository": "https://github.com/BerriAI/litellm",
+    "url": "https://raw.githubusercontent.com/BerriAI/litellm/418c7c6012d7c39a9d4a28c72cabe1995595ad2b/model_prices_and_context_window.json"
+  }
+}

--- a/src/agentic_ci/gcp.py
+++ b/src/agentic_ci/gcp.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+from collections.abc import Mapping
 
 _ADC_PATH = "~/.config/gcloud/application_default_credentials.json"
 
@@ -19,7 +20,7 @@ def adc_path() -> str:
     return os.path.expanduser(_ADC_PATH)
 
 
-def find_credentials() -> tuple[str, str]:
+def find_credentials(env: Mapping[str, str] | None = None) -> tuple[str, str]:
     """Locate GCP credentials. Returns (json_string, source_label).
 
     Search order:
@@ -30,7 +31,9 @@ def find_credentials() -> tuple[str, str]:
 
     Raises RuntimeError if no valid credentials are found.
     """
-    raw = os.environ.get("GCLOUD_CREDENTIALS", "")
+    credential_env = env if env is not None else os.environ
+
+    raw = credential_env.get("GCLOUD_CREDENTIALS", "")
     if raw:
         content, is_b64 = _resolve_json(raw)
         if content:
@@ -38,7 +41,7 @@ def find_credentials() -> tuple[str, str]:
             return content, f"GCLOUD_CREDENTIALS env var{suffix}"
         raise RuntimeError("GCLOUD_CREDENTIALS is not valid JSON or base64-encoded JSON")
 
-    sa_key = os.environ.get("GCP_SERVICE_ACCOUNT_KEY", "")
+    sa_key = credential_env.get("GCP_SERVICE_ACCOUNT_KEY", "")
     if sa_key:
         if os.path.isfile(sa_key):
             try:
@@ -57,7 +60,7 @@ def find_credentials() -> tuple[str, str]:
         raise RuntimeError("GCP_SERVICE_ACCOUNT_KEY is not valid JSON or base64-encoded JSON")
 
     adc = adc_path()
-    ga_creds = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "")
+    ga_creds = credential_env.get("GOOGLE_APPLICATION_CREDENTIALS", "")
     for path, label in [
         (adc, "default ADC file"),
         (ga_creds, "GOOGLE_APPLICATION_CREDENTIALS file"),
@@ -74,7 +77,7 @@ def find_credentials() -> tuple[str, str]:
     )
 
 
-def ensure_adc() -> str:
+def ensure_adc(env: Mapping[str, str] | None = None) -> str:
     """Ensure the gcloud ADC file exists, writing it from env vars if needed.
 
     When env vars are set they take precedence over an existing ADC file,
@@ -85,14 +88,15 @@ def ensure_adc() -> str:
     Raises RuntimeError if no credentials are found.
     """
     adc = adc_path()
+    credential_env = env if env is not None else os.environ
     has_env_creds = bool(
-        os.environ.get("GCLOUD_CREDENTIALS") or os.environ.get("GCP_SERVICE_ACCOUNT_KEY")
+        credential_env.get("GCLOUD_CREDENTIALS") or credential_env.get("GCP_SERVICE_ACCOUNT_KEY")
     )
     if os.path.isfile(adc) and not has_env_creds:
         cred_type = _read_credential_type(adc)
         return f"existing ADC file ({cred_type})"
 
-    creds_json, source = find_credentials()
+    creds_json, source = find_credentials(credential_env)
     os.makedirs(os.path.dirname(adc), exist_ok=True)
     with open(adc, "w") as f:
         f.write(creds_json)

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -1,7 +1,7 @@
 """Harness abstraction for AI agent CLI tools.
 
 A harness encapsulates everything specific to a particular agent CLI
-(Claude Code, OpenCode, etc.): how to build the command, what env vars
+(Claude Code, OpenCode, Codex, etc.): how to build the command, what env vars
 it needs, where credentials are mounted, and how to parse its output.
 """
 
@@ -9,9 +9,15 @@ import json
 import os
 import shlex
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
-from agentic_ci.stream import ClaudeCodeStreamProcessor, OpenCodeStreamProcessor
+from agentic_ci.stream import (
+    ClaudeCodeStreamProcessor,
+    CodexStreamProcessor,
+    OpenCodeStreamProcessor,
+)
 
 _OPENSHELL_GATEWAY_HOST = "10.200.0.1"
 
@@ -22,9 +28,26 @@ class Harness(ABC):
     @property
     def auth_mode(self) -> str:
         """Return 'api-key' if ANTHROPIC_API_KEY is set, else 'vertex'."""
-        if os.environ.get("ANTHROPIC_API_KEY"):
+        return self.auth_mode_for_env(os.environ)
+
+    def auth_mode_for_env(self, env: Mapping[str, str] | None = None) -> str:
+        """Return the authentication mode selected by *env*."""
+        credential_env = env if env is not None else os.environ
+        if credential_env.get("ANTHROPIC_API_KEY"):
             return "api-key"
         return "vertex"
+
+    def validate_credentials(
+        self,
+        env: Mapping[str, str] | None = None,
+        *,
+        allow_auth_file: bool = False,
+    ) -> None:
+        """Fail early when harness-specific credentials are unavailable.
+
+        Harnesses without additional validation requirements use this no-op
+        implementation.
+        """
 
     @property
     @abstractmethod
@@ -32,11 +55,17 @@ class Harness(ABC):
         """Human-readable name for log messages."""
 
     @abstractmethod
-    def build_args(self, prompt: str, model: str, extra_args: list[str] | None = None) -> list[str]:
+    def build_args(
+        self,
+        prompt: str,
+        model: str,
+        extra_args: list[str] | None = None,
+        otel_endpoint: str | None = None,
+    ) -> list[str]:
         """Build the CLI argument list to run inside the container."""
 
     @abstractmethod
-    def build_env_args(self) -> list[str]:
+    def build_env_args(self, env: Mapping[str, str] | None = None) -> list[str]:
         """Return ['--env', 'K=V', ...] pairs for ``podman run`` (PodmanBackend only).
 
         Container-image ENV vars (config dirs, AGENT_TOOL) are already
@@ -49,6 +78,7 @@ class Harness(ABC):
         otel_port: int | None = None,
         otel_rate_file: str | None = None,
         traceparent: str | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> list[str]:
         """Return ``export K=V`` lines for the env script (OpenShellBackend only).
 
@@ -89,6 +119,7 @@ class Harness(ABC):
         otel_port: int | None = None,
         otel_rate_file: str | None = None,
         traceparent: str | None = None,
+        env: Mapping[str, str] | None = None,
     ) -> dict[str, str]:
         """Return env vars as a plain dict for direct (local) execution.
 
@@ -129,7 +160,7 @@ class ClaudeCodeHarness(Harness):
     def name(self) -> str:
         return "Claude Code"
 
-    def build_args(self, prompt, model, extra_args=None):
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         args = [
             "claude",
             "--permission-mode",
@@ -147,7 +178,8 @@ class ClaudeCodeHarness(Harness):
             args.extend(extra_args)
         return args
 
-    def build_env_args(self):
+    def build_env_args(self, env=None):
+        credential_env = env if env is not None else os.environ
         common = [
             "--env",
             "AGENT_TOOL=claude",
@@ -156,29 +188,32 @@ class ClaudeCodeHarness(Harness):
             "--env",
             "DISABLE_AUTOUPDATER=1",
         ]
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             common.extend(["--env", f"AGENT_ENABLED_PLUGINS={enabled_plugins}"])
-        if self.auth_mode == "api-key":
+        if self.auth_mode_for_env(credential_env) == "api-key":
             return [
                 "--env",
                 "ANTHROPIC_API_KEY",
                 *common,
             ]
-        vertex_project = os.environ.get(
-            "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+        vertex_project = credential_env.get(
+            "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
         )
         return [
             "--env",
             "CLAUDE_CODE_USE_VERTEX=1",
             "--env",
-            f"CLOUD_ML_REGION={os.environ.get('CLOUD_ML_REGION', 'global')}",
+            f"CLOUD_ML_REGION={credential_env.get('CLOUD_ML_REGION', 'global')}",
             "--env",
             f"ANTHROPIC_VERTEX_PROJECT_ID={vertex_project}",
             *common,
         ]
 
-    def build_env_script_lines(self, otel_port=None, otel_rate_file=None, traceparent=None):
+    def build_env_script_lines(
+        self, otel_port=None, otel_rate_file=None, traceparent=None, env=None
+    ):
+        credential_env = env if env is not None else os.environ
         common = [
             "export AGENT_TOOL=claude",
             "export CLAUDE_CONFIG_DIR=/sandbox/.claude",
@@ -186,19 +221,19 @@ class ClaudeCodeHarness(Harness):
             "export CLAUDE_CODE_SYNC_PLUGIN_INSTALL=1",
             "export DISABLE_AUTOUPDATER=1",
         ]
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             common.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
-        if self.auth_mode == "api-key":
+        if self.auth_mode_for_env(credential_env) == "api-key":
             lines = [
-                f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",
+                f"export ANTHROPIC_API_KEY={shlex.quote(credential_env['ANTHROPIC_API_KEY'])}",
                 *common,
             ]
         else:
-            vertex_project = os.environ.get(
-                "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+            vertex_project = credential_env.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
             )
-            cloud_region = os.environ.get("CLOUD_ML_REGION", "global")
+            cloud_region = credential_env.get("CLOUD_ML_REGION", "global")
             lines = [
                 "export CLAUDE_CODE_USE_VERTEX=1",
                 f"export CLOUD_ML_REGION={shlex.quote(cloud_region)}",
@@ -259,23 +294,24 @@ class ClaudeCodeHarness(Harness):
             env.extend(["--env", f"TRACEPARENT={traceparent}"])
         return env
 
-    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None):
+    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None, env=None):
+        credential_env = env if env is not None else os.environ
         env = {
             "AGENT_TOOL": "claude",
             "DISABLE_AUTOUPDATER": "1",
             # -p sets sessionKind, breaking --continue lookup (claude-code#43013)
             "CLAUDE_CODE_ENTRYPOINT": "sdk-cli",
         }
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             env["AGENT_ENABLED_PLUGINS"] = enabled_plugins
-        if self.auth_mode == "api-key":
-            env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]
+        if self.auth_mode_for_env(credential_env) == "api-key":
+            env["ANTHROPIC_API_KEY"] = credential_env["ANTHROPIC_API_KEY"]
         else:
             env["CLAUDE_CODE_USE_VERTEX"] = "1"
-            env["CLOUD_ML_REGION"] = os.environ.get("CLOUD_ML_REGION", "global")
-            env["ANTHROPIC_VERTEX_PROJECT_ID"] = os.environ.get(
-                "ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")
+            env["CLOUD_ML_REGION"] = credential_env.get("CLOUD_ML_REGION", "global")
+            env["ANTHROPIC_VERTEX_PROJECT_ID"] = credential_env.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
             )
         if otel_port:
             env.update(
@@ -325,7 +361,7 @@ class OpenCodeHarness(Harness):
     def name(self) -> str:
         return "OpenCode"
 
-    def build_args(self, prompt, model, extra_args=None):
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         args = [
             "opencode",
             "run",
@@ -340,7 +376,8 @@ class OpenCodeHarness(Harness):
             args.extend(extra_args)
         return args
 
-    def build_env_args(self):
+    def build_env_args(self, env=None):
+        credential_env = env if env is not None else os.environ
         common = [
             "--env",
             "AGENT_TOOL=opencode",
@@ -349,22 +386,24 @@ class OpenCodeHarness(Harness):
             "--env",
             "OPENCODE_DISABLE_AUTOUPDATE=1",
         ]
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             common.extend(["--env", f"AGENT_ENABLED_PLUGINS={enabled_plugins}"])
-        if self.auth_mode == "api-key":
+        if self.auth_mode_for_env(credential_env) == "api-key":
             return [
                 "--env",
                 "ANTHROPIC_API_KEY",
                 *common,
             ]
-        project = os.environ.get(
+        project = credential_env.get(
             "GOOGLE_CLOUD_PROJECT",
-            os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+            credential_env.get(
+                "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
+            ),
         )
-        location = os.environ.get(
+        location = credential_env.get(
             "VERTEX_LOCATION",
-            os.environ.get("CLOUD_ML_REGION", "global"),
+            credential_env.get("CLOUD_ML_REGION", "global"),
         )
         mount_target = self.credential_mount_target()
         return [
@@ -377,28 +416,33 @@ class OpenCodeHarness(Harness):
             *common,
         ]
 
-    def build_env_script_lines(self, otel_port=None, otel_rate_file=None, traceparent=None):
+    def build_env_script_lines(
+        self, otel_port=None, otel_rate_file=None, traceparent=None, env=None
+    ):
+        credential_env = env if env is not None else os.environ
         common = [
             "export AGENT_TOOL=opencode",
             "export OPENCODE_CONFIG_DIR=/sandbox/.config/opencode",
             "export OPENCODE_DISABLE_AUTOUPDATE=1",
         ]
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             common.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
-        if self.auth_mode == "api-key":
+        if self.auth_mode_for_env(credential_env) == "api-key":
             lines = [
-                f"export ANTHROPIC_API_KEY={shlex.quote(os.environ['ANTHROPIC_API_KEY'])}",
+                f"export ANTHROPIC_API_KEY={shlex.quote(credential_env['ANTHROPIC_API_KEY'])}",
                 *common,
             ]
         else:
-            project = os.environ.get(
+            project = credential_env.get(
                 "GOOGLE_CLOUD_PROJECT",
-                os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+                credential_env.get(
+                    "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
+                ),
             )
-            location = os.environ.get(
+            location = credential_env.get(
                 "VERTEX_LOCATION",
-                os.environ.get("CLOUD_ML_REGION", "global"),
+                credential_env.get("CLOUD_ML_REGION", "global"),
             )
             lines = [
                 f"export GOOGLE_CLOUD_PROJECT={shlex.quote(project)}",
@@ -438,23 +482,26 @@ class OpenCodeHarness(Harness):
             env.extend(["--env", f"TRACEPARENT={traceparent}"])
         return env
 
-    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None):
+    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None, env=None):
+        credential_env = env if env is not None else os.environ
         env = {
             "AGENT_TOOL": "opencode",
             "OPENCODE_DISABLE_AUTOUPDATE": "1",
         }
-        enabled_plugins = os.environ.get("AGENT_ENABLED_PLUGINS")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
         if enabled_plugins:
             env["AGENT_ENABLED_PLUGINS"] = enabled_plugins
-        if self.auth_mode == "api-key":
-            env["ANTHROPIC_API_KEY"] = os.environ["ANTHROPIC_API_KEY"]
+        if self.auth_mode_for_env(credential_env) == "api-key":
+            env["ANTHROPIC_API_KEY"] = credential_env["ANTHROPIC_API_KEY"]
         else:
-            env["GOOGLE_CLOUD_PROJECT"] = os.environ.get(
+            env["GOOGLE_CLOUD_PROJECT"] = credential_env.get(
                 "GOOGLE_CLOUD_PROJECT",
-                os.environ.get("ANTHROPIC_VERTEX_PROJECT_ID", os.environ.get("GCP_PROJECT_ID", "")),
+                credential_env.get(
+                    "ANTHROPIC_VERTEX_PROJECT_ID", credential_env.get("GCP_PROJECT_ID", "")
+                ),
             )
-            env["VERTEX_LOCATION"] = os.environ.get(
-                "VERTEX_LOCATION", os.environ.get("CLOUD_ML_REGION", "global")
+            env["VERTEX_LOCATION"] = credential_env.get(
+                "VERTEX_LOCATION", credential_env.get("CLOUD_ML_REGION", "global")
             )
         if traceparent:
             env["TRACEPARENT"] = traceparent
@@ -501,11 +548,158 @@ class OpenCodeHarness(Harness):
         return []
 
 
+class CodexHarness(Harness):
+    """OpenAI Codex CLI harness."""
+
+    _CREDENTIAL_ENV_VARS = ("OPENAI_API_KEY",)
+
+    @property
+    def name(self) -> str:
+        return "Codex"
+
+    @property
+    def auth_mode(self) -> str:
+        """Codex uses OpenAI credentials, not Anthropic or Vertex."""
+        return "openai"
+
+    def auth_mode_for_env(self, env=None) -> str:
+        """Codex always uses its OpenAI-compatible authentication path."""
+        return "openai"
+
+    def validate_credentials(
+        self,
+        env: Mapping[str, str] | None = None,
+        *,
+        allow_auth_file: bool = False,
+    ) -> None:
+        credential_env = env if env is not None else os.environ
+        if any(credential_env.get(name) for name in self._CREDENTIAL_ENV_VARS):
+            return
+
+        home = Path(credential_env.get("HOME", str(Path.home())))
+        codex_home = Path(credential_env.get("CODEX_HOME", str(home / ".codex")))
+        auth_path = codex_home / "auth.json"
+        if allow_auth_file and auth_path.is_file():
+            return
+
+        expected = ", ".join(self._CREDENTIAL_ENV_VARS)
+        if allow_auth_file:
+            expected = f"{expected}, or {auth_path}"
+        raise RuntimeError(f"Codex credentials not found. Set one of: {expected}.")
+
+    @staticmethod
+    def _otel_config_args(endpoint):
+        endpoint = endpoint.rstrip("/")
+
+        def exporter(signal):
+            url = json.dumps(f"{endpoint}/v1/{signal}")
+            return f'{{ "otlp-http" = {{ endpoint = {url}, protocol = "json" }} }}'
+
+        return [
+            "-c",
+            f"otel.exporter={exporter('logs')}",
+            "-c",
+            f"otel.metrics_exporter={exporter('metrics')}",
+            "-c",
+            f"otel.trace_exporter={exporter('traces')}",
+        ]
+
+    def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
+        codex_args = [
+            "exec",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--json",
+            "--skip-git-repo-check",
+            "--ephemeral",
+            # Codex has no supported auto-update env var; use its native config.
+            "-c",
+            "check_for_update_on_startup=false",
+        ]
+        if otel_endpoint:
+            codex_args.extend(self._otel_config_args(otel_endpoint))
+        if extra_args:
+            # Keep every extra option before the prompt.  Codex treats a
+            # token such as ``--help`` or ``review`` after the prompt as
+            # command-line syntax rather than prompt text.
+            codex_args.extend(arg for arg in extra_args if arg != "--")
+        codex_args.extend(["-m", model, "--", prompt])
+        return [
+            "bash",
+            "-c",
+            'set -e; if [ -n "${OPENAI_API_KEY:-}" ]; then '
+            'printf "%s" "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null || '
+            '{ echo "codex login --with-api-key failed" >&2; exit 1; }; '
+            'fi; exec codex "$@"',
+            "--",
+            *codex_args,
+        ]
+
+    def build_env_args(self, env=None):
+        credential_env = env if env is not None else os.environ
+        args = ["--env", "AGENT_TOOL=codex"]
+        if credential_env.get("OPENAI_API_KEY"):
+            args.extend(["--env", "OPENAI_API_KEY"])
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            args.extend(["--env", f"AGENT_ENABLED_PLUGINS={enabled_plugins}"])
+        return args
+
+    def build_env_script_lines(
+        self, otel_port=None, otel_rate_file=None, traceparent=None, env=None
+    ):
+        credential_env = env if env is not None else os.environ
+        lines = [
+            "mkdir -p /sandbox/.codex",
+            "export AGENT_TOOL=codex",
+            "export CODEX_HOME=/sandbox/.codex",
+        ]
+        if credential_env.get("OPENAI_API_KEY"):
+            lines.append(f"export OPENAI_API_KEY={shlex.quote(credential_env['OPENAI_API_KEY'])}")
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            lines.append(f"export AGENT_ENABLED_PLUGINS={shlex.quote(enabled_plugins)}")
+        return lines
+
+    def build_otel_exec_env(self, otel_port=None, traceparent=None):
+        return []
+
+    def build_local_env(self, otel_port=None, otel_rate_file=None, traceparent=None, env=None):
+        credential_env = env if env is not None else os.environ
+        env = {"AGENT_TOOL": "codex"}
+        enabled_plugins = credential_env.get("AGENT_ENABLED_PLUGINS")
+        if enabled_plugins:
+            env["AGENT_ENABLED_PLUGINS"] = enabled_plugins
+        return env
+
+    def credential_mount_target(self):
+        return os.environ.get("CODEX_CONTAINER_HOME", "/home/agent-ci")
+
+    def create_stream_processor(self, pid=0):
+        return CodexStreamProcessor(agent_pid=pid)
+
+    def image_env_var(self):
+        return "CODEX_CONTAINER_IMAGE"
+
+    def model_env_var(self):
+        return "CODEX_MODEL"
+
+    def default_model(self):
+        return "gpt-5.6-sol"
+
+    @property
+    def supports_otel(self) -> bool:
+        return True
+
+
 def create_harness(name: str) -> Harness:
     """Create a harness instance by name."""
     if name == "claude-code":
         return ClaudeCodeHarness()
     elif name == "opencode":
         return OpenCodeHarness()
+    elif name == "codex":
+        return CodexHarness()
     else:
-        raise ValueError(f"Unknown harness: {name!r}. Choose 'claude-code' or 'opencode'.")
+        raise ValueError(
+            f"Unknown harness: {name!r}. Choose 'claude-code', 'opencode', or 'codex'."
+        )

--- a/src/agentic_ci/harness.py
+++ b/src/agentic_ci/harness.py
@@ -607,10 +607,9 @@ class CodexHarness(Harness):
     def build_args(self, prompt, model, extra_args=None, otel_endpoint=None):
         codex_args = [
             "exec",
-            "--dangerously-bypass-approvals-and-sandbox",
+            "--approve-for-me",
             "--json",
             "--skip-git-repo-check",
-            "--ephemeral",
             # Codex has no supported auto-update env var; use its native config.
             "-c",
             "check_for_update_on_startup=false",
@@ -618,18 +617,19 @@ class CodexHarness(Harness):
         if otel_endpoint:
             codex_args.extend(self._otel_config_args(otel_endpoint))
         if extra_args:
-            # Keep every extra option before the prompt.  Codex treats a
-            # token such as ``--help`` or ``review`` after the prompt as
-            # command-line syntax rather than prompt text.
+            # Keep every extra argument before the model and prompt so Codex
+            # can interpret subcommands/options such as ``resume --last``.
             codex_args.extend(arg for arg in extra_args if arg != "--")
         codex_args.extend(["-m", model, "--", prompt])
         return [
             "bash",
             "-c",
             'set -e; if [ -n "${OPENAI_API_KEY:-}" ]; then '
-            'printf "%s" "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null || '
+            'if ! printf "%s" "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>&1; then '
             '{ echo "codex login --with-api-key failed" >&2; exit 1; }; '
-            'fi; exec codex "$@"',
+            "fi; "
+            "fi; unset OPENAI_API_KEY; "
+            'exec codex "$@"',
             "--",
             *codex_args,
         ]

--- a/src/agentic_ci/otel.py
+++ b/src/agentic_ci/otel.py
@@ -5,6 +5,7 @@ tracks token usage over a sliding window, and prints a summary.
 """
 
 import json
+import math
 import os
 import signal
 import subprocess
@@ -14,6 +15,8 @@ import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from agentic_ci.cost import estimate_cost
 
 _token_samples: list[tuple[float, int]] = []
 _WINDOW_SECS = 60
@@ -175,11 +178,52 @@ def stop_collector(proc):
         proc.wait()
 
 
+def _otel_attribute_value(value):
+    if not isinstance(value, dict):
+        return None
+    for key in (
+        "stringValue",
+        "intValue",
+        "doubleValue",
+        "boolValue",
+        "string_value",
+        "int_value",
+        "double_value",
+        "bool_value",
+    ):
+        if key in value:
+            return value[key]
+    return None
+
+
+def _numeric_attribute(attributes, key):
+    try:
+        return float(attributes.get(key, 0))
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _optional_numeric_attribute(attributes, *keys):
+    """Return the first finite numeric attribute, or None if none exists."""
+    for key in keys:
+        if key not in attributes:
+            continue
+        try:
+            value = float(attributes[key])
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(value):
+            return value
+    return None
+
+
 def parse_metrics(records):
     """Parse OTLP JSONL records into structured token/cost data."""
     token_totals = defaultdict(float)
     cost_totals = defaultdict(float)
     api_requests = []
+    codex_api_requests = []
+    codex_response_requests = []
     active_time = defaultdict(float)
 
     for rec in records:
@@ -194,11 +238,9 @@ def parse_metrics(records):
                         data = metric.get("sum", metric.get("gauge", metric.get("histogram", {})))
                         for dp in data.get("dataPoints", []):
                             attrs = {
-                                a["key"]: a["value"].get(
-                                    "stringValue",
-                                    a["value"].get("intValue", a["value"].get("doubleValue")),
-                                )
+                                a.get("key"): _otel_attribute_value(a.get("value"))
                                 for a in dp.get("attributes", [])
+                                if a.get("key")
                             }
                             value = dp.get("asDouble", dp.get("asInt", 0))
 
@@ -220,14 +262,77 @@ def parse_metrics(records):
                         event_name = ""
                         event_attrs = {}
                         for a in lr.get("attributes", []):
-                            key = a["key"]
-                            val = a["value"]
-                            v = val.get("stringValue", val.get("intValue", val.get("doubleValue")))
+                            key = a.get("key")
+                            if not key:
+                                continue
+                            v = _otel_attribute_value(a.get("value"))
                             event_attrs[key] = v
                             if key == "event.name":
                                 event_name = v
                         if event_name == "claude_code.api_request":
                             api_requests.append(event_attrs)
+                        elif event_name == "codex.api_request":
+                            api_requests.append(event_attrs)
+                            codex_api_requests.append(event_attrs)
+                        elif (
+                            event_name == "codex.sse_event"
+                            and event_attrs.get("event.kind") == "response.completed"
+                        ):
+                            codex_response_requests.append(event_attrs)
+                            model = str(event_attrs.get("model") or "unknown")
+                            input_tokens = _numeric_attribute(event_attrs, "input_token_count")
+                            cached_tokens = _numeric_attribute(event_attrs, "cached_token_count")
+                            cache_write_tokens = _numeric_attribute(
+                                event_attrs, "cache_write_token_count"
+                            )
+                            # Codex reports input_token_count inclusive of the
+                            # cached and cache-write tokens, so subtract them to
+                            # get the fresh prompt tokens. The max(..., 0) guards
+                            # against exporters that report them separately (in
+                            # which case fresh_input clamps to 0 rather than
+                            # going negative).
+                            fresh_input = max(
+                                input_tokens - cached_tokens - cache_write_tokens,
+                                0,
+                            )
+                            token_totals[(model, "input")] += fresh_input
+                            token_totals[(model, "cacheRead")] += cached_tokens
+                            token_totals[(model, "cacheCreation")] += cache_write_tokens
+                            token_totals[(model, "output")] += _numeric_attribute(
+                                event_attrs, "output_token_count"
+                            )
+
+                            direct_cost = _optional_numeric_attribute(
+                                event_attrs,
+                                "cost_usd",
+                                "total_cost_usd",
+                                "cost",
+                                "total_cost",
+                            )
+                            if direct_cost is not None and direct_cost >= 0:
+                                cost_totals[model] += direct_cost
+                            else:
+                                service_tier = event_attrs.get("service_tier")
+                                if not isinstance(service_tier, str):
+                                    service_tier = None
+                                estimated_cost = estimate_cost(
+                                    model,
+                                    input_tokens=fresh_input,
+                                    output_tokens=_numeric_attribute(
+                                        event_attrs, "output_token_count"
+                                    ),
+                                    cached_input_tokens=cached_tokens,
+                                    cache_creation_input_tokens=cache_write_tokens,
+                                    service_tier=service_tier,
+                                )
+                                if estimated_cost is not None:
+                                    cost_totals[model] += estimated_cost
+
+    # Recent Codex versions emit response.completed events but no separate
+    # codex.api_request log event. Keep the explicit event when available and
+    # use completed responses as a conservative request-count fallback.
+    if not codex_api_requests:
+        api_requests.extend(codex_response_requests)
 
     return token_totals, cost_totals, api_requests, active_time
 

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -1,6 +1,6 @@
 """Plugin and skill installation and runtime filtering.
 
-Provides two build-time operations and one runtime operation:
+Provides three build-time operations and one runtime operation:
 
 Build-time (called from Containerfiles via ``agentic-ci install-plugins``):
 
@@ -8,8 +8,11 @@ Build-time (called from Containerfiles via ``agentic-ci install-plugins``):
   plugins from a marketplace seed directory.
 - :func:`install_opencode_skills` — clones plugin repos and copies SKILL.md
   files into OpenCode's skills directory.
+- :func:`install_codex_plugins` — installs native Codex plugins when the
+  marketplace supports them, with a skills-only fallback for legacy
+  marketplaces.
 
-Both generate a plugin-to-skill manifest at a well-known path.
+All generate a plugin-to-skill manifest at a well-known path.
 
 Runtime (called from entrypoint.sh / OpenShell env script via
 ``agentic-ci enable-plugins``):
@@ -31,7 +34,7 @@ from agentic_ci.git import clone_repo
 
 DEFAULT_MANIFEST_PATH = "/usr/local/share/agentic-ci/plugin-skills.manifest.json"
 
-_FALLBACK_SKILL_DIRS = [".claude/skills", ".opencode/skills", "skills"]
+_FALLBACK_SKILL_DIRS = [".agents/skills", ".claude/skills", ".opencode/skills", "skills"]
 
 
 def _manifest_path() -> Path:
@@ -43,17 +46,33 @@ def _find_skill_names(root: Path) -> list[str]:
 
     A skill name is the parent directory name of each SKILL.md file.
     """
-    names = set()
-    for skill_md in root.rglob("SKILL.md"):
-        names.add(skill_md.parent.name)
-    return sorted(names)
+    return sorted({path.name for path in _find_skill_dirs(root)})
+
+
+def _find_skill_dirs(root: Path) -> list[Path]:
+    """Return directories containing a non-symlink ``SKILL.md``."""
+    skill_dirs: list[Path] = []
+    if root.is_symlink():
+        return skill_dirs
+    for current_root, dir_names, file_names in os.walk(root, followlinks=False):
+        current_path = Path(current_root)
+        dir_names[:] = [name for name in dir_names if not (current_path / name).is_symlink()]
+        skill_md = current_path / "SKILL.md"
+        if "SKILL.md" in file_names and not skill_md.is_symlink():
+            skill_dirs.append(current_path)
+    return skill_dirs
 
 
 def _copy_tree(src: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
     for item in src.iterdir():
+        if item.is_symlink():
+            print(f"  WARN: skipping symlink in skills tree: {item}")
+            continue
         target = dest / item.name
         if item.is_dir():
-            shutil.copytree(item, target, dirs_exist_ok=True)
+            target.mkdir(parents=True, exist_ok=True)
+            _copy_tree(item, target)
         else:
             shutil.copy2(item, target)
 
@@ -162,35 +181,181 @@ def install_opencode_skills(
                 continue
 
             skills_sources: list[Path] = []
+            source_root = clone_dir.resolve()
 
             explicit_paths = entry.get("skills", [])
             if explicit_paths:
                 for sp in explicit_paths:
                     sp = sp.removeprefix("./")
-                    candidate = clone_dir / sp
+                    candidate = (source_root / sp).resolve()
+                    try:
+                        candidate.relative_to(source_root)
+                    except ValueError:
+                        print(f"  WARN: rejected skills path outside repository: {sp}")
+                        continue
                     if candidate.is_dir():
-                        _copy_tree(candidate, skills_dir)
                         skills_sources.append(candidate)
 
             if not skills_sources:
                 for fallback in _FALLBACK_SKILL_DIRS:
-                    candidate = clone_dir / fallback
+                    candidate = (source_root / fallback).resolve()
+                    try:
+                        candidate.relative_to(source_root)
+                    except ValueError:
+                        continue
                     if candidate.is_dir():
-                        _copy_tree(candidate, skills_dir)
                         skills_sources.append(candidate)
 
             if not skills_sources:
                 print(f"  No skills found in {name}")
                 continue
 
-            all_skill_names: set[str] = set()
+            skill_dirs: dict[str, Path] = {}
+            duplicate_skill_names: set[str] = set()
             for src in skills_sources:
-                all_skill_names.update(_find_skill_names(src))
-            if all_skill_names:
-                manifest[name] = sorted(all_skill_names)
+                for skill_dir in _find_skill_dirs(src):
+                    skill_name = skill_dir.name
+                    if skill_name in skill_dirs:
+                        duplicate_skill_names.add(skill_name)
+                    else:
+                        skill_dirs[skill_name] = skill_dir
+
+            owned_skill_names = {
+                skill_name for skill_names in manifest.values() for skill_name in skill_names
+            }
+            collisions = sorted(duplicate_skill_names | (set(skill_dirs) & owned_skill_names))
+            if collisions:
+                print(
+                    f"WARN: skipping {name}; destination path collision(s): {', '.join(collisions)}"
+                )
+                continue
+
+            for skill_name, skill_dir in skill_dirs.items():
+                _copy_tree(skill_dir, skills_dir / skill_name)
+            if skill_dirs:
+                manifest[name] = sorted(skill_dirs)
 
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     print(f"==> Skills installed to {skills_dir}")
+    print(f"==> Manifest written to {manifest_path}")
+
+
+def _codex_marketplace_root(marketplace_json: Path) -> Path:
+    if marketplace_json.parent.name == ".claude-plugin":
+        return marketplace_json.parent.parent
+    if (
+        marketplace_json.parent.name == "plugins"
+        and marketplace_json.parent.parent.name == ".agents"
+    ):
+        return marketplace_json.parent.parent.parent
+    return marketplace_json.parent
+
+
+def _run_codex_json(args: list[str]) -> dict | None:
+    try:
+        result = subprocess.run(
+            ["codex", *args, "--json"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        print(f"  WARN: failed to run codex {' '.join(args)}: {exc}")
+        return None
+    if result.returncode != 0:
+        detail = result.stderr.strip() or "no stderr output"
+        print(f"  WARN: codex {' '.join(args)} failed (exit {result.returncode}): {detail}")
+        return None
+    try:
+        data = json.loads(result.stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _safe_codex_operand(value: object, description: str) -> str | None:
+    """Return a safe dynamic Codex operand, rejecting option-like values."""
+    if not isinstance(value, str) or not value:
+        return None
+    if value.startswith("-"):
+        print(
+            f"  WARN: rejecting Codex {description} that starts with '-'",
+            file=sys.stderr,
+        )
+        return None
+    return value
+
+
+def install_codex_plugins(
+    marketplace_json: Path,
+    skills_dir: Path | None = None,
+    manifest_path: Path | None = None,
+) -> None:
+    """Install plugins for Codex from a marketplace.
+
+    Native Codex plugins are preferred. Legacy Claude-compatible marketplaces
+    that do not expose Codex plugin packages fall back to installing their
+    skills under ``CODEX_HOME/skills``.
+    """
+    marketplace_root = _codex_marketplace_root(marketplace_json)
+    added = _run_codex_json(["plugin", "marketplace", "add", str(marketplace_root)])
+    marketplace_name = _safe_codex_operand(
+        added.get("marketplaceName") if added else None,
+        "marketplace name",
+    )
+    if added and not marketplace_name:
+        print(
+            "  WARN: codex plugin marketplace add succeeded but returned no "
+            "marketplaceName; falling back to skills compatibility layer"
+        )
+
+    listing = None
+    if marketplace_name:
+        listing = _run_codex_json(
+            ["plugin", "list", "--available", "--marketplace", marketplace_name]
+        )
+    available = listing.get("available", []) if listing else []
+
+    if not available:
+        print("==> Marketplace has no native Codex plugins; installing skills compatibility layer")
+        if skills_dir is None:
+            codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+            skills_dir = codex_home / "skills"
+        install_opencode_skills(
+            marketplace_json,
+            skills_dir=skills_dir,
+            manifest_path=manifest_path,
+        )
+        return
+
+    for entry in available:
+        name = _safe_codex_operand(entry.get("name"), "plugin name")
+        selector = _safe_codex_operand(entry.get("pluginId"), "plugin selector")
+        if not selector and name:
+            selector = f"{name}@{marketplace_name}"
+        selector = _safe_codex_operand(selector, "plugin selector")
+        if not selector:
+            continue
+        print(f"==> Installing {selector}")
+        if _run_codex_json(["plugin", "add", selector]) is None:
+            print(f"WARN: failed to install {selector}")
+
+    installed = _run_codex_json(["plugin", "list"])
+    manifest: dict[str, list[str]] = {}
+    for entry in installed.get("installed", []) if installed else []:
+        if entry.get("marketplaceName") != marketplace_name:
+            continue
+        name = entry.get("name")
+        installed_path = entry.get("installedPath")
+        if not name or not installed_path:
+            continue
+        skill_names = _find_skill_names(Path(installed_path))
+        if skill_names:
+            manifest[name] = skill_names
+
+    manifest_path = manifest_path or _manifest_path()
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
     print(f"==> Manifest written to {manifest_path}")
 
 
@@ -243,22 +408,8 @@ def _filter_claude(wanted: set[str]) -> None:
 def _filter_opencode(wanted: set[str]) -> None:
     config_dir = Path(os.environ.get("OPENCODE_CONFIG_DIR", Path.home() / ".config" / "opencode"))
 
-    manifest_path = _manifest_path()
-    if not manifest_path.is_file():
-        print(
-            f"WARNING: AGENT_ENABLED_PLUGINS is set but {manifest_path} not found",
-            file=sys.stderr,
-        )
-        return
-
-    try:
-        with open(manifest_path) as f:
-            manifest = json.load(f)
-    except (json.JSONDecodeError, ValueError):
-        print(
-            f"WARNING: {manifest_path} contains invalid JSON",
-            file=sys.stderr,
-        )
+    manifest = _load_plugin_manifest(warn_if_missing=True)
+    if manifest is None:
         return
 
     matched = wanted & set(manifest.keys())
@@ -273,6 +424,100 @@ def _filter_opencode(wanted: set[str]) -> None:
     if skills_dir.is_dir():
         for entry in skills_dir.iterdir():
             if entry.name not in wanted_skills:
+                if entry.is_symlink():
+                    entry.unlink()
+                elif entry.is_dir():
+                    shutil.rmtree(entry)
+
+
+def _load_plugin_manifest(warn_if_missing: bool = False) -> dict[str, list[str]] | None:
+    """Load the plugin-to-skills manifest.
+
+    Returns the parsed mapping, or ``None`` when the manifest is missing or
+    unreadable (invalid JSON). Callers for which the manifest is the sole
+    source of truth (OpenCode) should treat ``None`` as "do not filter";
+    callers with another source of truth (Codex native plugins) can fall back
+    to ``{}``. A manifest whose top-level JSON is not an object is treated as
+    an empty mapping.
+
+    Set ``warn_if_missing`` to emit the "manifest not found" warning when the
+    file is absent (OpenCode); Codex loads it silently.
+    """
+    manifest_path = _manifest_path()
+    if not manifest_path.is_file():
+        if warn_if_missing:
+            print(
+                f"WARNING: AGENT_ENABLED_PLUGINS is set but {manifest_path} not found",
+                file=sys.stderr,
+            )
+        return None
+    try:
+        with open(manifest_path) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, ValueError):
+        print(
+            f"WARNING: {manifest_path} contains invalid JSON",
+            file=sys.stderr,
+        )
+        return None
+    if not isinstance(data, dict):
+        return {}
+    return {
+        name: [skill for skill in skills if isinstance(skill, str)]
+        for name, skills in data.items()
+        if isinstance(name, str) and isinstance(skills, list)
+    }
+
+
+def _filter_codex(wanted: set[str]) -> None:
+    installed = _run_codex_json(["plugin", "list"])
+    native_plugins = installed.get("installed", []) if installed else []
+    manifest = _load_plugin_manifest() or {}
+
+    native_names = {
+        entry.get("name") for entry in native_plugins if isinstance(entry.get("name"), str)
+    }
+    matched = wanted & (native_names | set(manifest))
+    _check_unmatched(wanted, matched)
+
+    remove_failures: list[str] = []
+    for entry in native_plugins:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get("name")
+        if not isinstance(name, str) or not name or name in wanted:
+            continue
+        selector = _safe_codex_operand(entry.get("pluginId"), "plugin selector")
+        if not selector:
+            marketplace = _safe_codex_operand(entry.get("marketplaceName"), "marketplace name")
+            safe_name = _safe_codex_operand(name, "plugin name")
+            selector = f"{safe_name}@{marketplace}" if marketplace and safe_name else safe_name
+        if not selector:
+            remove_failures.append(str(name))
+            continue
+        if _run_codex_json(["plugin", "remove", selector]) is None:
+            print(f"ERROR: failed to disable Codex plugin {selector}", file=sys.stderr)
+            remove_failures.append(selector)
+
+    if remove_failures:
+        print(
+            "ERROR: could not enforce AGENT_ENABLED_PLUGINS; still active: "
+            + ", ".join(sorted(remove_failures)),
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    wanted_skills: set[str] = set()
+    for plugin_name, skills in manifest.items():
+        if plugin_name in wanted:
+            wanted_skills.update(skills)
+
+    codex_home = Path(os.environ.get("CODEX_HOME", Path.home() / ".codex"))
+    skills_dir = codex_home / "skills"
+    if skills_dir.is_dir():
+        managed_skills = {skill for skills in manifest.values() for skill in skills}
+        for entry in skills_dir.iterdir():
+            if entry.name in managed_skills and entry.name not in wanted_skills:
                 if entry.is_symlink():
                     entry.unlink()
                 elif entry.is_dir():
@@ -298,12 +543,14 @@ def enable_plugins() -> None:
 
     agent_tool = os.environ.get("AGENT_TOOL")
     if not agent_tool:
-        print("ERROR: AGENT_TOOL must be set (claude or opencode)", file=sys.stderr)
+        print("ERROR: AGENT_TOOL must be set (claude, opencode, or codex)", file=sys.stderr)
         sys.exit(1)
     if agent_tool == "opencode":
         _filter_opencode(wanted)
     elif agent_tool == "claude":
         _filter_claude(wanted)
+    elif agent_tool == "codex":
+        _filter_codex(wanted)
     else:
         print(f"ERROR: unknown AGENT_TOOL: {agent_tool!r}", file=sys.stderr)
         sys.exit(1)

--- a/src/agentic_ci/stream.py
+++ b/src/agentic_ci/stream.py
@@ -563,3 +563,205 @@ class OpenCodeStreamProcessor:
             if self.process_line(line):
                 return True
         return False
+
+
+class CodexStreamProcessor:
+    """Processes Codex CLI --json JSONL output and prints human-readable CI logs.
+
+    Codex emits ``thread.started``, ``turn.*``, ``item.*``, and ``error``
+    events. Items cover assistant messages, reasoning, command executions,
+    file changes, MCP calls, web searches, and plan updates.
+    """
+
+    def __init__(self, color=True, wrap=0, agent_pid=0):
+        self.wrap = wrap
+        self.agent_pid = agent_pid
+
+        if color:
+            self.THINK = "\033[3;36m"
+            self.TOOL = "\033[1;90m"
+            self.AGENT = ""
+            self.RED = "\033[31m"
+            self.RESET = "\033[0m"
+        else:
+            self.THINK = self.TOOL = self.AGENT = self.RED = self.RESET = ""
+
+        self._errors: list[str] = []
+        self._started_items: set[str] = set()
+
+    _INDENT = "  "
+
+    def _print_text(self, label, text, style=""):
+        lines = str(text).splitlines() or [""]
+        first_prefix = f"{self._INDENT}{style}{label}"
+        # Width must be measured against visible characters only; the ANSI
+        # ``style`` escape is non-printing, so excluding it keeps wrapping at
+        # the intended column instead of wrapping early when color is enabled.
+        first_prefix_width = len(self._INDENT) + len(label)
+        continuation = self._INDENT * 2
+        for index, line in enumerate(lines):
+            prefix = first_prefix if index == 0 else continuation
+            prefix_width = first_prefix_width if index == 0 else len(continuation)
+            if self.wrap and prefix_width + len(line) > self.wrap:
+                available = max(self.wrap - len(continuation), 20)
+                words = line.split()
+                chunks = []
+                current = ""
+                for word in words:
+                    candidate = f"{current} {word}".strip()
+                    if current and len(candidate) > available:
+                        chunks.append(current)
+                        current = word
+                    else:
+                        current = candidate
+                chunks.append(current)
+                for chunk_index, chunk in enumerate(chunks):
+                    chunk_prefix = prefix if chunk_index == 0 else continuation
+                    print(f"{chunk_prefix}{chunk}{self.RESET}", flush=True)
+            else:
+                print(f"{prefix}{line}{self.RESET}", flush=True)
+
+    @staticmethod
+    def _error_message(error):
+        if isinstance(error, dict):
+            return error.get("message", str(error))
+        return str(error)
+
+    def _print_command(self, item):
+        command = item.get("command", "")
+        self._print_text("\U0001f527 Shell $ ", command, self.TOOL)
+
+    @staticmethod
+    def _mcp_name(item):
+        server = item.get("server", "")
+        tool = item.get("tool", item.get("name", "unknown"))
+        return f"{server}/{tool}" if server else tool
+
+    def _process_item(self, event_type, item):
+        item_id = item.get("id", "")
+        item_type = item.get("type", "")
+
+        if event_type == "item.started":
+            if item_id:
+                self._started_items.add(item_id)
+            if item_type == "command_execution":
+                self._print_command(item)
+            elif item_type == "mcp_tool_call":
+                self._print_text("\U0001f527 MCP ", self._mcp_name(item), self.TOOL)
+            elif item_type == "web_search":
+                self._print_text("\U0001f50d Web search ", item.get("query", ""), self.TOOL)
+            return
+
+        if item_type == "agent_message":
+            self._print_text("\U0001f4ac Codex ", item.get("text", ""), self.AGENT)
+        elif item_type == "reasoning":
+            text = item.get("text", item.get("summary", ""))
+            if text:
+                self._print_text("\U0001f9e0 Thinking ", text, self.THINK)
+        elif item_type == "command_execution":
+            if item_id not in self._started_items:
+                self._print_command(item)
+            exit_code = item.get("exit_code")
+            # Codex may serialize exit_code as a number or a numeric string;
+            # normalize before comparing so a successful "0" is not rendered
+            # as a failure.
+            try:
+                normalized = int(exit_code) if exit_code is not None else None
+            except (TypeError, ValueError):
+                normalized = exit_code
+            if normalized not in (None, 0):
+                self._print_text("  exit=", str(exit_code), self.RED)
+        elif item_type == "file_change":
+            changes = item.get("changes", [])
+            if changes:
+                for change in changes:
+                    if isinstance(change, dict):
+                        path = change.get("path", "")
+                        kind = change.get("kind", change.get("type", ""))
+                        detail = f"{kind} {path}".strip()
+                    else:
+                        detail = str(change)
+                    self._print_text("\U0001f527 File change ", detail, self.TOOL)
+            else:
+                self._print_text("\U0001f527 File change ", item.get("path", ""), self.TOOL)
+        elif item_type == "mcp_tool_call":
+            error = item.get("error")
+            if error or item.get("status") in ("failed", "error"):
+                message = self._error_message(error or "MCP tool call failed")
+                label = f"❌ MCP {self._mcp_name(item)} failed: "
+                self._print_text(label, message, self.RED)
+        elif item_type == "plan":
+            text = item.get("text", item.get("plan", ""))
+            if text:
+                self._print_text("\U0001f4cb Plan ", text, self.TOOL)
+
+    def flush_errors(self):
+        """Print collected errors."""
+        if not self._errors:
+            return
+        for error_msg in dict.fromkeys(self._errors):
+            print(
+                f"{self._INDENT}{self.RED}❌ Error: {error_msg}{self.RESET}",
+                flush=True,
+            )
+
+    def process_line(self, line):
+        """Process a single JSONL line from Codex. Returns True when run is complete."""
+        line = line.strip()
+        if not line:
+            return False
+
+        try:
+            msg = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            return False
+
+        msg_type = msg.get("type", "")
+
+        if msg_type == "error":
+            error_msg = msg.get("message", self._error_message(msg.get("error", "unknown error")))
+            self._errors.append(error_msg)
+            return False
+
+        if msg_type in ("item.started", "item.completed"):
+            self._process_item(msg_type, msg.get("item", {}))
+            return False
+
+        if msg_type == "turn.failed":
+            self._errors.append(self._error_message(msg.get("error", "Codex turn failed")))
+            return False
+
+        if msg_type == "turn.completed":
+            # ``codex exec`` runs a single turn per invocation and reports its
+            # terminal token usage here, so the first turn.completed marks the
+            # end of the run. Returning True is load-bearing for telemetry:
+            # backend._process_stream uses it to wait for the OTEL batch
+            # exporter to flush (otherwise the root span is often lost) and to
+            # promote a post-completion non-zero exit code to success. If a
+            # future Codex exec mode emits multiple turns, completion should be
+            # keyed off a thread-level terminal event instead of this first
+            # turn.completed to avoid truncating the run.
+            usage = msg.get("usage", {})
+            inp = usage.get("input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            cache_r = usage.get("cached_input_tokens", 0)
+            cache_w = usage.get("cache_write_input_tokens", 0)
+            total = inp + out
+            print(
+                f"{self._INDENT}{self.TOOL}\U0001f4ca TOKENS in={inp} "
+                f"out={out} cache_r={cache_r} cache_w={cache_w} "
+                f"total={total}{self.RESET}",
+                flush=True,
+            )
+            return True
+
+        return False
+
+    def process(self, input_stream):
+        """Process a stream of lines. Returns True if run completed normally."""
+        for line in input_stream:
+            if isinstance(line, bytes):
+                line = line.decode("utf-8", errors="replace")
+            if self.process_line(line):
+                return True
+        return False

--- a/tests/e2e/e2e-codex-runner.sh
+++ b/tests/e2e/e2e-codex-runner.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# shellcheck source=tests/images/shell-utils.sh
+# e2e-codex-runner.sh -- End-to-end tests for the codex-runner image
+# using agentic-ci.
+#
+# Builds are handled by the CI job; this script runs a test prompt via
+# agentic-ci and verifies the output.
+#
+# Requires: python3, podman, agentic-ci
+# Credentials: OPENAI_API_KEY
+#
+# Usage:
+#   ./tests/e2e/e2e-codex-runner.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$SCRIPT_DIR/../images/shell-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_E2E="$(mktemp -d)"
+
+cleanup() {
+    agentic-ci stop --harness codex 2>/dev/null || true
+    rm -rf "$TMPDIR_E2E"
+    echo ""
+    print_header "=== Results ==="
+    print_success "Passed: $PASS"
+    if [[ "$FAIL" -gt 0 ]]; then
+        print_error "Failed: $FAIL"
+        exit 1
+    else
+        print_success "All tests passed!"
+    fi
+}
+trap cleanup EXIT
+
+assert_ok() {
+    local desc="$1"; shift
+    if "$@" >/dev/null 2>&1; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local desc="$1" output="$2" pattern="$3"
+    if echo "$output" | grep -qi "$pattern"; then
+        print_success "PASS: $desc"
+        PASS=$((PASS + 1))
+    else
+        print_error "FAIL: $desc -- expected '$pattern' in output"
+        echo "  Got: ${output:0:200}"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# -- Preflight ---------------------------------------------------------------
+print_header "=== Preflight checks ==="
+check_dependencies python3 podman agentic-ci
+
+print_header "=== Component versions ==="
+echo "  agentic-ci: $(agentic-ci --version 2>&1 || echo unknown)"
+echo "  podman:     $(podman --version 2>&1 || echo unknown)"
+
+IMAGE="${CODEX_CONTAINER_IMAGE:-localhost/codex-runner:latest}"
+
+_has_creds() {
+    [[ -n "${OPENAI_API_KEY:-}" ]]
+}
+
+if ! _has_creds; then
+    echo ""
+    print_warning "Skipping e2e tests (no credentials set)"
+    print_warning "Set OPENAI_API_KEY"
+    exit 0
+fi
+
+# -- Run Codex test -----------------------------------------------------------
+print_header "=== agentic-ci run: Codex ==="
+
+WORKDIR="$TMPDIR_E2E/run"
+mkdir -p "$WORKDIR"
+
+print_step "Running Codex via agentic-ci..."
+RC=0
+agentic-ci run "Reply with only the word pong" \
+    --image "$IMAGE" \
+    --harness codex \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    > "$TMPDIR_E2E/out.txt" 2>"$TMPDIR_E2E/err.txt" || RC=$?
+
+assert_ok "container exited successfully" test "$RC" -eq 0
+
+COMBINED_OUTPUT="$(cat "$TMPDIR_E2E/out.txt" 2>/dev/null)$(cat "$TMPDIR_E2E/err.txt" 2>/dev/null)"
+assert_ok "output captured" test -n "$COMBINED_OUTPUT"
+
+if [[ -s "$TMPDIR_E2E/out.txt" ]]; then
+    echo "--- output ---"
+    head -20 "$TMPDIR_E2E/out.txt"
+    echo "--- end output ---"
+fi
+if [[ -s "$TMPDIR_E2E/err.txt" ]]; then
+    echo "--- stderr ---"
+    head -20 "$TMPDIR_E2E/err.txt"
+    echo "--- end stderr ---"
+fi
+
+# Stop the container before the next test
+agentic-ci stop --harness codex 2>/dev/null || true
+
+# -- Setup steps test ---------------------------------------------------------
+print_header "=== agentic-ci run: setup steps (podman) ==="
+
+WORKDIR="$TMPDIR_E2E/setup-steps"
+mkdir -p "$WORKDIR/.agentic-ci"
+cat > "$WORKDIR/.agentic-ci/config.yml" <<'CONFIG'
+setup:
+  - name: Create marker file
+    run: echo "setup-complete" > .setup-marker
+CONFIG
+
+print_step "Running Codex with setup steps (podman)..."
+SETUP_LOG="$TMPDIR_E2E/setup-steps-out.txt"
+RC=0
+agentic-ci run \
+    "Check if the file .setup-marker exists and contains 'setup-complete'. If yes, reply with only the word pong. If not, reply with only the word fail." \
+    --image "$IMAGE" \
+    --harness codex \
+    --workdir "$WORKDIR" \
+    --no-otel \
+    > "$SETUP_LOG" 2>&1 || RC=$?
+
+OUTPUT="$(cat "$SETUP_LOG")"
+assert_ok "setup-steps run exited successfully" test "$RC" -eq 0
+assert_contains "setup-steps: marker file found by agent" "$OUTPUT" "pong"
+
+agentic-ci stop --harness codex 2>/dev/null || true
+
+echo ""
+print_header "=== All test sections complete ==="

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -135,8 +135,8 @@ if [[ -s "$TMPDIR_E2E/nostream-out.txt" ]]; then
     echo "--- end non-streaming output ---"
 fi
 
-# -- Codex streaming + OTEL test ---------------------------------------------
-print_header "=== agentic-ci run --backend local: Codex + OTEL ==="
+# -- Codex streaming, resume + OTEL test -------------------------------------
+print_header "=== agentic-ci run --backend local: Codex + resume + OTEL ==="
 
 _has_codex_creds() {
     [[ -n "${OPENAI_API_KEY:-}" ]] || \
@@ -145,12 +145,14 @@ _has_codex_creds() {
 
 if command -v codex >/dev/null 2>&1 && _has_codex_creds; then
     WORKDIR="$TMPDIR_E2E/codex"
+    CODEX_HOME="$TMPDIR_E2E/codex-home"
     mkdir -p "$WORKDIR"
+    mkdir -p "$CODEX_HOME"
 
     print_step "Running Codex via local backend with OTEL..."
     RC=0
-    agentic-ci run --backend local \
-        "Reply with only the word codex-pong" \
+    CODEX_HOME="$CODEX_HOME" agentic-ci run --backend local \
+        "Remember this unique fact exactly: codex-resume-fact-7f3c. Reply with only codex-first-pong." \
         --harness codex \
         --model gpt-5.6-sol \
         --workdir "$WORKDIR" \
@@ -163,6 +165,20 @@ if command -v codex >/dev/null 2>&1 && _has_codex_creds; then
         "$(cat "$TMPDIR_E2E/codex-out.txt")" "API Requests:"
     assert_contains "Codex cost summary is present" \
         "$(cat "$TMPDIR_E2E/codex-out.txt")" "Cost (USD)"
+
+    print_step "Resuming the Codex session with --last..."
+    RC=0
+    CODEX_HOME="$CODEX_HOME" agentic-ci run --backend local \
+        "Reply with only the unique fact from the previous turn." \
+        --harness codex \
+        --model gpt-5.6-sol \
+        --workdir "$WORKDIR" \
+        -- resume --last \
+        > "$TMPDIR_E2E/codex-resume-out.txt" 2>"$TMPDIR_E2E/codex-resume-err.txt" || RC=$?
+
+    assert_ok "Codex resume local run exited successfully" test "$RC" -eq 0
+    assert_contains "Codex resume remembered the unique fact" \
+        "$(cat "$TMPDIR_E2E/codex-resume-out.txt")" "codex-resume-fact-7f3c"
 else
     print_warning "Skipping Codex local test (codex CLI or credentials unavailable)"
 fi

--- a/tests/e2e/e2e-local-runner.sh
+++ b/tests/e2e/e2e-local-runner.sh
@@ -135,6 +135,38 @@ if [[ -s "$TMPDIR_E2E/nostream-out.txt" ]]; then
     echo "--- end non-streaming output ---"
 fi
 
+# -- Codex streaming + OTEL test ---------------------------------------------
+print_header "=== agentic-ci run --backend local: Codex + OTEL ==="
+
+_has_codex_creds() {
+    [[ -n "${OPENAI_API_KEY:-}" ]] || \
+    [[ -f "${CODEX_HOME:-${HOME}/.codex}/auth.json" ]]
+}
+
+if command -v codex >/dev/null 2>&1 && _has_codex_creds; then
+    WORKDIR="$TMPDIR_E2E/codex"
+    mkdir -p "$WORKDIR"
+
+    print_step "Running Codex via local backend with OTEL..."
+    RC=0
+    agentic-ci run --backend local \
+        "Reply with only the word codex-pong" \
+        --harness codex \
+        --model gpt-5.6-sol \
+        --workdir "$WORKDIR" \
+        > "$TMPDIR_E2E/codex-out.txt" 2>"$TMPDIR_E2E/codex-err.txt" || RC=$?
+
+    assert_ok "Codex local run exited successfully" test "$RC" -eq 0
+    assert_contains "Codex streaming output contains response" \
+        "$(cat "$TMPDIR_E2E/codex-out.txt")" "codex-pong"
+    assert_contains "Codex exported OTEL API request events" \
+        "$(cat "$TMPDIR_E2E/codex-out.txt")" "API Requests:"
+    assert_contains "Codex cost summary is present" \
+        "$(cat "$TMPDIR_E2E/codex-out.txt")" "Cost (USD)"
+else
+    print_warning "Skipping Codex local test (codex CLI or credentials unavailable)"
+fi
+
 # -- Extra args passthrough test ----------------------------------------------
 print_header "=== agentic-ci run --backend local: extra args ==="
 

--- a/tests/e2e/e2e-openshell-sandbox.sh
+++ b/tests/e2e/e2e-openshell-sandbox.sh
@@ -27,6 +27,7 @@ TMPDIR_E2E="$(mktemp -d)"
 cleanup() {
     agentic-ci stop --backend openshell --harness claude-code 2>/dev/null || true
     agentic-ci stop --backend openshell --harness opencode 2>/dev/null || true
+    agentic-ci stop --backend openshell --harness codex 2>/dev/null || true
     rm -rf "$TMPDIR_E2E"
     echo ""
     print_header "=== Results ==="
@@ -75,12 +76,14 @@ dump_gateway_log() {
 
 # --- Resolve sandbox images ---
 # Use pre-built images from env vars (CI), or build locally (dev).
-if [[ -n "${CLAUDE_SANDBOX_IMAGE:-}" ]] && [[ -n "${OPENCODE_SANDBOX_IMAGE:-}" ]]; then
+if [[ -n "${CLAUDE_SANDBOX_IMAGE:-}" ]] && [[ -n "${OPENCODE_SANDBOX_IMAGE:-}" ]] && [[ -n "${CODEX_SANDBOX_IMAGE:-}" ]]; then
     print_header "=== Using pre-built sandbox images ==="
     CLAUDE_SANDBOX="$CLAUDE_SANDBOX_IMAGE"
     OPENCODE_SANDBOX="$OPENCODE_SANDBOX_IMAGE"
+    CODEX_SANDBOX="$CODEX_SANDBOX_IMAGE"
     print_step "claude-sandbox: $CLAUDE_SANDBOX"
     print_step "opencode-sandbox: $OPENCODE_SANDBOX"
+    print_step "codex-sandbox: $CODEX_SANDBOX"
 else
     print_header "=== Building OpenShell sandbox images ==="
 
@@ -102,6 +105,13 @@ else
         "$REPO_ROOT/images/runner/"
 
     OPENCODE_SANDBOX="localhost/opencode-sandbox:latest"
+
+    print_step "Building codex-sandbox..."
+    podman build -t localhost/codex-sandbox:latest \
+        -f "$REPO_ROOT/images/runner/codex/Containerfile.openshell" \
+        "$REPO_ROOT"
+
+    CODEX_SANDBOX="localhost/codex-sandbox:latest"
 fi
 
 # --- Resolve supervisor image ---
@@ -245,6 +255,19 @@ assert_contains "manifest has autofix-resolve" "$OC_AUTOFIX_SKILLS" "autofix-res
 assert_contains "manifest has autofix-cve-resolve" "$OC_AUTOFIX_SKILLS" "autofix-cve-resolve"
 assert_contains "manifest has autofix-triage" "$OC_AUTOFIX_SKILLS" "autofix-triage"
 
+# --- codex-sandbox checks ---
+print_header "=== codex-sandbox: binaries ==="
+assert_ok "codex is installed" run_in "$CODEX_SANDBOX" codex --version
+assert_ok "node is installed" run_in "$CODEX_SANDBOX" node --version
+print_header "=== codex-sandbox: config ==="
+assert_ok "codex home directory exists" \
+    run_in "$CODEX_SANDBOX" test -d /sandbox/.codex
+print_header "=== codex-sandbox: entrypoint ==="
+assert_ok "entrypoint.sh is installed" \
+    run_in "$CODEX_SANDBOX" test -x /usr/local/bin/entrypoint.sh
+assert_ok "agentic-ci is installed" \
+    run_in "$CODEX_SANDBOX" agentic-ci --version
+
 # --- Agent run tests (require credentials) ---
 _has_creds() {
     [[ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]] || \
@@ -282,6 +305,7 @@ else
     echo "  podman:            $(podman --version 2>&1 || echo unknown)"
     echo "  claude:            $(run_in "$CLAUDE_SANDBOX" claude --version 2>&1 || echo unknown)"
     echo "  opencode:          $(run_in "$OPENCODE_SANDBOX" opencode --version 2>&1 || echo unknown)"
+    echo "  codex:             $(run_in "$CODEX_SANDBOX" codex --version 2>&1 || echo unknown)"
 
     # --- Claude Code via OpenShell ---
     print_header "=== agentic-ci run: Claude Code via OpenShell ==="
@@ -324,6 +348,34 @@ else
     dump_gateway_log
 
     agentic-ci stop --backend openshell --harness opencode 2>/dev/null || true
+
+    # --- Codex via OpenShell ---
+    _has_codex_creds() {
+        [[ -n "${OPENAI_API_KEY:-}" ]]
+    }
+
+    if _has_codex_creds; then
+        print_header "=== agentic-ci run: Codex via OpenShell ==="
+
+        WORKDIR="$TMPDIR_E2E/codex"
+        mkdir -p "$WORKDIR"
+
+        print_step "Running Codex via agentic-ci (openshell backend)..."
+        RC=0
+        agentic-ci run "Reply with only the word pong" \
+            --backend openshell \
+            --image "$CODEX_SANDBOX" \
+            --harness codex \
+            --workdir "$WORKDIR" \
+            --no-otel || RC=$?
+
+        assert_ok "codex exited successfully" test "$RC" -eq 0
+        dump_gateway_log
+
+        agentic-ci stop --backend openshell --harness codex 2>/dev/null || true
+    else
+        print_warning "Skipping Codex OpenShell test (OPENAI_API_KEY not set)"
+    fi
 
     # --- Repo-level network policy test ---
     # Verifies that .agentic-ci/openshell-policy.yml in the workdir adds

--- a/tests/images/test_entrypoint.sh
+++ b/tests/images/test_entrypoint.sh
@@ -89,6 +89,12 @@ OC_ENV=$(run_detect "opencode")
 assert_contains "opencode: sets OPENCODE_DISABLE_AUTOUPDATE=1" "$OC_ENV" "OPENCODE_DISABLE_AUTOUPDATE=1"
 assert_not_contains "opencode: does not set DISABLE_AUTOUPDATER" "$OC_ENV" "DISABLE_AUTOUPDATER"
 
+print_header "=== Entrypoint tool detection: codex ==="
+
+CODEX_ENV=$(run_detect "codex")
+assert_not_contains "codex: does not set Claude auto-update vars" "$CODEX_ENV" "DISABLE_AUTOUPDATER"
+assert_not_contains "codex: does not set OpenCode auto-update vars" "$CODEX_ENV" "OPENCODE_DISABLE_AUTOUPDATE"
+
 print_header "=== Entrypoint tool detection: AGENT_TOOL fallback ==="
 
 AGENT_TOOL_CLAUDE_ENV=$(env -i HOME="$HOME" PATH="$PATH" AGENT_TOOL=claude bash -c "

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,5 +1,6 @@
 """Tests for backend factory."""
 
+import json
 import threading
 from unittest import mock
 
@@ -7,9 +8,13 @@ import pytest
 
 from agentic_ci.backends import create_backend
 from agentic_ci.backends.local import LocalBackend
-from agentic_ci.backends.openshell import OpenShellBackend, _token_keepalive
+from agentic_ci.backends.openshell import (
+    OpenShellBackend,
+    _load_sandbox_identity,
+    _token_keepalive,
+)
 from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import ClaudeCodeHarness, create_harness
+from agentic_ci.harness import ClaudeCodeHarness, CodexHarness, create_harness
 
 
 @pytest.fixture()
@@ -59,6 +64,14 @@ def test_create_podman_with_timeout(harness):
     assert backend.timeout == 600
 
 
+def test_load_sandbox_identity_handles_invalid_utf8(monkeypatch, tmp_path):
+    state_path = tmp_path / "openshell-state.json"
+    state_path.write_bytes(b"\xff")
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    assert _load_sandbox_identity() is None
+
+
 def test_create_podman_with_extra_env(harness):
     backend = create_backend("podman", harness=harness, extra_env={"FOO": "bar"})
     assert backend._extra_env == {"FOO": "bar"}
@@ -79,6 +92,81 @@ def test_unknown_backend_raises(harness):
         create_backend("docker", harness=harness)
 
 
+def test_local_codex_credentials_fail_fast(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / "missing-codex-home"))
+
+    backend = LocalBackend(workdir=str(tmp_path), harness=CodexHarness())
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        backend.setup()
+
+
+def test_local_codex_accepts_auth_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    backend = LocalBackend(workdir=str(tmp_path), harness=CodexHarness())
+    backend.setup()
+
+
+def test_local_codex_passes_extra_openai_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    backend = LocalBackend(
+        workdir=str(tmp_path),
+        harness=CodexHarness(),
+        extra_env={"OPENAI_API_KEY": "extra-key"},
+    )
+    process = mock.Mock(pid=123)
+
+    with (
+        mock.patch("agentic_ci.backends.local.subprocess.Popen", return_value=process) as popen,
+        mock.patch.object(backend, "_process_stream", return_value=(0, False)),
+    ):
+        backend.run("prompt", "model", streaming=False)
+
+    assert popen.call_args.kwargs["env"]["OPENAI_API_KEY"] == "extra-key"
+    assert not any("extra-key" in arg for arg in popen.call_args.args[0])
+
+
+def test_local_codex_extra_openai_key_overrides_global_key(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "global-key")
+
+    backend = LocalBackend(
+        workdir=str(tmp_path),
+        harness=CodexHarness(),
+        extra_env={"OPENAI_API_KEY": "extra-key"},
+    )
+    process = mock.Mock(pid=123)
+
+    with (
+        mock.patch("agentic_ci.backends.local.subprocess.Popen", return_value=process) as popen,
+        mock.patch.object(backend, "_process_stream", return_value=(0, False)),
+    ):
+        backend.run("prompt", "model", streaming=False)
+
+    child_env = popen.call_args.kwargs["env"]
+    assert child_env["OPENAI_API_KEY"] == "extra-key"
+
+
+def test_podman_codex_openai_key_is_passed_without_secret_in_args(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        harness=CodexHarness(),
+        extra_env={"OPENAI_API_KEY": "test-key"},
+    )
+    args = backend._build_env_args({"OPENAI_API_KEY": "test-key"})
+
+    assert "OPENAI_API_KEY" in args
+    assert not any("test-key" in arg for arg in args)
+
+
 def test_backends_have_stop_method(harness):
     podman = create_backend("podman", harness=harness, workdir="/tmp")
     openshell = create_backend("openshell", harness=harness, workdir="/tmp")
@@ -86,6 +174,163 @@ def test_backends_have_stop_method(harness):
     assert callable(getattr(podman, "stop", None))
     assert callable(getattr(openshell, "stop", None))
     assert callable(getattr(local, "stop", None))
+
+
+def test_openshell_codex_requires_api_key(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    backend = OpenShellBackend(workdir=str(tmp_path), harness=CodexHarness())
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running") as is_running,
+        pytest.raises(RuntimeError, match="OPENAI_API_KEY"),
+    ):
+        backend.setup()
+
+    is_running.assert_not_called()
+
+
+def test_openshell_reuses_sandbox_when_auth_mode_matches(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    state_path = tmp_path / "openshell-state.json"
+    state_path.write_text(json.dumps({"auth_mode": "openai", "harness": "Codex", "image": None}))
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    backend = OpenShellBackend(workdir=str(tmp_path), harness=CodexHarness())
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.sandbox.exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.provider_exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.auth_mode", return_value="openai"),
+        mock.patch("agentic_ci.backends.openshell.provider.setup") as setup_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.create") as create_sandbox,
+    ):
+        backend.setup()
+
+    setup_provider.assert_not_called()
+    create_sandbox.assert_not_called()
+
+
+def test_openshell_recreates_sandbox_when_auth_mode_changes(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    state_path = tmp_path / "openshell-state.json"
+    state_path.write_text(
+        json.dumps({"auth_mode": "vertex", "harness": "Claude Code", "image": None})
+    )
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    backend = OpenShellBackend(workdir=str(tmp_path), harness=CodexHarness())
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.sandbox.exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.provider_exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.auth_mode", return_value="vertex"),
+        mock.patch("agentic_ci.backends.openshell.provider.delete") as delete_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.delete") as delete_sandbox,
+        mock.patch("agentic_ci.backends.openshell.provider.setup") as setup_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.create") as create_sandbox,
+        mock.patch.object(backend, "_run_setup_steps"),
+        mock.patch.object(backend, "_upload_sandbox_config"),
+        mock.patch("agentic_ci.backends.openshell.sandbox.upload"),
+    ):
+        backend.setup()
+
+    delete_sandbox.assert_called_once_with()
+    delete_provider.assert_called_once_with()
+    setup_provider.assert_called_once_with(auth_mode="openai", env=mock.ANY)
+    create_sandbox.assert_called_once()
+    assert create_sandbox.call_args.kwargs["auth_mode"] == "openai"
+
+
+def test_openshell_recreates_sandbox_when_identity_changes(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    state_path = tmp_path / "openshell-state.json"
+    state_path.write_text(
+        json.dumps({"auth_mode": "openai", "harness": "Codex", "image": "old-image"})
+    )
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    backend = OpenShellBackend(workdir=str(tmp_path), harness=CodexHarness(), image="new-image")
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.sandbox.exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.provider_exists", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.provider.auth_mode", return_value="openai"),
+        mock.patch("agentic_ci.backends.openshell.provider.setup") as setup_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.create") as create_sandbox,
+        mock.patch("agentic_ci.backends.openshell.sandbox.delete") as delete_sandbox,
+        mock.patch.object(backend, "_run_setup_steps"),
+        mock.patch.object(backend, "_upload_sandbox_config"),
+        mock.patch("agentic_ci.backends.openshell.sandbox.upload"),
+    ):
+        backend.setup()
+
+    delete_sandbox.assert_called_once_with()
+    setup_provider.assert_called_once_with(auth_mode="openai", env=mock.ANY)
+    create_sandbox.assert_called_once()
+    assert create_sandbox.call_args.kwargs["image"] == "new-image"
+
+
+def test_openshell_passes_extra_env_to_provider(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    state_path = tmp_path / "openshell-state.json"
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    backend = OpenShellBackend(
+        workdir=str(tmp_path),
+        harness=CodexHarness(),
+        extra_env={"OPENAI_API_KEY": "extra-key"},
+    )
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.sandbox.exists", return_value=False),
+        mock.patch("agentic_ci.backends.openshell.provider.provider_exists", return_value=False),
+        mock.patch("agentic_ci.backends.openshell.provider.validate_credentials") as validate,
+        mock.patch("agentic_ci.backends.openshell.provider.setup") as setup_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.create"),
+        mock.patch.object(backend, "_run_setup_steps"),
+        mock.patch.object(backend, "_upload_sandbox_config"),
+        mock.patch("agentic_ci.backends.openshell.sandbox.upload"),
+    ):
+        backend.setup()
+
+    validate.assert_called_once_with("openai", mock.ANY)
+    assert validate.call_args.args[1]["OPENAI_API_KEY"] == "extra-key"
+    setup_provider.assert_called_once_with(auth_mode="openai", env=mock.ANY)
+    assert setup_provider.call_args.kwargs["env"]["OPENAI_API_KEY"] == "extra-key"
+
+
+def test_openshell_uses_extra_env_for_claude_auth_mode(monkeypatch, tmp_path):
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    state_path = tmp_path / "openshell-state.json"
+    monkeypatch.setenv("AGENTIC_CI_OPENSHELL_STATE", str(state_path))
+
+    backend = OpenShellBackend(
+        workdir=str(tmp_path),
+        harness=ClaudeCodeHarness(),
+        extra_env={"ANTHROPIC_API_KEY": "extra-key"},
+    )
+
+    with (
+        mock.patch("agentic_ci.backends.openshell.gateway.is_running", return_value=True),
+        mock.patch("agentic_ci.backends.openshell.sandbox.exists", return_value=False),
+        mock.patch("agentic_ci.backends.openshell.provider.provider_exists", return_value=False),
+        mock.patch("agentic_ci.backends.openshell.provider.validate_credentials") as validate,
+        mock.patch("agentic_ci.backends.openshell.provider.setup") as setup_provider,
+        mock.patch("agentic_ci.backends.openshell.sandbox.create") as create_sandbox,
+        mock.patch.object(backend, "_run_setup_steps"),
+        mock.patch.object(backend, "_upload_sandbox_config"),
+        mock.patch("agentic_ci.backends.openshell.sandbox.upload"),
+    ):
+        backend.setup()
+
+    validate.assert_called_once_with("api-key", mock.ANY)
+    setup_provider.assert_called_once_with(auth_mode="api-key", env=mock.ANY)
+    assert create_sandbox.call_args.kwargs["auth_mode"] == "api-key"
 
 
 class TestOpenShellEnvScript:
@@ -121,6 +366,7 @@ class TestOpenShellEnvScript:
 
     def test_env_script_calls_enable_plugins(self, monkeypatch, tmp_path):
         script = self._capture_script(monkeypatch, tmp_path)
+        assert "command -v agentic-ci" in script
         assert "agentic-ci enable-plugins" in script
 
     def test_env_script_sets_seed_dir(self, monkeypatch, tmp_path):
@@ -177,6 +423,48 @@ class TestOpenShellEnvScript:
     def test_env_script_omits_max_retries_for_api_key(self, monkeypatch, tmp_path):
         script = self._capture_script(monkeypatch, tmp_path)
         assert "CLAUDE_CODE_MAX_RETRIES" not in script
+
+    def test_env_script_uses_extra_env_for_claude_api_key(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        backend = OpenShellBackend(
+            workdir=str(tmp_path),
+            harness=ClaudeCodeHarness(),
+            extra_env={"ANTHROPIC_API_KEY": "TEST_MARKER"},
+        )
+        captured = []
+
+        def mock_upload(path):
+            with open(path) as f:
+                captured.append(f.read())
+
+        with (
+            mock.patch("agentic_ci.backends.openshell.sandbox.upload", side_effect=mock_upload),
+            mock.patch("agentic_ci.backends.openshell.sandbox.exec_cmd"),
+        ):
+            backend._write_env_script("claude-opus-4-6")
+
+        assert "export ANTHROPIC_API_KEY=TEST_MARKER" in captured[0]
+        assert "CLAUDE_CODE_USE_VERTEX" not in captured[0]
+
+    def test_codex_env_script_contains_openai_key_for_l4_auth(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        monkeypatch.setenv("OPENAI_API_KEY", "super-secret")
+
+        backend = OpenShellBackend(workdir=str(tmp_path), harness=CodexHarness())
+        captured = []
+
+        def mock_upload(path):
+            with open(path) as env_script:
+                captured.append(env_script.read())
+
+        with (
+            mock.patch("agentic_ci.backends.openshell.sandbox.upload", side_effect=mock_upload),
+            mock.patch("agentic_ci.backends.openshell.sandbox.exec_cmd"),
+        ):
+            backend._write_env_script("gpt-5.6-sol")
+
+        assert len(captured) == 1
+        assert "export OPENAI_API_KEY=super-secret" in captured[0]
 
 
 class TestTokenKeepalive:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,69 @@
+"""Tests for telemetry-derived model cost estimates."""
+
+import json
+from importlib.resources import files
+
+import pytest
+
+from agentic_ci.cost import estimate_cost
+
+
+def test_bundled_cost_map_has_litellm_provenance():
+    snapshot = json.loads(
+        files("agentic_ci").joinpath("data/litellm_openai_cost_map.json").read_text()
+    )
+
+    assert len(snapshot["source"]["commit"]) == 40
+    assert snapshot["source"]["url"].endswith(
+        f"/{snapshot['source']['commit']}/model_prices_and_context_window.json"
+    )
+    assert len(snapshot["models"]) >= 100
+
+
+def test_estimate_codex_priority_cost_with_cache_rates():
+    cost = estimate_cost(
+        "gpt-5.6-sol",
+        input_tokens=50,
+        output_tokens=20,
+        cached_input_tokens=40,
+        cache_creation_input_tokens=10,
+        service_tier="priority",
+    )
+
+    assert cost == pytest.approx(0.001865)
+
+
+def test_estimate_cost_uses_custom_litellm_map(tmp_path, monkeypatch):
+    cost_map = tmp_path / "model-prices.json"
+    cost_map.write_text(
+        json.dumps(
+            {
+                "custom-model": {
+                    "input_cost_per_token": 1e-6,
+                    "output_cost_per_token": 2e-6,
+                    "cache_read_input_token_cost": 3e-7,
+                    "cache_creation_input_token_cost": 4e-7,
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("AGENTIC_CI_LITELLM_COST_MAP", str(cost_map))
+
+    cost = estimate_cost(
+        "custom-model",
+        input_tokens=10,
+        output_tokens=20,
+        cached_input_tokens=3,
+        cache_creation_input_tokens=4,
+    )
+
+    assert cost == pytest.approx(0.0000525)
+
+
+def test_estimate_cost_returns_none_for_unknown_model():
+    assert estimate_cost("unknown-model", input_tokens=10, output_tokens=10) is None
+
+
+def test_estimate_cost_returns_none_for_negative_usage():
+    assert estimate_cost("gpt-5.6-sol", input_tokens=-1, output_tokens=10) is None

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -4,9 +4,11 @@ import pytest
 
 from agentic_ci.harness import (
     ClaudeCodeHarness,
+    CodexHarness,
     OpenCodeHarness,
     create_harness,
 )
+from agentic_ci.stream import CodexStreamProcessor
 
 
 def test_create_claude_code_harness():
@@ -17,6 +19,11 @@ def test_create_claude_code_harness():
 def test_create_opencode_harness():
     harness = create_harness("opencode")
     assert isinstance(harness, OpenCodeHarness)
+
+
+def test_create_codex_harness():
+    harness = create_harness("codex")
+    assert isinstance(harness, CodexHarness)
 
 
 def test_create_unknown_harness_raises():
@@ -39,6 +46,11 @@ class TestAuthMode:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
         assert ClaudeCodeHarness().auth_mode == "vertex"
         assert OpenCodeHarness().auth_mode == "vertex"
+
+    def test_api_key_from_explicit_environment(self):
+        env = {"ANTHROPIC_API_KEY": "test-key"}
+        assert ClaudeCodeHarness().auth_mode_for_env(env) == "api-key"
+        assert OpenCodeHarness().auth_mode_for_env(env) == "api-key"
 
 
 class TestClaudeCodeHarness:
@@ -435,3 +447,124 @@ class TestOpenCodeHarness:
         harness = OpenCodeHarness()
         mounts = harness.sandbox_config_mounts(str(tmp_path))
         assert mounts == []
+
+
+class TestCodexHarness:
+    def test_name(self):
+        assert CodexHarness().name == "Codex"
+
+    def test_auth_mode_is_openai(self, monkeypatch):
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        assert CodexHarness().auth_mode == "openai"
+
+    def test_build_args(self):
+        harness = CodexHarness()
+        args = harness.build_args("do something", "gpt-5.6-sol")
+        assert args[0:2] == ["bash", "-c"]
+        assert "codex login --with-api-key" in args[2]
+        assert "codex login --with-api-key failed" in args[2]
+        assert "2>&1" not in args[2]
+        assert 'exec codex "$@"' in args[2]
+        assert "exec" in args
+        assert "--dangerously-bypass-approvals-and-sandbox" in args
+        assert "--json" in args
+        assert "--skip-git-repo-check" in args
+        assert "--ephemeral" in args
+        assert "--ignore-user-config" not in args
+        config_values = [args[index + 1] for index, arg in enumerate(args) if arg == "-c"]
+        assert "check_for_update_on_startup=false" in config_values
+        assert "-m" in args
+        assert "gpt-5.6-sol" in args
+        assert "do something" in args
+
+    def test_build_args_with_otel(self):
+        args = CodexHarness().build_args(
+            "prompt",
+            "model",
+            otel_endpoint="http://127.0.0.1:4318",
+        )
+        config_values = [args[index + 1] for index, arg in enumerate(args) if arg == "-c"]
+        assert any("http://127.0.0.1:4318/v1/logs" in value for value in config_values)
+        assert any("http://127.0.0.1:4318/v1/metrics" in value for value in config_values)
+        assert any("http://127.0.0.1:4318/v1/traces" in value for value in config_values)
+
+    def test_build_args_with_extra(self):
+        harness = CodexHarness()
+        args = harness.build_args("prompt", "model", extra_args=["--foo", "bar"])
+        assert "--foo" in args
+        assert "bar" in args
+
+    def test_build_args_keeps_prompt_after_option_delimiter(self):
+        args = CodexHarness().build_args("--help", "model", extra_args=["--color", "never"])
+
+        assert args[-1] == "--help"
+        assert args[-2] == "--"
+        assert args.index("--color") < len(args) - 2
+
+    def test_build_env_args(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        harness = CodexHarness()
+        args = harness.build_env_args()
+        assert "OPENAI_API_KEY" in args
+        assert "AGENT_TOOL=codex" in args
+        assert not any("test-key" in arg for arg in args)
+
+    def test_build_env_script_lines(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-key")
+        harness = CodexHarness()
+        lines = harness.build_env_script_lines()
+        assert "export OPENAI_API_KEY=sk-test-key" in lines
+        assert "mkdir -p /sandbox/.codex" in lines
+        assert any("AGENT_TOOL=codex" in line for line in lines)
+        assert any("CODEX_HOME=/sandbox/.codex" in line for line in lines)
+
+    def test_build_env_script_lines_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        lines = CodexHarness().build_env_script_lines()
+
+        assert not any("OPENAI_API_KEY" in line for line in lines)
+
+    def test_build_env_script_lines_forwards_enabled_plugins(self, monkeypatch):
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "alpha,beta")
+        lines = CodexHarness().build_env_script_lines()
+        assert any("AGENT_ENABLED_PLUGINS=alpha,beta" in line for line in lines)
+
+    def test_build_otel_exec_env_always_empty(self):
+        assert CodexHarness().build_otel_exec_env(otel_port=4318) == []
+
+    def test_build_local_env(self, monkeypatch):
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "alpha")
+        env = CodexHarness().build_local_env()
+        assert env["AGENT_TOOL"] == "codex"
+        assert env["AGENT_ENABLED_PLUGINS"] == "alpha"
+
+    def test_build_local_env_does_not_copy_api_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-key")
+
+        env = CodexHarness().build_local_env()
+
+        assert "OPENAI_API_KEY" not in env
+
+    def test_credential_mount_target(self):
+        assert CodexHarness().credential_mount_target() == "/home/agent-ci"
+
+    def test_credential_mount_target_env_override(self, monkeypatch):
+        monkeypatch.setenv("CODEX_CONTAINER_HOME", "/home/codex")
+        assert CodexHarness().credential_mount_target() == "/home/codex"
+
+    def test_create_stream_processor(self):
+        proc = CodexHarness().create_stream_processor(pid=789)
+        assert isinstance(proc, CodexStreamProcessor)
+
+    def test_image_env_var(self):
+        assert CodexHarness().image_env_var() == "CODEX_CONTAINER_IMAGE"
+
+    def test_model_env_var(self):
+        assert CodexHarness().model_env_var() == "CODEX_MODEL"
+
+    def test_default_model(self):
+        assert CodexHarness().default_model() == "gpt-5.6-sol"
+
+    def test_supports_otel(self):
+        assert CodexHarness().supports_otel is True

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -1,5 +1,9 @@
 """Tests for harness abstraction."""
 
+import json
+import os
+import subprocess
+
 import pytest
 
 from agentic_ci.harness import (
@@ -463,13 +467,15 @@ class TestCodexHarness:
         assert args[0:2] == ["bash", "-c"]
         assert "codex login --with-api-key" in args[2]
         assert "codex login --with-api-key failed" in args[2]
-        assert "2>&1" not in args[2]
+        assert ">/dev/null 2>&1" in args[2]
+        assert "unset OPENAI_API_KEY" in args[2]
         assert 'exec codex "$@"' in args[2]
         assert "exec" in args
-        assert "--dangerously-bypass-approvals-and-sandbox" in args
+        assert "--approve-for-me" in args
+        assert "--dangerously-bypass-approvals-and-sandbox" not in args
         assert "--json" in args
         assert "--skip-git-repo-check" in args
-        assert "--ephemeral" in args
+        assert "--ephemeral" not in args
         assert "--ignore-user-config" not in args
         config_values = [args[index + 1] for index, arg in enumerate(args) if arg == "-c"]
         assert "check_for_update_on_startup=false" in config_values
@@ -491,8 +497,25 @@ class TestCodexHarness:
     def test_build_args_with_extra(self):
         harness = CodexHarness()
         args = harness.build_args("prompt", "model", extra_args=["--foo", "bar"])
-        assert "--foo" in args
-        assert "bar" in args
+        model_index = args.index("-m")
+        assert args[model_index - 2 : model_index] == ["--foo", "bar"]
+
+    def test_build_args_with_resume_keeps_options_before_model_and_prompt(self):
+        args = CodexHarness().build_args(
+            "follow-up prompt", "model", extra_args=["resume", "--last"]
+        )
+
+        model_index = args.index("-m")
+        delimiter_index = args.index("--", model_index)
+        prompt_index = args.index("follow-up prompt")
+        assert args[args.index("resume") : model_index] == ["resume", "--last"]
+        assert model_index < delimiter_index < prompt_index
+        assert args[delimiter_index : prompt_index + 1] == ["--", "follow-up prompt"]
+
+    def test_build_args_without_resume_keeps_normal_command_valid(self):
+        args = CodexHarness().build_args("normal prompt", "model")
+
+        assert args[-4:] == ["-m", "model", "--", "normal prompt"]
 
     def test_build_args_keeps_prompt_after_option_delimiter(self):
         args = CodexHarness().build_args("--help", "model", extra_args=["--color", "never"])
@@ -500,6 +523,45 @@ class TestCodexHarness:
         assert args[-1] == "--help"
         assert args[-2] == "--"
         assert args.index("--color") < len(args) - 2
+
+    def test_api_key_login_is_silent_and_unsets_key_before_jsonl_process(self, tmp_path):
+        fake_codex = tmp_path / "codex"
+        fake_codex.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = login ]; then\n'
+            "  printf 'login stdout\\n'\n"
+            "  printf 'login stderr\\n' >&2\n"
+            "  cat >/dev/null\n"
+            "  exit 0\n"
+            "fi\n"
+            'if [ -n "${OPENAI_API_KEY+x}" ]; then\n'
+            "  printf '{\"api_key_unset\":false}\\n'\n"
+            "else\n"
+            "  printf '{\"api_key_unset\":true}\\n'\n"
+            "fi\n"
+        )
+        fake_codex.chmod(0o755)
+
+        secret = "sk-test-secret"
+        env = {
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+            "OPENAI_API_KEY": secret,
+        }
+        completed = subprocess.run(
+            CodexHarness().build_args("prompt", "model"),
+            capture_output=True,
+            text=True,
+            env=env,
+            check=True,
+        )
+
+        assert [json.loads(line) for line in completed.stdout.splitlines()] == [
+            {"api_key_unset": True}
+        ]
+        assert completed.stderr == ""
+        assert secret not in completed.stdout
+        assert secret not in completed.stderr
 
     def test_build_env_args(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")

--- a/tests/test_openshell_provider.py
+++ b/tests/test_openshell_provider.py
@@ -5,7 +5,14 @@ from unittest import mock
 
 import pytest
 
-from agentic_ci.backends.openshell.provider import PROVIDER_NAME, rotate_token
+from agentic_ci.backends.openshell.provider import (
+    PROVIDER_NAME,
+    auth_mode,
+    delete,
+    rotate_token,
+    setup,
+    validate_credentials,
+)
 
 
 class TestRotateToken:
@@ -33,3 +40,94 @@ class TestRotateToken:
         ):
             with pytest.raises(subprocess.CalledProcessError):
                 rotate_token()
+
+
+class TestProviderSetup:
+    def test_validate_openai_provider_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+            validate_credentials("openai")
+
+    def test_openai_provider_accepts_explicit_environment(self):
+        validate_credentials("openai", {"OPENAI_API_KEY": "extra-key"})
+
+    def test_auth_mode_reads_provider_type(self):
+        result = subprocess.CompletedProcess(
+            ["openshell", "provider", "list"],
+            0,
+            stdout='{"providers": [{"name": "ci-gcp", "type": "openai"}]}',
+        )
+        with mock.patch(
+            "agentic_ci.backends.openshell.provider._run", return_value=result
+        ) as mock_run:
+            assert auth_mode() == "openai"
+
+        mock_run.assert_called_once_with(
+            ["openshell", "provider", "list", "-o", "json"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+
+    def test_delete_removes_provider(self):
+        with mock.patch("agentic_ci.backends.openshell.provider._run") as mock_run:
+            delete()
+
+        mock_run.assert_called_once_with(
+            ["openshell", "provider", "delete", PROVIDER_NAME],
+            check=True,
+        )
+
+    def test_openai_provider_uses_openai_api_key(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+        with (
+            mock.patch(
+                "agentic_ci.backends.openshell.provider.provider_exists",
+                return_value=False,
+            ),
+            mock.patch("agentic_ci.backends.openshell.provider._run") as mock_run,
+        ):
+            setup("openai")
+
+        args = mock_run.call_args.args[0]
+        env = mock_run.call_args.kwargs["env"]
+        assert args == [
+            "openshell",
+            "provider",
+            "create",
+            "--name",
+            PROVIDER_NAME,
+            "--type",
+            "openai",
+            "--credential",
+            "OPENAI_API_KEY",
+        ]
+        assert env["OPENAI_API_KEY"] == "test-key"
+
+    def test_openai_provider_requires_api_key(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with (
+            mock.patch(
+                "agentic_ci.backends.openshell.provider.provider_exists",
+                return_value=False,
+            ),
+            pytest.raises(RuntimeError, match="OPENAI_API_KEY"),
+        ):
+            setup("openai")
+
+    def test_openai_provider_uses_explicit_environment(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        with (
+            mock.patch(
+                "agentic_ci.backends.openshell.provider.provider_exists",
+                return_value=False,
+            ),
+            mock.patch("agentic_ci.backends.openshell.provider._run") as mock_run,
+        ):
+            setup("openai", {"OPENAI_API_KEY": "extra-key"})
+
+        assert mock_run.call_args.kwargs["env"]["OPENAI_API_KEY"] == "extra-key"

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -5,7 +5,7 @@ from unittest import mock
 from agentic_ci.backends.openshell import sandbox
 
 
-def test_create_keeps_sandbox_main_process_alive():
+def test_create_uses_terminating_initial_command():
     with (
         mock.patch.object(sandbox, "_run") as run,
         mock.patch.object(sandbox, "_apply_policy"),
@@ -13,4 +13,4 @@ def test_create_keeps_sandbox_main_process_alive():
         sandbox.create(image="codex-sandbox:latest")
 
     create_args = run.call_args.args[0]
-    assert create_args[-2:] == ["sleep", "infinity"]
+    assert create_args[-2:] == ["--", "true"]

--- a/tests/test_openshell_sandbox.py
+++ b/tests/test_openshell_sandbox.py
@@ -1,0 +1,16 @@
+"""Tests for OpenShell sandbox lifecycle commands."""
+
+from unittest import mock
+
+from agentic_ci.backends.openshell import sandbox
+
+
+def test_create_keeps_sandbox_main_process_alive():
+    with (
+        mock.patch.object(sandbox, "_run") as run,
+        mock.patch.object(sandbox, "_apply_policy"),
+    ):
+        sandbox.create(image="codex-sandbox:latest")
+
+    create_args = run.call_args.args[0]
+    assert create_args[-2:] == ["sleep", "infinity"]

--- a/tests/test_otel.py
+++ b/tests/test_otel.py
@@ -11,6 +11,7 @@ from agentic_ci.otel import (
     _has_any_traces,
     generate_trace_context,
     inject_root_spans,
+    parse_metrics,
     start_collector,
     stop_collector,
 )
@@ -212,6 +213,160 @@ class TestGenerateTraceContext:
         trace_id, span_id, _ = generate_trace_context()
         int(trace_id, 16)
         int(span_id, 16)
+
+
+class TestParseMetrics:
+    def test_parses_codex_token_usage_and_api_requests(self):
+        attributes = {
+            "event.name": "codex.sse_event",
+            "event.kind": "response.completed",
+            "model": "gpt-test",
+            "input_token_count": "100",
+            "cached_token_count": 40,
+            "cache_write_token_count": 10,
+            "output_token_count": "20",
+        }
+
+        def attr(key, value):
+            value_key = "intValue" if isinstance(value, int) else "stringValue"
+            return {"key": key, "value": {value_key: value}}
+
+        response_record = {"attributes": [attr(key, value) for key, value in attributes.items()]}
+        request_record = {
+            "attributes": [
+                attr("event.name", "codex.api_request"),
+                attr("duration_ms", "123"),
+            ]
+        }
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "logRecords": [
+                                        response_record,
+                                        request_record,
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+
+        token_totals, _, api_requests, _ = parse_metrics(records)
+
+        assert token_totals[("gpt-test", "input")] == 50
+        assert token_totals[("gpt-test", "cacheRead")] == 40
+        assert token_totals[("gpt-test", "cacheCreation")] == 10
+        assert token_totals[("gpt-test", "output")] == 20
+        assert api_requests == [{"event.name": "codex.api_request", "duration_ms": "123"}]
+
+    def test_parses_codex_estimated_cost_and_response_request_fallback(self):
+        attributes = {
+            "event.name": "codex.sse_event",
+            "event.kind": "response.completed",
+            "model": "gpt-5.6-sol",
+            "input_token_count": "100",
+            "cached_token_count": 40,
+            "cache_write_token_count": 10,
+            "output_token_count": "20",
+            "service_tier": "priority",
+        }
+
+        def attr(key, value):
+            value_key = "intValue" if isinstance(value, int) else "stringValue"
+            return {"key": key, "value": {value_key: value}}
+
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "scope": {"name": "codex"},
+                                    "logRecords": [
+                                        {
+                                            "attributes": [
+                                                attr(key, value)
+                                                for key, value in attributes.items()
+                                            ]
+                                        }
+                                    ],
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+
+        token_totals, cost_totals, api_requests, _ = parse_metrics(records)
+
+        assert token_totals[("gpt-5.6-sol", "input")] == 50
+        assert token_totals[("gpt-5.6-sol", "cacheRead")] == 40
+        assert token_totals[("gpt-5.6-sol", "cacheCreation")] == 10
+        assert token_totals[("gpt-5.6-sol", "output")] == 20
+        assert cost_totals["gpt-5.6-sol"] == pytest.approx(0.001865)
+        assert len(api_requests) == 1
+        assert api_requests[0]["event.kind"] == "response.completed"
+
+    def test_prefers_codex_reported_cost_over_estimate(self):
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "logRecords": [
+                                        {
+                                            "attributes": [
+                                                {
+                                                    "key": "event.name",
+                                                    "value": {"stringValue": "codex.sse_event"},
+                                                },
+                                                {
+                                                    "key": "event.kind",
+                                                    "value": {"stringValue": "response.completed"},
+                                                },
+                                                {
+                                                    "key": "model",
+                                                    "value": {"stringValue": "gpt-5.6-sol"},
+                                                },
+                                                {
+                                                    "key": "input_token_count",
+                                                    "value": {"intValue": 10},
+                                                },
+                                                {
+                                                    "key": "output_token_count",
+                                                    "value": {"intValue": 10},
+                                                },
+                                                {
+                                                    "key": "cost_usd",
+                                                    "value": {"doubleValue": 0.25},
+                                                },
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+
+        _, cost_totals, _, _ = parse_metrics(records)
+
+        assert cost_totals["gpt-5.6-sol"] == pytest.approx(0.25)
 
 
 class TestFindOrphanTraces:
@@ -503,3 +658,80 @@ class TestInjectRootSpans:
         span = records[1]["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
         assert int(span["startTimeUnixNano"]) == 500
         assert int(span["endTimeUnixNano"]) == 12000
+
+
+class TestParseMetricsRobustness:
+    """parse_metrics must tolerate malformed OTLP attribute entries."""
+
+    def test_metrics_attribute_missing_key_is_skipped(self):
+        records = [
+            {
+                "path": "/v1/metrics",
+                "payload": {
+                    "resourceMetrics": [
+                        {
+                            "scopeMetrics": [
+                                {
+                                    "metrics": [
+                                        {
+                                            "name": "claude_code.token.usage",
+                                            "sum": {
+                                                "dataPoints": [
+                                                    {
+                                                        "asInt": 5,
+                                                        "attributes": [
+                                                            {"value": {"stringValue": "orphan"}},
+                                                            {
+                                                                "key": "model",
+                                                                "value": {"stringValue": "gpt-5"},
+                                                            },
+                                                            {
+                                                                "key": "type",
+                                                                "value": {"stringValue": "input"},
+                                                            },
+                                                        ],
+                                                    }
+                                                ]
+                                            },
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+        token_totals, _, _, _ = parse_metrics(records)
+        assert token_totals[("gpt-5", "input")] == 5
+
+    def test_logs_attribute_missing_key_is_skipped(self):
+        records = [
+            {
+                "path": "/v1/logs",
+                "payload": {
+                    "resourceLogs": [
+                        {
+                            "scopeLogs": [
+                                {
+                                    "logRecords": [
+                                        {
+                                            "attributes": [
+                                                {"value": {"stringValue": "orphan"}},
+                                                {
+                                                    "key": "event.name",
+                                                    "value": {"stringValue": "codex.api_request"},
+                                                },
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+            }
+        ]
+        _, _, api_requests, _ = parse_metrics(records)
+        assert len(api_requests) == 1
+        assert api_requests[0]["event.name"] == "codex.api_request"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -2,13 +2,18 @@
 
 import json
 import shutil
+import subprocess
 from unittest import mock
 
 import pytest
 
 from agentic_ci.plugins import (
+    _codex_marketplace_root,
+    _filter_codex,
     _find_skill_names,
+    _run_codex_json,
     enable_plugins,
+    install_codex_plugins,
     install_opencode_skills,
 )
 
@@ -30,6 +35,18 @@ class TestFindSkillNames:
         (tmp_path / "deep" / "nested").mkdir(parents=True)
         (tmp_path / "deep" / "nested" / "SKILL.md").touch()
         assert _find_skill_names(tmp_path) == ["nested"]
+
+    def test_ignores_symlinked_skill_trees(self, tmp_path):
+        source = tmp_path / "source"
+        real_skill = source / "real" / "SKILL.md"
+        real_skill.parent.mkdir(parents=True)
+        real_skill.touch()
+        outside = tmp_path / "outside" / "escaped" / "SKILL.md"
+        outside.parent.mkdir(parents=True)
+        outside.touch()
+        (real_skill.parent / "escaped").symlink_to(outside.parent, target_is_directory=True)
+
+        assert _find_skill_names(source) == ["real"]
 
 
 # -- enable_plugins: Claude Code filtering ------------------------------------
@@ -179,12 +196,187 @@ class TestEnablePluginsOpenCode:
         assert not orphan.exists()
         assert (tmp_path / "skills" / "skill-a1" / "SKILL.md").is_file()
 
-    def test_missing_manifest_returns_ok(self, monkeypatch, tmp_path):
+    def test_missing_manifest_returns_ok(self, monkeypatch, tmp_path, capsys):
         monkeypatch.setenv("AGENT_TOOL", "opencode")
         monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path))
         monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
-        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(tmp_path / "nonexistent.json"))
+        manifest = tmp_path / "nonexistent.json"
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
         enable_plugins()
+        assert f"{manifest} not found" in capsys.readouterr().err
+
+    def test_invalid_manifest_returns_ok(self, monkeypatch, tmp_path, capsys):
+        """An unreadable (invalid JSON) manifest warns and skips filtering."""
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text("{ not valid json")
+        skills_dir = tmp_path / "skills" / "skill-a1"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "SKILL.md").write_text("---\nname: skill-a1\n---\n")
+        monkeypatch.setenv("AGENT_TOOL", "opencode")
+        monkeypatch.setenv("OPENCODE_CONFIG_DIR", str(tmp_path))
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+        enable_plugins()
+        # Filtering is skipped, so the on-disk skill is left untouched.
+        assert (tmp_path / "skills" / "skill-a1" / "SKILL.md").is_file()
+        assert "invalid JSON" in capsys.readouterr().err
+
+
+# -- enable_plugins: Codex filtering -----------------------------------------
+
+
+class TestEnablePluginsCodex:
+    def test_filters_native_plugins_and_compatibility_skills(self, monkeypatch, tmp_path):
+        codex_home = tmp_path / "codex"
+        skills_dir = codex_home / "skills"
+        for name in ("skill-a", "skill-b", "personal-skill"):
+            skill_dir = skills_dir / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"plugin-a": ["skill-a"], "plugin-b": ["skill-b"]}))
+        installed = {
+            "installed": [
+                {
+                    "name": "plugin-a",
+                    "pluginId": "plugin-a@test",
+                    "marketplaceName": "test",
+                },
+                {
+                    "name": "plugin-b",
+                    "pluginId": "plugin-b@test",
+                    "marketplaceName": "test",
+                },
+            ]
+        }
+
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with mock.patch(
+            "agentic_ci.plugins._run_codex_json",
+            side_effect=[installed, {"pluginId": "plugin-b@test"}],
+        ) as run_codex:
+            enable_plugins()
+
+        assert run_codex.call_args_list[-1] == mock.call(["plugin", "remove", "plugin-b@test"])
+        assert (skills_dir / "skill-a").is_dir()
+        assert not (skills_dir / "skill-b").exists()
+        assert (skills_dir / "personal-skill").is_dir()
+
+    def test_unknown_plugin_exits(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "missing")
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(tmp_path / "missing-manifest.json"))
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                return_value={"installed": []},
+            ),
+            pytest.raises(SystemExit),
+        ):
+            enable_plugins()
+
+    def test_plugin_list_failure_still_filters_compatibility_skills(self, monkeypatch, tmp_path):
+        codex_home = tmp_path / "codex"
+        skills_dir = codex_home / "skills"
+        for name in ("skill-a", "skill-b", "personal-skill"):
+            skill_dir = skills_dir / name
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").touch()
+
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"plugin-a": ["skill-a"], "plugin-b": ["skill-b"]}))
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", return_value=None) as run_codex:
+            _filter_codex({"plugin-a"})
+
+        run_codex.assert_called_once_with(["plugin", "list"])
+        assert (skills_dir / "skill-a").is_dir()
+        assert not (skills_dir / "skill-b").exists()
+        assert (skills_dir / "personal-skill").is_dir()
+
+    def test_failed_plugin_removal_exits_nonzero(self, monkeypatch, tmp_path, capsys):
+        codex_home = tmp_path / "codex"
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(json.dumps({"plugin-a": []}))
+        installed = {
+            "installed": [
+                {
+                    "name": "plugin-b",
+                    "pluginId": "plugin-b@test",
+                }
+            ]
+        }
+
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                side_effect=[installed, None],
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            enable_plugins()
+
+        assert exc_info.value.code == 1
+        assert "could not enforce AGENT_ENABLED_PLUGINS" in capsys.readouterr().err
+
+    def test_invalid_manifest_values_are_ignored(self, monkeypatch, tmp_path):
+        manifest = tmp_path / "manifest.json"
+        manifest.write_text(
+            json.dumps(
+                {
+                    "plugin-a": ["skill-a", 123, None],
+                    "plugin-b": "skill-b",
+                    "plugin-c": None,
+                    7: ["skill-c"],
+                }
+            )
+        )
+        monkeypatch.setenv("AGENT_TOOL", "codex")
+        monkeypatch.setenv("AGENT_ENABLED_PLUGINS", "plugin-a")
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / "codex"))
+        monkeypatch.setenv("PLUGIN_SKILLS_MANIFEST", str(manifest))
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", return_value={"installed": []}):
+            enable_plugins()
+
+    def test_rejects_option_like_plugin_selector(self, monkeypatch, tmp_path, capsys):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+
+        responses = [
+            {"marketplaceName": "trusted"},
+            {
+                "available": [
+                    {"name": "--config=bad", "pluginId": "--config=bad"},
+                ]
+            },
+            {"installed": []},
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses) as run_codex:
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert run_codex.call_args_list == [
+            mock.call(["plugin", "marketplace", "add", str(tmp_path)]),
+            mock.call(["plugin", "list", "--available", "--marketplace", "trusted"]),
+            mock.call(["plugin", "list"]),
+        ]
+        assert "starts with '-'" in capsys.readouterr().err
 
 
 # -- install_opencode_skills -------------------------------------------------
@@ -280,6 +472,41 @@ class TestInstallOpencodeSkills:
         data = json.loads(manifest.read_text())
         assert "helper-skill" in data["helpers"]
 
+    def test_rejects_skills_path_outside_clone(self, tmp_path):
+        repo = tmp_path / "mock-repo"
+        repo.mkdir()
+        mkt = tmp_path / "marketplace.json"
+        mkt.write_text(
+            json.dumps(
+                {
+                    "name": "test-mkt",
+                    "plugins": [
+                        {
+                            "name": "escaping",
+                            "source": {"repo": "fake/escaping", "ref": "main"},
+                            "skills": ["../../etc"],
+                        }
+                    ],
+                }
+            )
+        )
+
+        skills_dir = tmp_path / "skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            shutil.copytree(repo, dest)
+            return True
+
+        with (
+            mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone),
+            mock.patch("agentic_ci.plugins._copy_tree") as copy_tree,
+        ):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+
+        copy_tree.assert_not_called()
+        assert json.loads(manifest.read_text()) == {}
+
     def test_fallback_collects_all_matching_dirs(self, tmp_path):
         """Skills in both .claude/skills/ and skills/ are installed."""
         repo = tmp_path / "mock-repo"
@@ -306,6 +533,118 @@ class TestInstallOpencodeSkills:
         data = json.loads(manifest.read_text())
         assert sorted(data["mock-greet"]) == ["debug-skill", "main-skill"]
 
+    def test_skips_nested_symlinks_when_copying(self, tmp_path):
+        repo = tmp_path / "mock-repo"
+        skill = repo / "skills" / "safe-skill"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: safe-skill\n---\n")
+        outside = tmp_path / "outside" / "secret.txt"
+        outside.parent.mkdir()
+        outside.write_text("must not be copied")
+        (skill / "linked-secret").symlink_to(outside)
+
+        mkt = self._make_marketplace(tmp_path)
+        skills_dir = tmp_path / "installed-skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            shutil.copytree(repo, dest, symlinks=True)
+            return True
+
+        with mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+
+        assert (skills_dir / "safe-skill" / "SKILL.md").is_file()
+        assert not (skills_dir / "safe-skill" / "linked-secret").exists()
+        assert "safe-skill" in json.loads(manifest.read_text())["mock-greet"]
+
+    def test_skips_plugin_with_colliding_skill_name(self, tmp_path):
+        first_repo = tmp_path / "first-repo"
+        first_skill = first_repo / "skills" / "shared"
+        first_skill.mkdir(parents=True)
+        (first_skill / "SKILL.md").write_text("first\n")
+        second_repo = tmp_path / "second-repo"
+        second_skill = second_repo / "skills" / "shared"
+        second_skill.mkdir(parents=True)
+        (second_skill / "SKILL.md").write_text("second\n")
+
+        mkt = tmp_path / "marketplace.json"
+        mkt.write_text(
+            json.dumps(
+                {
+                    "name": "test-mkt",
+                    "plugins": [
+                        {"name": "first", "source": {"repo": "fake/first", "ref": "main"}},
+                        {
+                            "name": "second",
+                            "source": {"repo": "fake/second", "ref": "main"},
+                        },
+                    ],
+                }
+            )
+        )
+        skills_dir = tmp_path / "installed-skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            source = first_repo if "fake/first" in url else second_repo
+            shutil.copytree(source, dest)
+            return True
+
+        with mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+
+        assert (skills_dir / "shared" / "SKILL.md").read_text() == "first\n"
+        assert json.loads(manifest.read_text()) == {"first": ["shared"]}
+
+    def test_skips_unowned_files_outside_complete_skill_dirs(self, tmp_path):
+        first_repo = tmp_path / "first-repo"
+        first_skill = first_repo / "skills" / "shared"
+        first_skill.mkdir(parents=True)
+        (first_skill / "SKILL.md").write_text("first\n")
+
+        second_repo = tmp_path / "second-repo"
+        second_beta = second_repo / "skills" / "beta"
+        second_beta.mkdir(parents=True)
+        (second_beta / "SKILL.md").write_text("beta\n")
+        second_shared = second_repo / "skills" / "shared"
+        second_shared.mkdir()
+        (second_shared / "SECOND_MARKER.txt").write_text("must not be copied")
+
+        mkt = tmp_path / "marketplace.json"
+        mkt.write_text(
+            json.dumps(
+                {
+                    "name": "test-mkt",
+                    "plugins": [
+                        {"name": "first", "source": {"repo": "fake/first", "ref": "main"}},
+                        {
+                            "name": "second",
+                            "source": {"repo": "fake/second", "ref": "main"},
+                        },
+                    ],
+                }
+            )
+        )
+        skills_dir = tmp_path / "installed-skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            source = first_repo if "fake/first" in url else second_repo
+            shutil.copytree(source, dest)
+            return True
+
+        with mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+
+        assert (skills_dir / "shared" / "SKILL.md").read_text() == "first\n"
+        assert not (skills_dir / "shared" / "SECOND_MARKER.txt").exists()
+        assert (skills_dir / "beta" / "SKILL.md").read_text() == "beta\n"
+        assert json.loads(manifest.read_text()) == {
+            "first": ["shared"],
+            "second": ["beta"],
+        }
+
     def test_empty_marketplace(self, tmp_path):
         mkt = tmp_path / "marketplace.json"
         mkt.write_text(json.dumps({"name": "empty", "plugins": []}))
@@ -315,3 +654,190 @@ class TestInstallOpencodeSkills:
         install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
 
         assert json.loads(manifest.read_text()) == {}
+
+
+# -- install_codex_plugins ---------------------------------------------------
+
+
+class TestInstallCodexPlugins:
+    def test_marketplace_root_plain_directory(self, tmp_path):
+        marketplace = tmp_path / "registry" / "marketplace.json"
+        marketplace.parent.mkdir()
+        marketplace.touch()
+
+        assert _codex_marketplace_root(marketplace) == marketplace.parent
+
+    def test_installs_native_plugins_and_writes_manifest(self, tmp_path):
+        marketplace_dir = tmp_path / ".agents" / "plugins"
+        marketplace_dir.mkdir(parents=True)
+        marketplace = marketplace_dir / "marketplace.json"
+        marketplace.write_text("{}")
+
+        installed_plugin = tmp_path / "installed-plugin"
+        skill = installed_plugin / "skills" / "review"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: review\n---\n")
+        manifest = tmp_path / "manifest.json"
+
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            {"pluginId": "review-plugin@test-marketplace"},
+            {
+                "installed": [
+                    {
+                        "name": "review-plugin",
+                        "marketplaceName": "test-marketplace",
+                        "installedPath": str(installed_plugin),
+                    }
+                ]
+            },
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses) as run_codex:
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert run_codex.call_args_list[0] == mock.call(
+            ["plugin", "marketplace", "add", str(tmp_path)]
+        )
+        assert json.loads(manifest.read_text()) == {"review-plugin": ["review"]}
+
+    def test_legacy_marketplace_falls_back_to_skills(self, tmp_path):
+        marketplace_dir = tmp_path / ".claude-plugin"
+        marketplace_dir.mkdir()
+        marketplace = marketplace_dir / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        skills_dir = tmp_path / "skills"
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                side_effect=[
+                    {"marketplaceName": "legacy"},
+                    {"available": []},
+                ],
+            ),
+            mock.patch("agentic_ci.plugins.install_opencode_skills") as install_skills,
+        ):
+            install_codex_plugins(
+                marketplace,
+                skills_dir=skills_dir,
+                manifest_path=manifest,
+            )
+
+        install_skills.assert_called_once_with(
+            marketplace,
+            skills_dir=skills_dir,
+            manifest_path=manifest,
+        )
+
+    def test_marketplace_add_without_name_falls_back_and_warns(self, tmp_path, capsys):
+        """A marketplace add that returns no marketplaceName warns and falls back."""
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        skills_dir = tmp_path / "skills"
+
+        with (
+            mock.patch(
+                "agentic_ci.plugins._run_codex_json",
+                side_effect=[{"ok": True}],
+            ),
+            mock.patch("agentic_ci.plugins.install_opencode_skills") as install_skills,
+        ):
+            install_codex_plugins(
+                marketplace,
+                skills_dir=skills_dir,
+                manifest_path=manifest,
+            )
+
+        assert "returned no marketplaceName" in capsys.readouterr().out
+        install_skills.assert_called_once_with(
+            marketplace,
+            skills_dir=skills_dir,
+            manifest_path=manifest,
+        )
+
+    def test_final_plugin_list_failure_writes_empty_manifest(self, tmp_path):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            {"pluginId": "review-plugin@test-marketplace"},
+            None,
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses):
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert json.loads(manifest.read_text()) == {}
+
+    def test_plugin_add_failure_warns(self, tmp_path, capsys):
+        marketplace = tmp_path / "marketplace.json"
+        marketplace.write_text("{}")
+        manifest = tmp_path / "manifest.json"
+        responses = [
+            {"marketplaceName": "test-marketplace"},
+            {
+                "available": [
+                    {
+                        "name": "review-plugin",
+                        "pluginId": "review-plugin@test-marketplace",
+                    }
+                ]
+            },
+            None,
+            {"installed": []},
+        ]
+
+        with mock.patch("agentic_ci.plugins._run_codex_json", side_effect=responses):
+            install_codex_plugins(marketplace, manifest_path=manifest)
+
+        assert "WARN: failed to install review-plugin@test-marketplace" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("error", [FileNotFoundError(), OSError("exec failed")])
+def test_run_codex_json_handles_missing_or_unexecutable_binary(error):
+    with mock.patch("agentic_ci.plugins.subprocess.run", side_effect=error):
+        assert _run_codex_json(["plugin", "list"]) is None
+
+
+def test_run_codex_json_times_out_and_warns(capsys):
+    error = subprocess.TimeoutExpired(["codex", "plugin", "list"], 120)
+    with mock.patch("agentic_ci.plugins.subprocess.run", side_effect=error) as run:
+        assert _run_codex_json(["plugin", "list"]) is None
+
+    assert run.call_args.kwargs["timeout"] == 120
+    assert "WARN: failed to run codex plugin list" in capsys.readouterr().out
+
+
+def test_run_codex_json_reports_stderr(capsys):
+    result = subprocess.CompletedProcess(
+        ["codex", "plugin", "list"],
+        returncode=2,
+        stdout="",
+        stderr="plugin registry unavailable",
+    )
+    with mock.patch("agentic_ci.plugins.subprocess.run", return_value=result):
+        assert _run_codex_json(["plugin", "list"]) is None
+
+    output = capsys.readouterr().out
+    assert "exit 2" in output
+    assert "plugin registry unavailable" in output

--- a/tests/test_podman.py
+++ b/tests/test_podman.py
@@ -3,11 +3,12 @@
 import json
 import os
 import subprocess as _subprocess
+from unittest import mock
 
 import pytest
 
 from agentic_ci.backends.podman import PodmanBackend
-from agentic_ci.harness import ClaudeCodeHarness, OpenCodeHarness
+from agentic_ci.harness import ClaudeCodeHarness, CodexHarness, OpenCodeHarness
 
 
 @pytest.fixture()
@@ -45,6 +46,19 @@ def test_build_env_args_extra_env(tmp_path, claude_harness):
     )
     args = backend._build_env_args()
     assert "MY_VAR=value" in args
+
+
+def test_build_env_args_does_not_forward_openai_credentials_to_claude(tmp_path, claude_harness):
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        harness=claude_harness,
+        extra_env={"OPENAI_API_KEY": "unrelated-key"},
+    )
+
+    args = backend._build_env_args()
+
+    assert not any("OPENAI_API_KEY" in arg for arg in args)
+    assert not any("unrelated-key" in arg for arg in args)
 
 
 def test_resolve_credentials_creates_config(monkeypatch, tmp_path, claude_harness):
@@ -91,6 +105,19 @@ def test_resolve_image_raises_with_correct_env_var(monkeypatch, tmp_path, openco
     backend = PodmanBackend(workdir=str(tmp_path), harness=opencode_harness)
     with pytest.raises(RuntimeError, match="OPENCODE_CONTAINER_IMAGE"):
         backend._resolve_image()
+
+
+def test_setup_codex_credentials_fail_fast(monkeypatch, tmp_path):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        image="localhost/codex:test",
+        harness=CodexHarness(),
+    )
+
+    with pytest.raises(RuntimeError, match="OPENAI_API_KEY"):
+        backend.setup()
 
 
 def test_build_vol_args_claude_mount_target(monkeypatch, tmp_path, claude_harness):
@@ -290,3 +317,22 @@ def test_is_local_image_missing_remote(monkeypatch, tmp_path, claude_harness):
     monkeypatch.setattr(_subprocess, "run", mock_run)
 
     assert backend._is_local_image() is False
+
+
+def test_run_passes_otel_port_to_implicit_setup(tmp_path, claude_harness):
+    backend = PodmanBackend(
+        workdir=str(tmp_path),
+        image="localhost/test:latest",
+        harness=claude_harness,
+    )
+
+    with (
+        mock.patch.object(backend, "is_running", return_value=False),
+        mock.patch.object(backend, "setup") as setup,
+        mock.patch.object(backend, "_process_stream", return_value=(0, True)),
+        mock.patch.object(backend, "_wait_for_otel_flush"),
+        mock.patch("agentic_ci.backends.podman.subprocess.Popen"),
+    ):
+        assert backend.run("test", "test-model", otel_port=4318) == 0
+
+    setup.assert_called_once_with(otel_port=4318)

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,6 +1,7 @@
 """Tests for policy resolution."""
 
 from agentic_ci.backends.openshell.policy import (
+    AUTH_ENDPOINTS,
     DEFAULT_ENDPOINTS,
     build_credential_binding_patch,
     resolve_endpoints,
@@ -56,13 +57,17 @@ def test_duplicate_endpoints_deduplicated(tmp_path):
 
 
 def test_endpoints_include_vertex_ai():
-    result = resolve_endpoints()
+    result = resolve_endpoints(auth_mode="vertex")
     assert any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.anthropic.com" in ep for ep in result)
+    assert not any("api.openai.com" in ep for ep in result)
 
 
 def test_endpoints_include_anthropic_api():
-    result = resolve_endpoints()
+    result = resolve_endpoints(auth_mode="api-key")
     assert any("api.anthropic.com" in ep for ep in result)
+    assert not any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.openai.com" in ep for ep in result)
 
 
 def test_credential_binding_patch_adds_binding_to_gcp():
@@ -130,3 +135,12 @@ def test_credential_binding_patch_preserves_existing_binding():
         },
     }
     assert build_credential_binding_patch(policy_get_output) is None
+
+
+def test_endpoints_include_openai_apis():
+    result = resolve_endpoints(auth_mode="openai")
+    assert result == list(DEFAULT_ENDPOINTS) + AUTH_ENDPOINTS["openai"]
+    assert "api.openai.com:443:read-write" in result
+    assert "chatgpt.com:443:read-write" in result
+    assert not any("aiplatform.googleapis.com" in ep for ep in result)
+    assert not any("api.anthropic.com" in ep for ep in result)

--- a/tests/test_stream_codex.py
+++ b/tests/test_stream_codex.py
@@ -1,0 +1,247 @@
+"""Tests for CodexStreamProcessor."""
+
+import json
+
+from agentic_ci.stream import CodexStreamProcessor
+
+
+def _make_event(event_type, **kwargs):
+    event = {"type": event_type}
+    event.update(kwargs)
+    return json.dumps(event)
+
+
+def _item(item_type, item_id="item_1", **kwargs):
+    item = {"id": item_id, "type": item_type}
+    item.update(kwargs)
+    return item
+
+
+class TestProcessLine:
+    def test_empty_line(self):
+        assert CodexStreamProcessor(color=False).process_line("") is False
+
+    def test_invalid_json(self):
+        assert CodexStreamProcessor(color=False).process_line("not json") is False
+
+    def test_agent_message(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item("agent_message", text="Done with analysis"),
+        )
+        assert proc.process_line(line) is False
+        assert "💬 Codex Done with analysis" in capsys.readouterr().out
+
+    def test_reasoning(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item("reasoning", text="Checking the repository"),
+        )
+        proc.process_line(line)
+        assert "Thinking Checking the repository" in capsys.readouterr().out
+
+    def test_command_execution(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        started = _make_event(
+            "item.started",
+            item=_item(
+                "command_execution",
+                command="/bin/bash -lc 'ls -la'",
+                status="in_progress",
+            ),
+        )
+        completed = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="/bin/bash -lc 'ls -la'",
+                exit_code=0,
+                status="completed",
+            ),
+        )
+        assert proc.process_line(started) is False
+        assert proc.process_line(completed) is False
+        output = capsys.readouterr().out
+        assert "Shell $" in output
+        assert "ls -la" in output
+        assert output.count("Shell $") == 1
+
+    def test_failed_command_prints_exit_code(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="false",
+                exit_code=1,
+                status="failed",
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "Shell $ false" in output
+        assert "exit=1" in output
+
+    def test_string_exit_code_zero_not_failure(self, capsys):
+        """Codex may serialize exit_code as the string "0"; treat it as success."""
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="true",
+                exit_code="0",
+                status="completed",
+            ),
+        )
+        proc.process_line(line)
+        assert "exit=" not in capsys.readouterr().out
+
+    def test_string_exit_code_nonzero_is_failure(self, capsys):
+        """A string exit_code like "2" is still rendered as a failure."""
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "command_execution",
+                command="false",
+                exit_code="2",
+                status="failed",
+            ),
+        )
+        proc.process_line(line)
+        assert "exit=2" in capsys.readouterr().out
+
+    def test_thinking_uses_cyan_color(self, capsys):
+        """Reasoning output uses cyan (not red, which is reserved for errors)."""
+        proc = CodexStreamProcessor(color=True)
+        line = _make_event(
+            "item.completed",
+            item=_item("reasoning", text="Checking the repository"),
+        )
+        proc.process_line(line)
+        assert "\033[3;36m" in capsys.readouterr().out
+
+    def test_file_change(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "file_change",
+                changes=[{"path": "src/app.py", "kind": "update"}],
+            ),
+        )
+        proc.process_line(line)
+        assert "File change update src/app.py" in capsys.readouterr().out
+
+    def test_mcp_tool_call(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.started",
+            item=_item("mcp_tool_call", server="github", tool="get_pr"),
+        )
+        proc.process_line(line)
+        assert "MCP github/get_pr" in capsys.readouterr().out
+
+    def test_failed_mcp_tool_call(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "mcp_tool_call",
+                server="github",
+                tool="get_pr",
+                status="failed",
+                error={"message": "repository unavailable"},
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "❌ MCP github/get_pr failed: repository unavailable" in output
+
+    def test_web_search(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.started",
+            item=_item("web_search", query="Codex telemetry"),
+        )
+        proc.process_line(line)
+        assert "Web search Codex telemetry" in capsys.readouterr().out
+
+    def test_turn_completed(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "turn.completed",
+            usage={
+                "input_tokens": 100,
+                "cached_input_tokens": 40,
+                "cache_write_input_tokens": 10,
+                "output_tokens": 20,
+                "reasoning_output_tokens": 5,
+            },
+        )
+        assert proc.process_line(line) is True
+        output = capsys.readouterr().out
+        assert "TOKENS in=100 out=20 cache_r=40 cache_w=10 total=120" in output
+
+    def test_error_event(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        assert proc.process_line(_make_event("error", message="token invalid")) is False
+        proc.flush_errors()
+        assert "token invalid" in capsys.readouterr().out
+
+    def test_turn_failed(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event("turn.failed", error={"message": "request failed"})
+        assert proc.process_line(line) is False
+        proc.flush_errors()
+        assert "request failed" in capsys.readouterr().out
+
+    def test_unknown_type_ignored(self):
+        proc = CodexStreamProcessor(color=False)
+        assert proc.process_line(_make_event("something_unknown", data="foo")) is False
+
+    def test_wraps_long_agent_message(self, capsys):
+        proc = CodexStreamProcessor(color=False, wrap=30)
+        line = _make_event(
+            "item.completed",
+            item=_item(
+                "agent_message",
+                text="one two three four five six seven eight nine ten",
+            ),
+        )
+        proc.process_line(line)
+        output = capsys.readouterr().out
+        assert "💬 Codex one two three four five" in output
+        assert "\n    six seven eight nine ten\n" in output
+
+
+class TestProcess:
+    def test_full_run(self):
+        proc = CodexStreamProcessor(color=False)
+        events = [
+            _make_event("thread.started", thread_id="thread-1"),
+            _make_event("turn.started"),
+            _make_event(
+                "item.completed",
+                item=_item("agent_message", text="Finished"),
+            ),
+            _make_event("turn.completed", usage={}),
+        ]
+        assert proc.process(events) is True
+
+    def test_incomplete_stream(self):
+        proc = CodexStreamProcessor(color=False)
+        events = [_make_event("turn.started")]
+        assert proc.process(events) is False
+
+    def test_bytes_input(self, capsys):
+        proc = CodexStreamProcessor(color=False)
+        line = _make_event(
+            "item.completed",
+            item=_item("agent_message", text="Hello"),
+        )
+        assert proc.process([line.encode("utf-8")]) is False
+        assert "Hello" in capsys.readouterr().out

--- a/tests/test_update_litellm_cost_map.py
+++ b/tests/test_update_litellm_cost_map.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from scripts.update_litellm_cost_map import build_snapshot
+from scripts.update_litellm_cost_map import REPO_ROOT, build_snapshot, display_output_path
 
 
 def test_build_snapshot_filters_openai_and_preserves_cost_fields():
@@ -46,3 +46,10 @@ def test_build_snapshot_rejects_too_few_openai_models():
             {"model": {"litellm_provider": "openai", "input_cost_per_token": 1e-6}},
             "a" * 40,
         )
+
+
+def test_display_output_path_supports_repo_relative_and_external_paths(tmp_path):
+    assert display_output_path(REPO_ROOT / "map.json") == (REPO_ROOT / "map.json").relative_to(
+        REPO_ROOT
+    )
+    assert display_output_path(tmp_path / "map.json") == tmp_path / "map.json"

--- a/tests/test_update_litellm_cost_map.py
+++ b/tests/test_update_litellm_cost_map.py
@@ -1,0 +1,48 @@
+"""Tests for the LiteLLM pricing snapshot generator."""
+
+import pytest
+
+from scripts.update_litellm_cost_map import build_snapshot
+
+
+def test_build_snapshot_filters_openai_and_preserves_cost_fields():
+    source = {
+        **{
+            f"openai-model-{index}": {
+                "litellm_provider": "openai",
+                "input_cost_per_token": 1e-6,
+            }
+            for index in range(100)
+        },
+        "openai-model-with-alias": {
+            "litellm_provider": "openai",
+            "input_cost_per_token": 2e-6,
+            "output_cost_per_token_priority": 4e-6,
+            "aliases": ["openai-model-alias"],
+            "max_tokens": 10,
+        },
+        "anthropic-model": {
+            "litellm_provider": "anthropic",
+            "input_cost_per_token": 3e-6,
+        },
+    }
+
+    snapshot = build_snapshot(source, "a" * 40)
+
+    assert "anthropic-model" not in snapshot["models"]
+    assert snapshot["models"]["openai-model-alias"]["input_cost_per_token"] == 2e-6
+    assert snapshot["models"]["openai-model-with-alias"] == {
+        "aliases": ["openai-model-alias"],
+        "input_cost_per_token": 2e-6,
+        "litellm_provider": "openai",
+        "output_cost_per_token_priority": 4e-6,
+    }
+    assert snapshot["source"]["commit"] == "a" * 40
+
+
+def test_build_snapshot_rejects_too_few_openai_models():
+    with pytest.raises(ValueError, match="unexpectedly few"):
+        build_snapshot(
+            {"model": {"litellm_provider": "openai", "input_cost_per_token": 1e-6}},
+            "a" * 40,
+        )


### PR DESCRIPTION
## Summary

Add Codex as a supported agentic-ci harness across the local, Podman, and OpenShell backends, including streaming output, plugin compatibility, `OPENAI_API_KEY` authentication, telemetry, cost estimation, and OpenShell policy support. Codex pricing comes from a generated, dependency-free snapshot of LiteLLM's OpenAI cost map.

Codex now uses the safer `--approve-for-me` default and omits both `--dangerously-bypass-approvals-and-sandbox` and `--ephemeral`. Sessions persist so follow-up invocations can pass `resume --last` before the model and prompt arguments, while arbitrary Codex arguments remain supported.

This is a squashed, rebased replacement for #292.

## Validation

- `uvx tox -e py313,lint,check-format,typecheck` — 918 tests passed; lint, formatting, and type-check passed
- `uv run pytest -q tests/test_harness.py` — 86 tests passed
- `bash -n tests/e2e/e2e-local-runner.sh` — passed
- Harness regression tests cover the safe default flags, arbitrary argument passthrough, `resume --last` ordering, the normal non-resume command, and API-key login silence/unset with valid JSONL output

### Current two-turn Codex resume smoke test

The current update was smoke-tested from PR commit `8fceec7` with Codex CLI `0.149.0`, `gpt-5.6-sol`, an isolated temporary `CODEX_HOME`, and the available local login state:

1. The first local turn exited successfully after storing the unique fact `codex-live-resume-fact-7f3c`.
2. The second local turn exited successfully using `-- resume --last` and recalled `codex-live-resume-fact-7f3c`.

### Previous single-turn backend smoke tests

The following backend checks ran earlier from PR commit `3fc629e` with `gpt-5.6-luna` and only `OPENAI_API_KEY`.

The bundled cost map was regenerated by resolving LiteLLM `main` to an immutable commit SHA:

```console
$ make update-cost-map
uv run python scripts/update_litellm_cost_map.py
Updated src/agentic_ci/data/litellm_openai_cost_map.json from LiteLLM 418c7c6012d7c39a9d4a28c72cabe1995595ad2b (154 OpenAI models)
```

#### OpenShell backend (L4)

```console
$ agentic-ci run --backend openshell --harness codex \
    --image quay.io/aipcc/base-images/agentic/codex:latest \
    --model gpt-5.6-luna \
    "You are a moonlit librarian checking a price atlas through an L4 tunnel. Do not edit files or run shell commands. Reply with exactly: openshell-generated-map-pong — the ledger crossed the fog."

▶ Backend: openshell
  Harness: Codex
  Auth: OpenAI
▶ Running Codex (gpt-5.6-luna) via openshell backend
  💬 Codex openshell-generated-map-pong — the ledger crossed the fog.

▶ Agent exit code: 0
▶ Token/Cost Summary (OpenTelemetry)
  Model: gpt-5.6-luna
  TOTAL 20,727 tokens
  Cost (USD): $0.0048
  API Requests: 2
```

#### Direct local backend

```console
$ agentic-ci run --backend local --harness codex \
    --model gpt-5.6-luna \
    "You are a tiny comet auditing a freshly generated star chart. Do not edit files or run shell commands. Reply with exactly: local-generated-map-pong — the prices twinkle on schedule."

▶ Backend: local
  Harness: Codex
  Auth: OpenAI
▶ Running Codex (gpt-5.6-luna) via local backend
  💬 Codex local-generated-map-pong — the prices twinkle on schedule.

▶ Agent exit code: 0
▶ Token/Cost Summary (OpenTelemetry)
  Model: gpt-5.6-luna
  TOTAL 21,040 tokens
  Cost (USD): $0.0049
  API Requests: 2
```

The local smoke used an isolated temporary `CODEX_HOME` so it did not modify existing Codex login state. These earlier runs verify that OpenShell and direct Codex execution respond, rendered output appears, OTEL token usage is collected, and rates from the generated LiteLLM snapshot produce cost estimates. The current two-turn smoke test above verifies that the default non-ephemeral execution persists a session for `resume --last`.

### OpenShell security limitation

This PR intentionally mirrors agentic-ci's existing L4 API-key behavior for backend parity. L4 CONNECT policy cannot replace credentials at the HTTP layer, so `OPENAI_API_KEY` and the generated Codex login state are available inside the sandbox. This is functional but does not provide OpenShell's stronger L7 credential-isolation benefit.

A follow-up should migrate static API-key providers together to profile-backed L7 inspection so sandboxes receive only opaque placeholders. That broader migration is kept out of this Codex parity PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Codex support for local, container-based, and sandboxed runs.
  * Added Codex and OpenAI authentication options with credential validation.
  * Added Codex plugin installation, filtering, marketplace support, and legacy skill compatibility.
  * Added formatted Codex streaming output and OpenTelemetry usage reporting.
  * Added token-based cost estimation with customizable model pricing.
  * Added authentication-aware network configuration for sandboxed runs.

* **Bug Fixes**
  * Prevented sandbox creation from hanging during startup.

* **Documentation**
  * Updated setup, credentials, configuration, telemetry, plugin, and troubleshooting guidance.

* **Tests**
  * Expanded coverage across Codex execution, authentication, plugins, streaming, telemetry, costs, and end-to-end runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
