### PR TITLE
AIPCC-31384: Add lifecycle outcome event contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ pipelines:
 - **`agentic_ci.pipeline`** — GitLab child pipeline YAML generation
   with hash-based slot distribution.
 - **`agentic_ci.verdict`** — Structured verdict JSON schema validation.
+- **`agentic_ci.lifecycle`** — Versioned, immutable SDLC lifecycle outcome
+  events with generic correlation and deterministic IDs.
 
 ## Building a Pipeline with the Generic Skill Runner
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -26,6 +26,7 @@ Auto-generated reference documentation for all public modules in `agentic-ci`.
 | [Gates](gates.md) | Pre- and post-agent validation gates |
 | [Skill Runner](skill.md) | Generic skill runner framework |
 | [Verdict](verdict.md) | Structured verdict JSON validation |
+| [Lifecycle Outcomes](lifecycle.md) | Versioned SDLC lifecycle outcome events |
 | [Git Operations](git.md) | Git operations for CI pipelines |
 | [Pipeline Generation](pipeline.md) | GitLab child pipeline YAML generation |
 

--- a/docs/api/lifecycle.md
+++ b/docs/api/lifecycle.md
@@ -1,0 +1,85 @@
+# Lifecycle Outcome Events
+
+`agentic_ci.lifecycle` provides a small, versioned contract for reporting
+outcomes from Autofix and other SDLC automation. The contract contains no
+storage or transport implementation. Producers can serialize an event and send
+it to the system used by their pipeline.
+
+## Event shape
+
+`OutcomeEvent` is immutable after construction. It contains:
+
+- `schema_version` and `event_type` for contract negotiation.
+- A deterministic `event_id`, derived from the schema major version,
+  `correlation_id`, `stage`, and `attempt`.
+- `stage` values for `eligibility`, `analyzed`, `proposed`, `iterated`,
+  `blocked`, `rejected`, `abandoned`, `stale`, `merged`, and `reconciliation`.
+- `final_outcome`, including `reconciled` for reconciliation events.
+- Event and stage timestamps, attempt number, verdict, reason, harness, model,
+  and optional token, cache-token, cost, and latency metrics.
+- Optional correlation fields for Jira key/project, repository/branch, forge
+  URL/ID, pipeline/job, and trace/session identifiers.
+
+Jira fields are optional. A non-Jira SDLC pipeline can use the same contract
+with only its repository, forge, pipeline, or telemetry identifiers.
+
+## Create and serialize an event
+
+```python
+from agentic_ci.lifecycle import (
+    OutcomeCorrelation,
+    OutcomeEvent,
+    OutcomeMetrics,
+)
+
+event = OutcomeEvent.create(
+    correlation_id="AIPCC-31384",
+    stage="proposed",
+    attempt=1,
+    correlation=OutcomeCorrelation(
+        jira_key="AIPCC-31384",
+        jira_project="AIPCC",
+        repository="https://github.com/example/project",
+        branch="codex/aipcc-31384",
+        forge_url="https://github.com/example/project/pull/42",
+        forge_id="42",
+        pipeline_id="pipeline-7",
+        job_id="job-12",
+        trace_id="trace-abc",
+        session_id="session-xyz",
+    ),
+    harness="codex",
+    model="gpt-5.6-luna",
+    verdict="committed",
+    reason="Merge request created",
+    metrics=OutcomeMetrics(
+        input_tokens=1200,
+        output_tokens=300,
+        cache_read_tokens=800,
+        cache_write_tokens=100,
+        total_tokens=2400,
+        cost_usd=0.03,
+        latency_ms=4200,
+    ),
+)
+
+payload = event.to_dict()
+json_line = event.to_json()
+same_id = OutcomeEvent.create(correlation_id="AIPCC-31384", stage="proposed", attempt=1).event_id
+assert same_id == event.event_id
+```
+
+Use a new `attempt` for a new execution of the same lifecycle stage. Retries
+that publish the same stage attempt must reuse the same `correlation_id`, stage,
+and attempt so downstream consumers can de-duplicate by `event_id`.
+
+## Compatibility
+
+`validate_outcome_event(payload)` accepts schema version `1.x`. Unknown fields
+are retained in `OutcomeEvent.extensions`, which allows minor-version additions
+without breaking existing consumers. A major version change raises
+`LifecycleEventError`. The checked-in JSON Schema is available through
+`outcome_event_schema()` and at
+`src/agentic_ci/data/outcome_event.schema.json`.
+
+::: agentic_ci.lifecycle

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ simplicity and security.
 - **OTEL telemetry**: Token usage, cost tracking, and metrics collection
 - **Gates**: Pre- and post-agent validation (sensitive files, commit checks, secret scanning)
 - **Skill runner**: Generic framework for building AI-powered CI pipelines
