### PR TITLE
fix: support git-subdir marketplace sources

### DIFF
--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -96,6 +96,10 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: UBI9 defaults `python3` to 3.9; agentic-ci needs 3.10+. The images install `python3.12` and symlink it as the default `python3`/`python` in `/usr/local/bin`. A missing symlink or missing `python3.12` breaks the `uv pip install --system` step.
 - **Where to look**: `images/ci/Containerfile.openshell`, `images/runner/claude-code/Containerfile.openshell`, `images/runner/opencode/Containerfile.openshell` python setup
 
+### CI image build cannot find the pinned ACLI RPM
+- **Likely cause**: Atlassian removed the pinned ACLI version from its RPM repository. Query the live repository metadata and update `ACLI_VERSION` in both CI Containerfiles to the currently published version.
+- **Where to look**: `images/ci/Containerfile.podman`, `images/ci/Containerfile.openshell`, Atlassian ACLI RPM repository metadata
+
 ### OpenCode image build fails with `KeyError: 'repo'`
 - **Likely cause**: A marketplace plugin uses a `git-subdir` source with `url` and `path` instead of the legacy GitHub `repo` field. The OpenCode compatibility installer must resolve both source formats and search for skills relative to the configured subdirectory.
 - **Where to look**: `plugins.py:install_opencode_skills()`, the generated marketplace entry

--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -95,3 +95,7 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 ### agentic-ci fails to run in OpenShell image (Python too old)
 - **Likely cause**: UBI9 defaults `python3` to 3.9; agentic-ci needs 3.10+. The images install `python3.12` and symlink it as the default `python3`/`python` in `/usr/local/bin`. A missing symlink or missing `python3.12` breaks the `uv pip install --system` step.
 - **Where to look**: `images/ci/Containerfile.openshell`, `images/runner/claude-code/Containerfile.openshell`, `images/runner/opencode/Containerfile.openshell` python setup
+
+### OpenCode image build fails with `KeyError: 'repo'`
+- **Likely cause**: A marketplace plugin uses a `git-subdir` source with `url` and `path` instead of the legacy GitHub `repo` field. The OpenCode compatibility installer must resolve both source formats and search for skills relative to the configured subdirectory.
+- **Where to look**: `plugins.py:install_opencode_skills()`, the generated marketplace entry

--- a/images/ci/Containerfile.openshell
+++ b/images/ci/Containerfile.openshell
@@ -121,7 +121,7 @@ RUN curl -fsSL -o /tmp/vale.tar.gz \
     && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.29~stable-1
+ARG ACLI_VERSION=1.3.30~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/images/ci/Containerfile.podman
+++ b/images/ci/Containerfile.podman
@@ -71,7 +71,7 @@ RUN curl -fsSL -o /tmp/vale.tar.gz \
     && rm -rf /tmp/vale.tar.gz /tmp/vale
 
 # Atlassian CLI (acli, pinned via RPM)
