### PR TITLE
Fix renovate: track claude-code openshell Containerfile deps

### DIFF
--- a/images/runner/claude-code/Containerfile.openshell
+++ b/images/runner/claude-code/Containerfile.openshell
@@ -19,8 +19,8 @@
 ARG CLAUDE_CODE_BASE_IMAGE=quay.io/aipcc/base-images/agentic/claude-code:2.1.241@sha256:1c274549d59a749fc1ea2f879f06de23aeb09b17d55f4a8bcb726b9adb3621f9
 FROM ${CLAUDE_CODE_BASE_IMAGE}
 
-ARG UV_VERSION=0.12.1
-ARG UV_SHA256=47823f814693bab8623308341369190de30b5c621eec5b1ee20352eae8c7982c
+ARG UV_VERSION=0.12.3
+ARG UV_SHA256=0643b9fb8c9fb27458e709ce6ff939695013c41975ff7b02d3f3b138d8d4bdb3
 
 ARG SHELLCHECK_VERSION=0.11.0
 ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e227198
@@ -28,8 +28,8 @@ ARG SHELLCHECK_SHA256=8c3be12b05d5c177a04c29e3c78ce89ac86f1595681cab149b65b97c4e
 ARG GH_VERSION=2.97.0
 ARG GH_SHA256=a2c9b8497e1f85b1ad0dfcb78b5a622e098801b8e461e459e88e1ee12f018112
 
-ARG GLAB_VERSION=1.111.0
-ARG GLAB_SHA256=d3aa186428ce6668455e2e35184c6f60b013840d759c7ea4cf02bac68d2a1827
+ARG GLAB_VERSION=1.113.0
+ARG GLAB_SHA256=c265589fb2018f310b6a27df9356efee42991f858e7e3a5fa232228a13b47467
 
 USER root
 
@@ -89,7 +89,7 @@ COPY images/runner/shared/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY pyproject.toml README.md /tmp/agentic-ci/
 COPY src/ /tmp/agentic-ci/src/
 RUN chmod +x /usr/local/bin/entrypoint.sh \
-    && uv pip install --system --python python3.12 --no-cache /tmp/agentic-ci ruff==0.16.1 \
+    && uv pip install --system --python python3.12 --no-cache /tmp/agentic-ci ruff==0.16.3 \
     && rm -rf /tmp/agentic-ci \
     && install -d -m 755 -o sandbox -g sandbox /usr/local/share/agentic-ci
 

--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
@@ -65,6 +66,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$"
       ],
@@ -78,6 +80,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
@@ -93,6 +96,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",
@@ -155,6 +159,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$"
       ],
@@ -166,6 +171,7 @@
       "customType": "regex",
       "fileMatch": [
         "^images/runner/shared/Containerfile\\.base$",
+        "^images/runner/claude-code/Containerfile\\.openshell$",
         "^images/runner/opencode/Containerfile\\.openshell$",
         "^images/runner/codex/Containerfile\\.openshell$",
         "^images/ci/Containerfile\\.podman$",


### PR DESCRIPTION
## Summary

- Add `claude-code/Containerfile.openshell` to all renovate custom manager `fileMatch` arrays (UV, ShellCheck, GH CLI, GitLab CLI, ruff, agentic-ci)
- Sync drifted pinned versions to match the other openshell Containerfiles:
  - UV: 0.12.1 -> 0.12.3
  - GLAB: 1.111.0 -> 1.113.0
  - ruff: 0.16.1 -> 0.16.3

The claude-code openshell Containerfile was never added to the renovate managers, so its dependencies drifted silently while the opencode openshell Containerfile stayed current.

## Test plan

- [ ] Verify renovate.json is valid JSON
- [ ] Confirm claude-code openshell now appears in all 6 relevant custom manager fileMatch arrays
- [ ] Verify pinned versions match between claude-code and opencode openshell Containerfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated bundled versions of Claude Code, uv, GitLab CLI, and Ruff.
  * Refreshed associated integrity checksums.
  * Enabled automated detection of dependency updates in the Claude Code OpenShell image configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->