+- **Lifecycle outcomes**: Versioned, idempotent outcome events for SDLC automation
 
 ## Install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
           - Gates: api/gates.md
           - Skill Runner: api/skill.md
           - Verdict: api/verdict.md
+          - Lifecycle Outcomes: api/lifecycle.md
           - Git Operations: api/git.md
           - Pipeline Generation: api/pipeline.md
       - Integrations:

--- a/src/agentic_ci/data/outcome_event.schema.json
+++ b/src/agentic_ci/data/outcome_event.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://opendatahub-io.github.io/agentic-ci/schemas/outcome-event-1.0.json",
+  "title": "Agentic CI SDLC lifecycle outcome event",
+  "description": "Versioned, idempotent outcome event for generic SDLC automation.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "event_id",
+    "correlation_id",
+    "stage",
+    "final_outcome",
+    "event_timestamp",
+    "stage_timestamp",
+    "attempt",
+    "correlation",
+    "metrics",
+    "metadata"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^1\\.[0-9]+$"
+    },
+    "event_type": {
+      "const": "sdlc.lifecycle.outcome"
+    },
+    "event_id": {
+      "type": "string",
+      "pattern": "^outcome-v1-[0-9a-f]{64}$"
+    },
+    "correlation_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "stage": {
+      "type": "string",
+      "enum": [
+        "eligibility",
+        "analyzed",
+        "proposed",
+        "iterated",
+        "blocked",
+        "rejected",
+        "abandoned",
+        "stale",
+        "merged",
+        "reconciliation"
+      ]
+    },
+    "final_outcome": {
+      "type": "string",
+      "enum": [
+        "eligible",
+        "analyzed",
+        "proposed",
+        "iterated",
+        "blocked",
+        "rejected",
+        "abandoned",
+        "stale",
+        "merged",
+        "reconciled"
+      ]
+    },
+    "event_timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "stage_timestamp": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "attempt": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "correlation": {
+      "$ref": "#/$defs/correlation"
+    },
+    "harness": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "model": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "verdict": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "reason": {
+      "type": ["string", "null"],
+      "minLength": 1
+    },
+    "metrics": {
+      "$ref": "#/$defs/metrics"
+    },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "correlation": {
+      "type": "object",
+      "description": "Optional identifiers for issue trackers, repositories, forges, and telemetry.",
+      "properties": {
+        "jira_key": {"type": ["string", "null"], "minLength": 1},
+        "jira_project": {"type": ["string", "null"], "minLength": 1},
+        "repository": {"type": ["string", "null"], "minLength": 1},
+        "branch": {"type": ["string", "null"], "minLength": 1},
+        "forge_url": {"type": ["string", "null"], "minLength": 1},
+        "forge_id": {"type": ["string", "null"], "minLength": 1},
+        "pipeline_id": {"type": ["string", "null"], "minLength": 1},
+        "job_id": {"type": ["string", "null"], "minLength": 1},
+        "trace_id": {"type": ["string", "null"], "minLength": 1},
+        "session_id": {"type": ["string", "null"], "minLength": 1}
+      },
+      "additionalProperties": true
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "input_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "output_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "cache_read_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "cache_write_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "total_tokens": {"type": ["integer", "null"], "minimum": 0},
+        "cost_usd": {"type": ["number", "null"], "minimum": 0},
+        "latency_ms": {"type": ["number", "null"], "minimum": 0}
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/src/agentic_ci/lifecycle.py
+++ b/src/agentic_ci/lifecycle.py
@@ -1,0 +1,531 @@
+"""Versioned lifecycle outcome events for SDLC automation.
+
+This module defines a small, immutable event contract that SDLC pipelines can
+use to publish lifecycle outcomes without coupling producers to storage or a
+particular issue tracker.  Jira fields are optional correlation attributes,
+not workflow requirements.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from functools import lru_cache
+from importlib.resources import files
+from types import MappingProxyType
+from typing import Any, Literal, TypeAlias, cast
+
+SCHEMA_VERSION = "1.0"
+EVENT_TYPE = "sdlc.lifecycle.outcome"
+
+LifecycleStage: TypeAlias = Literal[
+    "eligibility",
+    "analyzed",
+    "proposed",
+    "iterated",
+    "blocked",
+    "rejected",
+    "abandoned",
+    "stale",
+    "merged",
+    "reconciliation",
+]
+FinalOutcome: TypeAlias = Literal[
+    "eligible",
+    "analyzed",
+    "proposed",
+    "iterated",
+    "blocked",
+    "rejected",
+    "abandoned",
+    "stale",
+    "merged",
+    "reconciled",
+]
+JSONValue: TypeAlias = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+
+VALID_STAGES = frozenset(
+    {
+        "eligibility",
+        "analyzed",
+        "proposed",
+        "iterated",
+        "blocked",
+        "rejected",
+        "abandoned",
+        "stale",
+        "merged",
+        "reconciliation",
+    }
+)
+VALID_OUTCOMES = frozenset(
+    {
+        "eligible",
+        "analyzed",
+        "proposed",
+        "iterated",
+        "blocked",
+        "rejected",
+        "abandoned",
+        "stale",
+        "merged",
+        "reconciled",
+    }
+)
+_DEFAULT_OUTCOME_BY_STAGE: dict[str, str] = {
+    "eligibility": "eligible",
+    "analyzed": "analyzed",
+    "proposed": "proposed",
+    "iterated": "iterated",
+    "blocked": "blocked",
+    "rejected": "rejected",
+    "abandoned": "abandoned",
+    "stale": "stale",
+    "merged": "merged",
+    "reconciliation": "reconciled",
+}
+_SCHEMA_VERSION_RE = re.compile(r"^(?P<major>[1-9][0-9]*)\.(?P<minor>[0-9]+)$")
+_EVENT_ID_RE = re.compile(r"^outcome-v[1-9][0-9]*-[0-9a-f]{64}$")
+_KNOWN_EVENT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "event_type",
+        "event_id",
+        "correlation_id",
+        "stage",
+        "final_outcome",
+        "event_timestamp",
+        "stage_timestamp",
+        "attempt",
+        "correlation",
+        "harness",
+        "model",
+        "verdict",
+        "reason",
+        "metrics",
+        "metadata",
+    }
+)
+
+
+class LifecycleEventError(ValueError):
+    """Raised when a lifecycle event is malformed or incompatible."""
+
+
+def is_compatible_schema_version(version: str) -> bool:
+    """Return whether *version* can be read by this contract.
+
+    Minor versions are forward-compatible because unknown fields are retained
+    in :attr:`OutcomeEvent.extensions`.  A major version change requires a
+    new reader and is rejected.
+    """
+
+    match = _SCHEMA_VERSION_RE.fullmatch(version) if isinstance(version, str) else None
+    return match is not None and int(match.group("major")) == 1
+
+
+def _check_schema_version(version: str) -> None:
+    if not is_compatible_schema_version(version):
+        raise LifecycleEventError(
+            f"Unsupported lifecycle event schema version {version!r}; supported major version is 1"
+        )
+
+
+def _check_optional_string(name: str, value: Any) -> None:
+    if value is not None and (not isinstance(value, str) or not value.strip()):
+        raise LifecycleEventError(f"{name} must be a non-empty string or null")
+
+
+def _freeze_json(value: Any, *, path: str = "value") -> Any:
+    """Recursively freeze JSON-compatible values for immutable event fields."""
+
+    if value is None or isinstance(value, (bool, int, str)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise LifecycleEventError(f"{path} must contain finite numbers")
+        return value
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise LifecycleEventError(f"{path} keys must be strings")
+            frozen[key] = _freeze_json(item, path=f"{path}.{key}")
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_json(item, path=f"{path}[]") for item in value)
+    raise LifecycleEventError(f"{path} must contain JSON-compatible values")
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _validate_timestamp(name: str, value: str) -> None:
+    if not isinstance(value, str):
+        raise LifecycleEventError(f"{name} must be an RFC 3339 timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise LifecycleEventError(f"{name} must be an RFC 3339 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise LifecycleEventError(f"{name} must include a timezone")
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def event_id_for(
+    correlation_id: str,
+    stage: str,
+    attempt: int = 1,
+    *,
+    schema_version: str = SCHEMA_VERSION,
+) -> str:
+    """Return deterministic, idempotent ID for one lifecycle stage attempt.
+
+    Producers must reuse ``correlation_id``, ``stage``, and ``attempt`` when
+    retrying publication of the same logical event.  Event payload changes do
+    not create a second ID for that stage attempt.
+    """
+
+    _check_schema_version(schema_version)
+    _check_optional_string("correlation_id", correlation_id)
+    _check_optional_string("stage", stage)
+    if stage not in VALID_STAGES:
+        raise LifecycleEventError(f"unknown lifecycle stage: {stage!r}")
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 1:
+        raise LifecycleEventError("attempt must be a positive integer")
+
+    major = schema_version.split(".", maxsplit=1)[0]
+    identity = json.dumps(
+        [EVENT_TYPE, major, correlation_id.strip(), stage, attempt],
+        separators=(",", ":"),
+    ).encode("utf-8")
+    digest = hashlib.sha256(identity).hexdigest()
+    return f"outcome-v{major}-{digest}"
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeCorrelation:
+    """Optional identifiers that connect an event to SDLC systems."""
+
+    jira_key: str | None = None
+    jira_project: str | None = None
+    repository: str | None = None
+    branch: str | None = None
+    forge_url: str | None = None
+    forge_id: str | None = None
+    pipeline_id: str | None = None
+    job_id: str | None = None
+    trace_id: str | None = None
+    session_id: str | None = None
+
+    def __post_init__(self) -> None:
+        for name in self.__dataclass_fields__:
+            _check_optional_string(name, getattr(self, name))
+
+    def to_dict(self) -> dict[str, str | None]:
+        """Return JSON-ready correlation fields."""
+
+        return {name: getattr(self, name) for name in self.__dataclass_fields__}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any] | None) -> "OutcomeCorrelation":
+        """Build correlation fields from a JSON object."""
+
+        if value is None:
+            return cls()
+        if not isinstance(value, Mapping):
+            raise LifecycleEventError("correlation must be an object")
+        fields = {name: value.get(name) for name in cls.__dataclass_fields__ if name in value}
+        return cls(**fields)
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeMetrics:
+    """Optional token, cost, and latency measurements for one event."""
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cache_read_tokens: int | None = None
+    cache_write_tokens: int | None = None
+    total_tokens: int | None = None
+    cost_usd: float | None = None
+    latency_ms: float | None = None
+
+    def __post_init__(self) -> None:
+        for name in (
+            "input_tokens",
+            "output_tokens",
+            "cache_read_tokens",
+            "cache_write_tokens",
+            "total_tokens",
+        ):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value < 0
+            ):
+                raise LifecycleEventError(f"{name} must be a non-negative integer or null")
+        for name in ("cost_usd", "latency_ms"):
+            value = getattr(self, name)
+            if value is not None and (
+                isinstance(value, bool)
+                or not isinstance(value, (int, float))
+                or not math.isfinite(value)
+                or value < 0
+            ):
+                raise LifecycleEventError(f"{name} must be a non-negative number or null")
+
+    def to_dict(self) -> dict[str, int | float | None]:
+        """Return JSON-ready metrics fields."""
+
+        return {name: getattr(self, name) for name in self.__dataclass_fields__}
+
+    @classmethod
+    def from_dict(cls, value: Mapping[str, Any] | None) -> "OutcomeMetrics":
+        """Build metrics from a JSON object."""
+
+        if value is None:
+            return cls()
+        if not isinstance(value, Mapping):
+            raise LifecycleEventError("metrics must be an object")
+        fields = {name: value.get(name) for name in cls.__dataclass_fields__ if name in value}
+        return cls(**fields)
+
+
+@dataclass(frozen=True, slots=True)
+class OutcomeEvent:
+    """Immutable, versioned outcome event shared by SDLC pipelines."""
+
+    schema_version: str
+    event_type: str
+    event_id: str
+    correlation_id: str
+    stage: LifecycleStage
+    final_outcome: FinalOutcome
+    event_timestamp: str
+    stage_timestamp: str
+    attempt: int
+    correlation: OutcomeCorrelation = field(default_factory=OutcomeCorrelation)
+    harness: str | None = None
+    model: str | None = None
+    verdict: str | None = None
+    reason: str | None = None
+    metrics: OutcomeMetrics = field(default_factory=OutcomeMetrics)
+    metadata: Mapping[str, JSONValue] = field(default_factory=dict)
+    extensions: Mapping[str, JSONValue] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        _check_schema_version(self.schema_version)
+        if self.event_type != EVENT_TYPE:
+            raise LifecycleEventError(f"event_type must be {EVENT_TYPE!r}")
+        _check_optional_string("correlation_id", self.correlation_id)
+        if self.stage not in VALID_STAGES:
+            raise LifecycleEventError(f"unknown lifecycle stage: {self.stage!r}")
+        if self.final_outcome not in VALID_OUTCOMES:
+            raise LifecycleEventError(f"unknown final outcome: {self.final_outcome!r}")
+        expected_id = event_id_for(
+            self.correlation_id,
+            self.stage,
+            self.attempt,
+            schema_version=self.schema_version,
+        )
+        if not _EVENT_ID_RE.fullmatch(self.event_id) or self.event_id != expected_id:
+            raise LifecycleEventError("event_id does not match deterministic event identity")
+        _validate_timestamp("event_timestamp", self.event_timestamp)
+        _validate_timestamp("stage_timestamp", self.stage_timestamp)
+        if isinstance(self.attempt, bool) or not isinstance(self.attempt, int) or self.attempt < 1:
+            raise LifecycleEventError("attempt must be a positive integer")
+        if not isinstance(self.correlation, OutcomeCorrelation):
+            raise LifecycleEventError("correlation must be OutcomeCorrelation")
+        if not isinstance(self.metrics, OutcomeMetrics):
+            raise LifecycleEventError("metrics must be OutcomeMetrics")
+        for name in ("harness", "model", "verdict", "reason"):
+            _check_optional_string(name, getattr(self, name))
+        frozen_metadata = _freeze_json(self.metadata, path="metadata")
+        frozen_extensions = _freeze_json(self.extensions, path="extensions")
+        if not isinstance(frozen_metadata, Mapping):
+            raise LifecycleEventError("metadata must be an object")
+        if not isinstance(frozen_extensions, Mapping):
+            raise LifecycleEventError("extensions must be an object")
+        if set(frozen_extensions) & _KNOWN_EVENT_FIELDS:
+            raise LifecycleEventError("extensions cannot replace contract fields")
+        object.__setattr__(self, "metadata", frozen_metadata)
+        object.__setattr__(self, "extensions", frozen_extensions)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        correlation_id: str,
+        stage: LifecycleStage,
+        final_outcome: FinalOutcome | None = None,
+        event_timestamp: str | None = None,
+        stage_timestamp: str | None = None,
+        attempt: int = 1,
+        correlation: OutcomeCorrelation | Mapping[str, Any] | None = None,
+        harness: str | None = None,
+        model: str | None = None,
+        verdict: str | None = None,
+        reason: str | None = None,
+        metrics: OutcomeMetrics | Mapping[str, Any] | None = None,
+        metadata: Mapping[str, JSONValue] | None = None,
+        schema_version: str = SCHEMA_VERSION,
+    ) -> "OutcomeEvent":
+        """Create one lifecycle event with deterministic ID and timestamps."""
+
+        _check_schema_version(schema_version)
+        if final_outcome is None:
+            final_outcome = cast(FinalOutcome, _DEFAULT_OUTCOME_BY_STAGE.get(stage, ""))
+        event_time = event_timestamp or _utc_now()
+        return cls(
+            schema_version=schema_version,
+            event_type=EVENT_TYPE,
+            event_id=event_id_for(
+                correlation_id,
+                stage,
+                attempt,
+                schema_version=schema_version,
+            ),
+            correlation_id=correlation_id,
+            stage=stage,
+            final_outcome=final_outcome,
+            event_timestamp=event_time,
+            stage_timestamp=stage_timestamp or event_time,
+            attempt=attempt,
+            correlation=(
+                correlation
+                if isinstance(correlation, OutcomeCorrelation)
+                else OutcomeCorrelation.from_dict(correlation)
+            ),
+            harness=harness,
+            model=model,
+            verdict=verdict,
+            reason=reason,
+            metrics=(
+                metrics
+                if isinstance(metrics, OutcomeMetrics)
+                else OutcomeMetrics.from_dict(metrics)
+            ),
+            metadata=metadata or {},
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-ready copy of this event."""
+
+        payload: dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "event_type": self.event_type,
+            "event_id": self.event_id,
+            "correlation_id": self.correlation_id,
+            "stage": self.stage,
+            "final_outcome": self.final_outcome,
+            "event_timestamp": self.event_timestamp,
+            "stage_timestamp": self.stage_timestamp,
+            "attempt": self.attempt,
+            "correlation": self.correlation.to_dict(),
+            "harness": self.harness,
+            "model": self.model,
+            "verdict": self.verdict,
+            "reason": self.reason,
+            "metrics": self.metrics.to_dict(),
+            "metadata": _thaw_json(self.metadata),
+        }
+        payload.update(_thaw_json(self.extensions))
+        return payload
+
+    def to_json(self) -> str:
+        """Serialize this event using stable JSON key ordering."""
+
+        return json.dumps(self.to_dict(), sort_keys=True, separators=(",", ":"))
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "OutcomeEvent":
+        """Parse and validate an event, accepting compatible minor versions."""
+
+        if not isinstance(payload, Mapping):
+            raise LifecycleEventError("lifecycle event must be an object")
+        missing = (
+            _KNOWN_EVENT_FIELDS
+            - set(payload)
+            - {
+                "harness",
+                "model",
+                "verdict",
+                "reason",
+            }
+        )
+        if missing:
+            raise LifecycleEventError(f"lifecycle event missing fields: {sorted(missing)}")
+        schema_version = payload.get("schema_version")
+        if not isinstance(schema_version, str):
+            raise LifecycleEventError("schema_version must be a string")
+        _check_schema_version(schema_version)
+        if not isinstance(payload["correlation"], Mapping):
+            raise LifecycleEventError("correlation must be an object")
+        if not isinstance(payload["metrics"], Mapping):
+            raise LifecycleEventError("metrics must be an object")
+        extensions = {
+            key: value for key, value in payload.items() if key not in _KNOWN_EVENT_FIELDS
+        }
+        return cls(
+            schema_version=schema_version,
+            event_type=payload["event_type"],
+            event_id=payload["event_id"],
+            correlation_id=payload["correlation_id"],
+            stage=payload["stage"],
+            final_outcome=payload["final_outcome"],
+            event_timestamp=payload["event_timestamp"],
+            stage_timestamp=payload["stage_timestamp"],
+            attempt=payload["attempt"],
+            correlation=OutcomeCorrelation.from_dict(payload["correlation"]),
+            harness=payload.get("harness"),
+            model=payload.get("model"),
+            verdict=payload.get("verdict"),
+            reason=payload.get("reason"),
+            metrics=OutcomeMetrics.from_dict(payload["metrics"]),
+            metadata=payload["metadata"],
+            extensions=extensions,
+        )
+
+
+def validate_outcome_event(payload: Mapping[str, Any]) -> OutcomeEvent:
+    """Validate JSON-like payload and return its immutable event form."""
+
+    return OutcomeEvent.from_dict(payload)
+
+
+@lru_cache(maxsize=1)
+def outcome_event_schema() -> dict[str, Any]:
+    """Load the checked-in JSON Schema for lifecycle outcome events."""
+
+    schema_path = files("agentic_ci").joinpath("data/outcome_event.schema.json")
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+__all__ = [
+    "EVENT_TYPE",
+    "FinalOutcome",
+    "JSONValue",
+    "LifecycleEventError",
+    "LifecycleStage",
+    "OutcomeCorrelation",
+    "OutcomeEvent",
+    "OutcomeMetrics",
+    "SCHEMA_VERSION",
+    "event_id_for",
+    "is_compatible_schema_version",
+    "outcome_event_schema",
+    "validate_outcome_event",
+]

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,150 @@
+"""Tests for the generic lifecycle outcome event contract."""
+
+import json
+
+import pytest
+
+from agentic_ci.lifecycle import (
+    EVENT_TYPE,
+    LifecycleEventError,
+    OutcomeCorrelation,
+    OutcomeEvent,
+    OutcomeMetrics,
+    event_id_for,
+    is_compatible_schema_version,
+    outcome_event_schema,
+    validate_outcome_event,
+)
+
+
+def test_event_id_is_stable_for_stage_attempt() -> None:
+    first = event_id_for("run-123", "proposed", 2)
+    second = event_id_for("run-123", "proposed", 2)
+
+    assert first == second
+    assert first != event_id_for("run-123", "proposed", 3)
+    assert first != event_id_for("run-123", "merged", 2)
+    assert first.startswith("outcome-v1-")
+
+
+def test_event_is_immutable_and_round_trips() -> None:
+    event = OutcomeEvent.create(
+        correlation_id="run-123",
+        stage="proposed",
+        event_timestamp="2026-09-04T12:00:00Z",
+        correlation=OutcomeCorrelation(
+            jira_key="AIPCC-31384",
+            jira_project="AIPCC",
+            repository="org/repo",
+            branch="feature/outcome",
+            forge_url="https://gitlab.example/org/repo/-/merge_requests/7",
+            forge_id="7",
+            pipeline_id="pipeline-1",
+            job_id="job-2",
+            trace_id="trace-3",
+            session_id="session-4",
+        ),
+        harness="codex",
+        model="gpt-5.6-luna",
+        verdict="committed",
+        reason="MR opened",
+        metrics=OutcomeMetrics(
+            input_tokens=10,
+            output_tokens=20,
+            cache_read_tokens=30,
+            cache_write_tokens=40,
+            total_tokens=100,
+            cost_usd=0.5,
+            latency_ms=1200,
+        ),
+        metadata={"owner": "autofix", "labels": ["jira-autofix"]},
+    )
+
+    assert event.event_type == EVENT_TYPE
+    assert event.stage_timestamp == event.event_timestamp
+    assert event.to_dict()["correlation"]["jira_key"] == "AIPCC-31384"
+    assert event.to_dict()["metrics"]["cache_read_tokens"] == 30
+    assert event.to_dict()["metrics"]["cache_write_tokens"] == 40
+    assert validate_outcome_event(event.to_dict()).to_dict() == event.to_dict()
+    assert json.loads(event.to_json()) == event.to_dict()
+
+    with pytest.raises((AttributeError, TypeError)):
+        event.stage = "merged"  # type: ignore[misc]
+    with pytest.raises(TypeError):
+        event.metadata["new"] = "value"  # type: ignore[index]
+    with pytest.raises((TypeError, AttributeError)):
+        event.metadata["labels"].append("other")  # type: ignore[union-attr]
+
+
+@pytest.mark.parametrize(
+    ("stage", "final_outcome"),
+    [
+        ("eligibility", "eligible"),
+        ("analyzed", "analyzed"),
+        ("proposed", "proposed"),
+        ("iterated", "iterated"),
+        ("blocked", "blocked"),
+        ("rejected", "rejected"),
+        ("abandoned", "abandoned"),
+        ("stale", "stale"),
+        ("merged", "merged"),
+        ("reconciliation", "reconciled"),
+    ],
+)
+def test_all_lifecycle_outcomes_are_supported(stage: str, final_outcome: str) -> None:
+    event = OutcomeEvent.create(
+        correlation_id="generic-run",
+        stage=stage,  # type: ignore[arg-type]
+        event_timestamp="2026-09-04T12:00:00+00:00",
+    )
+
+    assert event.final_outcome == final_outcome
+
+
+def test_minor_versions_are_forward_compatible_and_extensions_are_retained() -> None:
+    event = OutcomeEvent.create(
+        correlation_id="generic-run",
+        stage="analyzed",
+        event_timestamp="2026-09-04T12:00:00Z",
+    )
+    payload = event.to_dict()
+    payload["schema_version"] = "1.1"
+    payload["future_field"] = {"enabled": True}
+    payload["event_id"] = event_id_for("generic-run", "analyzed", schema_version="1.1")
+
+    parsed = validate_outcome_event(payload)
+
+    assert is_compatible_schema_version("1.1")
+    assert parsed.event_id == event.event_id
+    assert parsed.extensions["future_field"] == {"enabled": True}
+    assert parsed.to_dict()["future_field"] == {"enabled": True}
+    assert not is_compatible_schema_version("2.0")
+
+
+def test_invalid_events_are_rejected() -> None:
+    with pytest.raises(LifecycleEventError, match="Unsupported lifecycle event schema"):
+        OutcomeEvent.create(correlation_id="run", stage="analyzed", schema_version="2.0")
+    with pytest.raises(LifecycleEventError, match="non-negative"):
+        OutcomeEvent.create(
+            correlation_id="run",
+            stage="analyzed",
+            metrics=OutcomeMetrics(input_tokens=-1),
+        )
+    with pytest.raises(LifecycleEventError, match="timezone"):
+        OutcomeEvent.create(
+            correlation_id="run",
+            stage="analyzed",
+            event_timestamp="2026-09-04T12:00:00",
+        )
+    with pytest.raises(LifecycleEventError, match="unknown lifecycle stage"):
+        event_id_for("run", "unknown")
+
+
+def test_checked_in_schema_is_available() -> None:
+    schema = outcome_event_schema()
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["properties"]["event_type"]["const"] == EVENT_TYPE
+    assert "reconciliation" in schema["properties"]["stage"]["enum"]
+    assert "cache_read_tokens" in schema["$defs"]["metrics"]["properties"]
+    assert "cache_write_tokens" in schema["$defs"]["metrics"]["properties"]


### PR DESCRIPTION
Define a versioned, immutable lifecycle event with deterministic IDs, cross-system correlation fields, cost metrics, JSON Schema, tests, and public documentation. This establishes the shared contract required by the follow-up telemetry and Org Pulse work.

Closes AIPCC-31384

Co-authored-by: Codex <noreply@openai.com>
Signed-off-by: Andre Lustosa <alustosa@redhat.com>