-ARG ACLI_VERSION=1.3.29~stable-1
+ARG ACLI_VERSION=1.3.30~stable-1
 RUN curl -fsSL -o /etc/yum.repos.d/acli.repo \
         https://acli.atlassian.com/linux/rpm/acli.repo \
     && dnf install -y --nodocs "acli-${ACLI_VERSION}" \

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -168,11 +168,21 @@ def install_opencode_skills(
     data = json.loads(marketplace_json.read_text())
     for entry in data.get("plugins", []):
         name = entry["name"]
-        repo = entry["source"]["repo"]
-        ref = entry["source"].get("ref", "main")
-        url = f"https://github.com/{repo}.git"
+        source = entry.get("source", {})
+        repo = source.get("repo")
+        ref = source.get("ref", "main")
+        source_path = source.get("path", "")
+        if repo:
+            url = f"https://github.com/{repo}.git"
+            source_label = repo
+        elif source.get("source") == "git-subdir" and source.get("url"):
+            url = source["url"]
+            source_label = url
+        else:
+            print(f"WARN: skipping {name}; unsupported marketplace source")
+            continue
 
-        print(f"==> Installing skills from {name} ({repo} @ {ref})")
+        print(f"==> Installing skills from {name} ({source_label} @ {ref})")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             clone_dir = Path(tmpdir) / "src"
@@ -181,7 +191,16 @@ def install_opencode_skills(
                 continue
 
             skills_sources: list[Path] = []
-            source_root = clone_dir.resolve()
+            clone_root = clone_dir.resolve()
+            source_root = (clone_root / source_path.removeprefix("./")).resolve()
+            try:
+                source_root.relative_to(clone_root)
+            except ValueError:
+                print(f"  WARN: rejected source path outside repository: {source_path}")
+                continue
+            if not source_root.is_dir():
+                print(f"  WARN: source path not found: {source_path}")
+                continue
 
             explicit_paths = entry.get("skills", [])
             if explicit_paths:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -436,6 +436,43 @@ class TestInstallOpencodeSkills:
 
         assert json.loads(manifest.read_text()) == {}
 
+    def test_installs_skills_from_git_subdir_source(self, tmp_path):
+        repo = tmp_path / "mock-repo"
+        skill = repo / "plugins" / "patternfly" / "pf-react" / "skills" / "pf-react"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: pf-react\n---\n")
+        mkt = tmp_path / "marketplace.json"
+        mkt.write_text(
+            json.dumps(
+                {
+                    "plugins": [
+                        {
+                            "name": "pf-react",
+                            "source": {
+                                "source": "git-subdir",
+                                "url": "https://github.com/rh-uxd/ai-helpers.git",
+                                "path": "plugins/patternfly/pf-react",
+                                "ref": "main",
+                            },
+                        }
+                    ]
+                }
+            )
+        )
+        skills_dir = tmp_path / "skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            assert url == "https://github.com/rh-uxd/ai-helpers.git"
+            shutil.copytree(repo, dest)
+            return True
+
+        with mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+
+        assert (skills_dir / "pf-react" / "SKILL.md").is_file()
+        assert json.loads(manifest.read_text()) == {"pf-react": ["pf-react"]}
+
     def test_explicit_skills_paths(self, tmp_path):
         repo = tmp_path / "mock-repo"
         helpers = repo / "helpers" / "skills" / "helper-skill"


### PR DESCRIPTION
## Description

The 0.3.42 container image release failed while installing OpenCode compatibility skills after opendatahub-io/skills-registry#97 introduced `git-subdir` marketplace sources. `install_opencode_skills()` assumed every source contained a GitHub `repo` field and raised `KeyError: repo`.

This change:

- Preserves support for legacy `repo` marketplace sources.
- Resolves `git-subdir` sources from their explicit `url`, `ref`, and `path` fields.
- Searches for skills relative to the configured plugin subdirectory.
- Rejects source paths that escape the cloned repository.
- Skips unsupported marketplace source formats with a warning.
- Documents the failure pattern in the debug symptom catalog.

Failed release workflow: https://github.com/opendatahub-io/agentic-ci/actions/runs/33003226895

## How Has This Been Tested?

Added a regression test reproducing the PatternFly `git-subdir` marketplace shape and verifying that the expected skill is installed and recorded in the manifest.

Validated with:

- `tox -e py313` (919 tests passed)
- `tox -e lint`
- `tox -e check-format`
- `tox -e typecheck`

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body.
- [x] The developer has manually tested the changes and verified that the changes work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode skill installation from marketplace plugins using direct Git URLs and nested repository paths.
  * Added validation to prevent paths outside the cloned repository and warnings for missing paths.
  * Unsupported marketplace source formats are now skipped safely.

* **Tests**
  * Added coverage verifying installation from nested `git-subdir` sources and manifest generation.

* **Documentation**
  * Documented troubleshooting guidance for related OpenCode image build failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->