### PR TITLE
AIPCC-31377: Add generic event telemetry transport

### DIFF
--- a/.claude/skills/debug-agentic-ci/references/symptoms.md
+++ b/.claude/skills/debug-agentic-ci/references/symptoms.md
@@ -54,6 +54,11 @@ Known failure patterns from this repo's history. Update this file when fixing bu
 - **Likely cause**: For OpenShell backend, OTEL host networking wasn't configured. Fixed to set up OTEL endpoint forwarding.
 - **Where to look**: `otel.py` collector setup, `backends/openshell/` network config
 
+### Generic event export fails after a workflow completes
+- **Likely cause**: Producer event was not JSON-compatible, violated privacy or size limits, the runner-owned log root was unsafe, or the OTLP collector was unavailable.
+- **Expected behavior**: `agentic_ci.telemetry` raises a transport error. The caller owns failure policy and must preserve its workflow result when export is best effort.
+- **Where to look**: `telemetry.py:validate_event()`, `telemetry.py:emit_event()`, and the producer's export boundary.
+
 ### Codex starts but plugins or OTEL data are missing
 - **Likely cause**: Codex was launched with `--ignore-user-config`, which suppresses plugin state and user-level OTel configuration, or the per-run `otel.*` exporter overrides were not passed.
 - **Where to look**: `harness.py` Codex arguments, `plugins.py`, backend `otel_endpoint` argument wiring

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ pipelines:
 - **`agentic_ci.pipeline`** — GitLab child pipeline YAML generation
   with hash-based slot distribution.
 - **`agentic_ci.verdict`** — Structured verdict JSON schema validation.
+- **`agentic_ci.telemetry`** — Generic producer-event validation and OTLP transport for the MLflow export path.
 
 ## Building a Pipeline with the Generic Skill Runner
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -11,6 +11,7 @@ Auto-generated reference documentation for all public modules in `agentic-ci`.
 | [Harness](harness.md) | Harness abstraction for AI agent CLI tools |
 | [Stream Processors](stream.md) | Parsers for Claude Code and OpenCode output |
 | [OTEL Collector](otel.md) | OTLP HTTP/JSON receiver and token/cost summary |
+| [Generic Event Transport](telemetry.md) | Producer-owned event validation and OTLP export |
 
 ## Backends
 

--- a/docs/api/telemetry.md
+++ b/docs/api/telemetry.md
@@ -1,0 +1,62 @@
+# Generic Event Transport
+
+`agentic_ci.telemetry` transports producer-owned event mappings through the
+existing OTLP trace path used by the MLflow exporter. It does not define lifecycle stages,
+outcomes, schemas, issue trackers, or workflow orchestration.
+
+## Event boundary
+
+An event must provide a non-empty `event_type` field. Producers can pass a
+JSON-compatible mapping or an immutable object implementing `to_dict()`.
+Additional safe fields are preserved unchanged and serialized in the OTLP
+span event body.
+
+The transport rejects content rather than silently redacting and changing a
+producer schema. Sensitive field names, email addresses, bearer credentials,
+private-key material, URL userinfo, and secret-bearing query parameters are
+not accepted in event or correlation values. Prompt, description, comment,
+diff, source-code, request/response body, username, and credential fields must
+be reduced to approved identifiers or aggregate metrics by the producer.
+Events are also bounded by nesting, collection, string, and serialized-size
+limits. Token-count fields such as `input_tokens` remain valid.
+
+Correlation identifiers are supplied separately as an arbitrary mapping. The
+transport emits them as `telemetry.correlation.<name>` attributes. A valid
+32-character hexadecimal `trace_id` joins the event to an existing trace;
+otherwise the transport creates a trace ID from the event identity. Existing
+root spans in a JSONL log are used as the event span's parent.
+
+## Emit or export
+
+```python
+from agentic_ci.telemetry import emit_event
+
+emit_event(
+    {
+        "event_type": "workflow.completed",
+        "event_id": "run-42-complete",
+        "result": "accepted",
+    },
+    log_root="_run",
+    correlation={
+        "work_item": "item-42",
+        "pipeline": "pipeline-7",
+        "job": "job-12",
+        "trace_id": "0123456789abcdef0123456789abcdef",
+    },
+)
+```
+
+File emission always appends to `claude-otel.jsonl` beneath the runner-owned
+`log_root`. Symbolic-link roots and symbolic-link log files are rejected, and
+the file is opened without following links. Producers cannot select an
+arbitrary output path.
+
+Use a trusted `endpoint="http://collector:4318"` to POST the same OTLP trace
+payload to an HTTP collector, or provide both destinations. Endpoint URLs and
+authorization headers are runner configuration, not producer event input.
+`emit_event()` and `export_event()` raise transport errors. The caller decides
+whether an export failure is fatal, so event transport cannot silently change
+a workflow result.
+
+::: agentic_ci.telemetry

--- a/docs/otel-architecture.md
+++ b/docs/otel-architecture.md
@@ -57,6 +57,20 @@ and the MLflow export pipeline.
               └──────────────────────────────┘
 ```
 
+Producer-owned events use `agentic_ci.telemetry.emit_event()` to enter this
+same trace path. The transport validates JSON compatibility, preserves event
+fields in a zero-duration OTLP span, copies caller-supplied correlation IDs to
+namespaced attributes, and leaves lifecycle meaning to the producer. Existing
+`mlflow-push` can consume the same OTLP span shape without a separate MLflow
+storage or UI integration; this repository does not run the MLflow E2E path
+for the generic transport.
+
+File emission uses a runner-owned log root and a fixed
+`claude-otel.jsonl` name. The transport rejects symbolic-link sinks, sensitive
+event/correlation content, and oversized payloads before persistence or
+export. Collector endpoints and authorization headers must come from trusted
+runner configuration.
+
 ## Collector (otel.py)
 
 The collector is a lightweight OTLP HTTP/JSON receiver built on Python's

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
           - Harness: api/harness.md
           - Stream Processors: api/stream.md
           - OTEL Collector: api/otel.md
+          - Generic Event Transport: api/telemetry.md
       - Backends:
           - Factory & Podman: api/backends.md
           - OpenShell: api/openshell.md

--- a/src/agentic_ci/jira/client.py
+++ b/src/agentic_ci/jira/client.py
@@ -235,10 +235,13 @@ class JiraClient:
         """Fetch a single issue with comments. Returns a normalised dict.
 
         The returned dict has keys: ``key``, ``summary``, ``description``
-        (plain text), ``issue_type``, ``labels``, ``status``, ``project``,
-        ``components``, ``reporter_name``, ``reporter_email``, ``comments``.
+        (plain text), ``created`` (ISO 8601 timestamp), ``issue_type``,
+        ``labels``, ``status``, ``project``, ``components``, ``reporter_name``,
+        ``reporter_email``, ``comments``.
         """
-        req_fields = "summary,description,issuetype,labels,status,reporter,components,project"
+        req_fields = (
+            "summary,description,created,issuetype,labels,status,reporter,components,project"
+        )
         resp = self._request(
             "get",
             self._api_url(f"issue/{key}") + f"?fields={req_fields}",
@@ -253,6 +256,9 @@ class JiraClient:
             description = adf_to_text(desc_field)
         else:
             description = desc_field or ""
+        created = fields.get("created")
+        if not isinstance(created, str):
+            created = ""
 
         comments = self._fetch_comments(key)
         reporter = fields.get("reporter") or {}
@@ -262,6 +268,7 @@ class JiraClient:
             "key": issue.get("key", ""),
             "summary": fields.get("summary", ""),
             "description": description,
+            "created": created,
             "issue_type": fields.get("issuetype", {}).get("name", ""),
             "labels": fields.get("labels", []),
             "status": fields.get("status", {}).get("name", ""),
@@ -297,7 +304,7 @@ class JiraClient:
         return comments
 
     def search(self, jql: str, *, max_results: int = 500) -> list[dict]:
-        """Search issues by JQL. Returns a list of normalised dicts."""
+        """Search issues by JQL. Returns normalised dicts with ``created`` timestamps."""
         results: list[dict] = []
         next_page_token: str | None = None
         search_url = self._api_url("search/jql")
@@ -305,7 +312,15 @@ class JiraClient:
         while True:
             payload: dict = {
                 "jql": jql,
-                "fields": ["summary", "description", "issuetype", "labels", "comment", "status"],
+                "fields": [
+                    "summary",
+                    "description",
+                    "created",
+                    "issuetype",
+                    "labels",
+                    "comment",
+                    "status",
+                ],
                 "maxResults": min(50, max_results - len(results)),
             }
             if next_page_token:
@@ -327,6 +342,9 @@ class JiraClient:
                     description = adf_to_text(desc_field)
                 else:
                     description = desc_field or ""
+                created = fields.get("created")
+                if not isinstance(created, str):
+                    created = ""
 
                 comments_data = fields.get("comment", {})
                 comments = []
@@ -350,6 +368,7 @@ class JiraClient:
                         "key": issue.get("key", ""),
                         "summary": fields.get("summary", ""),
                         "description": description,
+                        "created": created,
                         "issue_type": fields.get("issuetype", {}).get("name", ""),
                         "labels": fields.get("labels", []),
                         "status": fields.get("status", {}).get("name", ""),

--- a/src/agentic_ci/telemetry.py
+++ b/src/agentic_ci/telemetry.py
@@ -1,0 +1,470 @@
+"""Generic event transport for the existing OTLP trace pipeline.
+
+This module owns transport and serialization only. Producers own event schemas,
+workflow timing, outcome classification, and correlation-field meaning.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import re
+import stat
+import time
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol, TypeAlias
+from urllib.parse import urlsplit
+
+import requests
+
+JSONValue: TypeAlias = None | bool | int | float | str | list["JSONValue"] | dict[str, "JSONValue"]
+Correlation: TypeAlias = Mapping[str, str | None]
+
+MAX_EVENT_BYTES = 65_536
+MAX_STRING_LENGTH = 16_384
+MAX_NESTING_DEPTH = 20
+MAX_COLLECTION_ITEMS = 1_000
+_LOG_FILENAME = "claude-otel.jsonl"
+_SENSITIVE_KEYS = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "body",
+        "client_secret",
+        "comment",
+        "content",
+        "cookie",
+        "description",
+        "diff",
+        "email",
+        "email_address",
+        "password",
+        "passwd",
+        "patch",
+        "private_key",
+        "prompt",
+        "raw_request",
+        "raw_response",
+        "refresh_token",
+        "request_body",
+        "response_body",
+        "review_text",
+        "secret",
+        "set_cookie",
+        "source_code",
+        "user_email",
+        "username",
+    }
+)
+_EMAIL_RE = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_BEARER_RE = re.compile(r"\bbearer\s+[A-Z0-9._~+/=-]{8,}", re.IGNORECASE)
+_PRIVATE_KEY_RE = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
+_URL_USERINFO_RE = re.compile(r"^[a-z][a-z0-9+.-]*://[^/?#\s]*@", re.IGNORECASE)
+_SECRET_QUERY_RE = re.compile(
+    r"[?&](?:access_token|api_key|apikey|authorization|password|secret|token)=[^&#\s]+",
+    re.IGNORECASE,
+)
+
+
+class TelemetryEvent(Protocol):
+    """Protocol accepted by :func:`emit_event`.
+
+    Producers can pass any immutable event object that returns a JSON-like
+    mapping from ``to_dict()``. Plain mappings are accepted as well.
+    """
+
+    def to_dict(self) -> Mapping[str, JSONValue]:
+        """Return the event's JSON-compatible fields."""
+
+
+class TelemetryEventError(ValueError):
+    """Raised when a producer event cannot be transported safely."""
+
+
+class TelemetryExportError(RuntimeError):
+    """Raised when an OTLP event export request fails."""
+
+
+def _normalise_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "_", value.lower()).strip("_")
+
+
+def _is_sensitive_key(value: str) -> bool:
+    normalised = _normalise_key(value)
+    return normalised in _SENSITIVE_KEYS or normalised.endswith(
+        (
+            "_access_token",
+            "_api_key",
+            "_authorization",
+            "_password",
+            "_private_key",
+            "_secret",
+        )
+    )
+
+
+def _validate_string(value: str, path: str) -> None:
+    if len(value) > MAX_STRING_LENGTH:
+        raise TelemetryEventError(f"{path} exceeds the maximum string length")
+    if (
+        _EMAIL_RE.search(value)
+        or _BEARER_RE.search(value)
+        or _PRIVATE_KEY_RE.search(value)
+        or _URL_USERINFO_RE.search(value)
+        or _SECRET_QUERY_RE.search(value)
+    ):
+        raise TelemetryEventError(f"{path} contains sensitive content")
+
+
+def _validate_json(value: Any, path: str = "event", depth: int = 0) -> None:
+    if depth > MAX_NESTING_DEPTH:
+        raise TelemetryEventError(f"{path} exceeds the maximum nesting depth")
+    if value is None or isinstance(value, (bool, int)):
+        return
+    if isinstance(value, str):
+        _validate_string(value, path)
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TelemetryEventError(f"{path} contains a non-finite number")
+        return
+    if isinstance(value, Mapping):
+        if len(value) > MAX_COLLECTION_ITEMS:
+            raise TelemetryEventError(f"{path} contains too many fields")
+        for key, item in value.items():
+            if not isinstance(key, str) or not key:
+                raise TelemetryEventError(f"{path} keys must be non-empty strings")
+            if _is_sensitive_key(key):
+                raise TelemetryEventError(f"{path}.{key} is not allowed in telemetry events")
+            _validate_json(item, f"{path}.{key}", depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        if len(value) > MAX_COLLECTION_ITEMS:
+            raise TelemetryEventError(f"{path} contains too many items")
+        for index, item in enumerate(value):
+            _validate_json(item, f"{path}[{index}]", depth + 1)
+        return
+    raise TelemetryEventError(f"{path} contains unsupported value {type(value).__name__}")
+
+
+def validate_event(event: Mapping[str, JSONValue] | TelemetryEvent) -> dict[str, JSONValue]:
+    """Validate and copy a generic event before transport.
+
+    Transport requires a non-empty ``event_type`` field. Other fields remain
+    producer-owned and are preserved unchanged after privacy and size checks.
+    """
+    if isinstance(event, Mapping):
+        payload = dict(event)
+    else:
+        to_dict = getattr(event, "to_dict", None)
+        if not callable(to_dict):
+            raise TelemetryEventError("event must be a mapping or provide to_dict()")
+        raw_payload = to_dict()
+        if not isinstance(raw_payload, Mapping):
+            raise TelemetryEventError("to_dict() must return a mapping")
+        payload = dict(raw_payload)
+    _validate_json(payload)
+    event_type = payload.get("event_type")
+    if not isinstance(event_type, str) or not event_type.strip():
+        raise TelemetryEventError("event_type must be a non-empty string")
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_EVENT_BYTES:
+        raise TelemetryEventError("event exceeds the maximum serialized size")
+    return payload
+
+
+def _validate_correlation(correlation: Correlation | None) -> dict[str, str | None]:
+    if correlation is None:
+        return {}
+    if not isinstance(correlation, Mapping):
+        raise TelemetryEventError("correlation must be a mapping")
+    result: dict[str, str | None] = {}
+    for key, value in correlation.items():
+        if not isinstance(key, str) or not key:
+            raise TelemetryEventError("correlation keys must be non-empty strings")
+        if _is_sensitive_key(key):
+            raise TelemetryEventError(f"correlation.{key} is not allowed in telemetry events")
+        if value is not None and (not isinstance(value, str) or not value.strip()):
+            raise TelemetryEventError(f"correlation.{key} must be a non-empty string or null")
+        if value is not None:
+            _validate_string(value, f"correlation.{key}")
+        result[key] = value
+    return result
+
+
+def _valid_id(value: str | None, length: int) -> bool:
+    if not isinstance(value, str) or len(value) != length:
+        return False
+    try:
+        int(value, 16)
+    except ValueError:
+        return False
+    return True
+
+
+def _attribute(key: str, value: str) -> dict[str, Any]:
+    return {"key": key, "value": {"stringValue": value}}
+
+
+def _trace_id(event: Mapping[str, JSONValue], correlation: Mapping[str, str | None]) -> str:
+    supplied = correlation.get("trace_id")
+    if _valid_id(supplied, 32):
+        return str(supplied)
+    event_id = event.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        return uuid.uuid5(uuid.NAMESPACE_URL, event_id).hex
+    return uuid.uuid4().hex
+
+
+def build_event_record(
+    event: Mapping[str, JSONValue] | TelemetryEvent,
+    *,
+    correlation: Correlation | None = None,
+    parent_span_id: str | None = None,
+) -> dict[str, Any]:
+    """Build an OTLP trace record for one generic event.
+
+    The record uses a zero-duration span so existing JSONL and MLflow trace
+    exporters consume events without a separate storage or UI integration.
+    Correlation values are emitted as namespaced attributes and never
+    interpreted by this module.
+    """
+    payload = validate_event(event)
+    correlation_values = _validate_correlation(correlation)
+    trace_id = _trace_id(payload, correlation_values)
+    span_id = uuid.uuid4().hex[:16]
+    timestamp_ns = time.time_ns()
+    attributes = [
+        _attribute("event.name", str(payload["event_type"])),
+    ]
+    event_id = payload.get("event_id")
+    if isinstance(event_id, str) and event_id:
+        attributes.append(_attribute("event.id", event_id))
+    for key, value in correlation_values.items():
+        if value is not None:
+            attributes.append(_attribute(f"telemetry.correlation.{key}", value))
+
+    span: dict[str, Any] = {
+        "traceId": trace_id,
+        "spanId": span_id,
+        "name": str(payload["event_type"]),
+        "kind": 1,
+        "startTimeUnixNano": str(timestamp_ns),
+        "endTimeUnixNano": str(timestamp_ns),
+        "status": {"code": 0},
+        "attributes": attributes,
+        "events": [
+            {
+                "name": str(payload["event_type"]),
+                "timeUnixNano": str(timestamp_ns),
+                "attributes": [_attribute("telemetry.event", json.dumps(payload, sort_keys=True))],
+            }
+        ],
+    }
+    if _valid_id(parent_span_id, 16):
+        span["parentSpanId"] = parent_span_id
+
+    return {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "path": "/v1/traces",
+        "payload": {
+            "resourceSpans": [
+                {
+                    "resource": {"attributes": [_attribute("service.name", "agentic-ci")]},
+                    "scopeSpans": [
+                        {
+                            "scope": {"name": "agentic-ci.telemetry"},
+                            "spans": [span],
+                        }
+                    ],
+                }
+            ]
+        },
+    }
+
+
+def _resolve_log_root(log_root: str | Path) -> Path:
+    root = Path(log_root)
+    if root.is_symlink():
+        raise TelemetryEventError("log_root must not be a symbolic link")
+    root.mkdir(parents=True, exist_ok=True)
+    try:
+        resolved = root.resolve(strict=True)
+    except OSError as exc:
+        raise TelemetryEventError("log_root must be a valid directory") from exc
+    if not resolved.is_dir():
+        raise TelemetryEventError("log_root must be a directory")
+    return resolved
+
+
+def _open_log(root: Path, flags: int, mode: str):
+    directory_fd = os.open(root, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        try:
+            file_fd = os.open(
+                _LOG_FILENAME,
+                flags | os.O_NOFOLLOW,
+                0o600,
+                dir_fd=directory_fd,
+            )
+        except FileNotFoundError:
+            raise
+        except OSError as exc:
+            raise TelemetryEventError("telemetry log must be a regular file in log_root") from exc
+    finally:
+        os.close(directory_fd)
+    if not stat.S_ISREG(os.fstat(file_fd).st_mode):
+        os.close(file_fd)
+        raise TelemetryEventError("telemetry log must be a regular file in log_root")
+    return os.fdopen(file_fd, mode, encoding="utf-8")
+
+
+def _find_parent_span_id(log_root: Path, trace_id: str) -> str | None:
+    try:
+        with _open_log(log_root, os.O_RDONLY, "r") as stream:
+            for line in stream:
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if "/v1/traces" not in record.get("path", ""):
+                    continue
+                for resource_spans in (record.get("payload") or {}).get("resourceSpans", []):
+                    for scope_spans in resource_spans.get("scopeSpans", []):
+                        for span in scope_spans.get("spans", []):
+                            if span.get("traceId") == trace_id and not span.get("parentSpanId"):
+                                parent = span.get("spanId")
+                                if _valid_id(parent, 16):
+                                    return parent
+    except FileNotFoundError:
+        return None
+    return None
+
+
+def append_event(
+    log_root: str | Path,
+    event: Mapping[str, JSONValue] | TelemetryEvent,
+    *,
+    correlation: Correlation | None = None,
+    parent_span_id: str | None = None,
+) -> dict[str, Any]:
+    """Append an event to the fixed OTLP JSONL file beneath trusted ``log_root``."""
+    root = _resolve_log_root(log_root)
+    record = build_event_record(event, correlation=correlation, parent_span_id=parent_span_id)
+    span = record["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    if "parentSpanId" not in span:
+        parent = _find_parent_span_id(root, span["traceId"])
+        if parent:
+            span["parentSpanId"] = parent
+    with _open_log(root, os.O_WRONLY | os.O_CREAT | os.O_APPEND, "a") as stream:
+        stream.write(json.dumps(record) + "\n")
+    return record
+
+
+def _post_record(
+    endpoint: str,
+    record: Mapping[str, Any],
+    *,
+    headers: Mapping[str, str] | None,
+    timeout: float,
+) -> None:
+    url = endpoint.rstrip("/")
+    parsed = urlsplit(url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise TelemetryEventError("endpoint must be an HTTP(S) URL without userinfo")
+    if not url.endswith("/v1/traces"):
+        url = f"{url}/v1/traces"
+    try:
+        response = requests.post(
+            url,
+            json=record["payload"],
+            headers=dict(headers or {}),
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise TelemetryExportError(f"telemetry event export failed: {exc}") from exc
+
+
+def export_event(
+    endpoint: str,
+    event: Mapping[str, JSONValue] | TelemetryEvent,
+    *,
+    correlation: Correlation | None = None,
+    parent_span_id: str | None = None,
+    headers: Mapping[str, str] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    """Export one generic event to an OTLP HTTP trace endpoint."""
+    record = build_event_record(event, correlation=correlation, parent_span_id=parent_span_id)
+    _post_record(endpoint, record, headers=headers, timeout=timeout)
+    return record
+
+
+def emit_event(
+    event: Mapping[str, JSONValue] | TelemetryEvent,
+    *,
+    log_root: str | Path | None = None,
+    endpoint: str | None = None,
+    correlation: Correlation | None = None,
+    parent_span_id: str | None = None,
+    headers: Mapping[str, str] | None = None,
+    timeout: float = 30,
+) -> dict[str, Any]:
+    """Emit one event to JSONL, OTLP HTTP, or both.
+
+    At least one destination is required. This function does not catch write
+    or export errors, allowing callers to preserve their workflow's result
+    while deciding how to report transport failure.
+    """
+    if log_root is None and endpoint is None:
+        raise TelemetryEventError("log_root or endpoint is required")
+    if endpoint is not None and not endpoint.strip():
+        raise TelemetryEventError("endpoint must be a non-empty string")
+    if log_root is not None:
+        record = append_event(
+            log_root,
+            event,
+            correlation=correlation,
+            parent_span_id=parent_span_id,
+        )
+        if endpoint is not None:
+            _post_record(
+                endpoint,
+                record,
+                headers=headers,
+                timeout=timeout,
+            )
+        return record
+    return export_event(
+        endpoint or "",
+        event,
+        correlation=correlation,
+        parent_span_id=parent_span_id,
+        headers=headers,
+        timeout=timeout,
+    )
+
+
+__all__ = [
+    "Correlation",
+    "JSONValue",
+    "TelemetryEvent",
+    "TelemetryEventError",
+    "TelemetryExportError",
+    "append_event",
+    "build_event_record",
+    "emit_event",
+    "export_event",
+    "validate_event",
+]

--- a/tests/test_jira_client.py
+++ b/tests/test_jira_client.py
@@ -57,6 +57,7 @@ class TestGetIssue:
             "fields": {
                 "summary": "Fix bug",
                 "description": "Some desc",
+                "created": "2026-08-01T12:34:56.000+0000",
                 "issuetype": {"name": "Bug"},
                 "labels": ["autofix"],
                 "status": {"name": "Open"},
@@ -75,8 +76,26 @@ class TestGetIssue:
         result = client.get_issue("TEST-1")
         assert result["key"] == "TEST-1"
         assert result["summary"] == "Fix bug"
+        assert result["created"] == "2026-08-01T12:34:56.000+0000"
         assert result["reporter_email"] == "j@test.com"
         assert result["labels"] == ["autofix"]
+        assert "created" in mock_requests.get.call_args_list[0].args[0]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_get_issue_missing_created_defaults_to_empty_string(self, mock_requests, client):
+        issue_resp = MagicMock()
+        issue_resp.status_code = 200
+        issue_resp.json.return_value = {"key": "TEST-1", "fields": {}}
+
+        comment_resp = MagicMock()
+        comment_resp.status_code = 200
+        comment_resp.json.return_value = {"comments": []}
+
+        mock_requests.get.side_effect = [issue_resp, comment_resp]
+
+        result = client.get_issue("TEST-1")
+
+        assert result["created"] == ""
 
     @patch("agentic_ci.jira.client.requests")
     def test_fetch_comments_includes_updated(self, mock_requests, client):
@@ -130,6 +149,7 @@ class TestSearch:
                     "fields": {
                         "summary": "Bug 1",
                         "description": "desc",
+                        "created": "2026-08-02T12:34:56.000+0000",
                         "issuetype": {"name": "Bug"},
                         "labels": [],
                         "status": {"name": "Open"},
@@ -144,6 +164,22 @@ class TestSearch:
         results = client.search("project = TEST")
         assert len(results) == 1
         assert results[0]["key"] == "TEST-1"
+        assert results[0]["created"] == "2026-08-02T12:34:56.000+0000"
+        assert "created" in mock_requests.post.call_args.kwargs["json"]["fields"]
+
+    @patch("agentic_ci.jira.client.requests")
+    def test_search_missing_created_defaults_to_empty_string(self, mock_requests, client):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.json.return_value = {
+            "issues": [{"key": "TEST-1", "fields": {}}],
+            "isLast": True,
+        }
+        mock_requests.post.return_value = resp
+
+        results = client.search("project = TEST")
+
+        assert results[0]["created"] == ""
 
 
 class TestGetIssueLinks:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,206 @@
+"""Tests for generic event validation and OTLP transport."""
+
+import json
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+from requests import RequestException
+
+from agentic_ci.telemetry import (
+    TelemetryEventError,
+    TelemetryExportError,
+    append_event,
+    build_event_record,
+    emit_event,
+    export_event,
+    validate_event,
+)
+
+
+@dataclass(frozen=True)
+class EventObject:
+    event_type: str
+    event_id: str
+
+    def to_dict(self):
+        return {"event_type": self.event_type, "event_id": self.event_id, "value": {"ok": True}}
+
+
+def test_validate_accepts_mapping_and_protocol():
+    mapping = {"event_type": "workflow.completed", "event_id": "event-1", "value": 3}
+
+    assert validate_event(mapping) == mapping
+    assert validate_event(EventObject("workflow.completed", "event-2"))["event_id"] == "event-2"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {},
+        {"event_type": ""},
+        {"event_type": "workflow.completed", "value": float("inf")},
+        {"event_type": "workflow.completed", 1: "invalid"},
+        object(),
+    ],
+)
+def test_validate_rejects_invalid_events(event):
+    with pytest.raises(TelemetryEventError):
+        validate_event(event)
+
+
+def test_build_record_keeps_event_schema_and_correlation_generic():
+    record = build_event_record(
+        EventObject("workflow.completed", "event-3"),
+        correlation={
+            "work_item": "item-3",
+            "pipeline": "pipeline-4",
+            "trace_id": "a" * 32,
+        },
+    )
+    span = record["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    attributes = {item["key"]: item["value"]["stringValue"] for item in span["attributes"]}
+
+    assert record["path"] == "/v1/traces"
+    assert span["traceId"] == "a" * 32
+    assert span["status"]["code"] == 0
+    assert attributes["telemetry.correlation.work_item"] == "item-3"
+    assert attributes["telemetry.correlation.pipeline"] == "pipeline-4"
+    assert json.loads(span["events"][0]["attributes"][0]["value"]["stringValue"]) == {
+        "event_type": "workflow.completed",
+        "event_id": "event-3",
+        "value": {"ok": True},
+    }
+
+
+def test_event_type_only_records_get_unique_trace_ids():
+    first = build_event_record({"event_type": "workflow.completed"})
+    second = build_event_record({"event_type": "workflow.completed"})
+
+    first_span = first["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    second_span = second["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+    assert first_span["traceId"] != second_span["traceId"]
+
+
+def test_append_event_joins_existing_trace_root(tmp_path):
+    log_root = tmp_path / "run"
+    log_file = log_root / "claude-otel.jsonl"
+    root = {
+        "path": "/v1/traces",
+        "payload": {
+            "resourceSpans": [
+                {"scopeSpans": [{"spans": [{"traceId": "b" * 32, "spanId": "c" * 16}]}]}
+            ]
+        },
+    }
+    log_root.mkdir()
+    log_file.write_text(json.dumps(root) + "\n", encoding="utf-8")
+
+    record = append_event(
+        log_root,
+        {"event_type": "workflow.completed", "event_id": "event-4"},
+        correlation={"trace_id": "b" * 32},
+    )
+    span = record["payload"]["resourceSpans"][0]["scopeSpans"][0]["spans"][0]
+
+    assert span["parentSpanId"] == "c" * 16
+    assert len(log_file.read_text(encoding="utf-8").splitlines()) == 2
+
+
+def test_emit_event_requires_destination():
+    with pytest.raises(TelemetryEventError, match="log_root or endpoint"):
+        emit_event({"event_type": "workflow.completed"})
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"event_type": "workflow.completed", "password": "not-safe"},
+        {"event_type": "workflow.completed", "metadata": {"api-key": "not-safe"}},
+        {"event_type": "workflow.completed", "metadata": {"provider_secret": "not-safe"}},
+        {"event_type": "workflow.completed", "prompt": "summarize this"},
+        {"event_type": "workflow.completed", "value": "Bearer abcdefghijklmnop"},
+        {"event_type": "workflow.completed", "value": "owner@example.com"},
+        {"event_type": "workflow.completed", "value": "https://user:pass@example.test/x"},
+        {
+            "event_type": "workflow.completed",
+            "value": "https://collector.test/x?access_token=secret-value",
+        },
+    ],
+)
+def test_validate_rejects_sensitive_event_content(event):
+    with pytest.raises(TelemetryEventError):
+        validate_event(event)
+
+
+def test_validate_allows_aggregate_tokens_and_safe_urls():
+    event = {
+        "event_type": "workflow.completed",
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "repository": "https://github.com/example/repository",
+    }
+
+    assert validate_event(event) == event
+
+
+def test_build_record_rejects_sensitive_correlation():
+    with pytest.raises(TelemetryEventError, match="sensitive content"):
+        build_event_record(
+            {"event_type": "workflow.completed"},
+            correlation={"work_item": "owner@example.com"},
+        )
+
+
+def test_validate_rejects_oversized_events():
+    event = {"event_type": "workflow.completed", "values": ["x" * 100] * 1_000}
+
+    with pytest.raises(TelemetryEventError, match="maximum serialized size"):
+        validate_event(event)
+
+
+def test_append_event_rejects_symlink_log_file(tmp_path):
+    log_root = tmp_path / "run"
+    log_root.mkdir()
+    outside = tmp_path / "outside.jsonl"
+    outside.write_text("unchanged\n", encoding="utf-8")
+    (log_root / "claude-otel.jsonl").symlink_to(outside)
+
+    with pytest.raises(TelemetryEventError, match="regular file"):
+        append_event(log_root, {"event_type": "workflow.completed"})
+
+    assert outside.read_text(encoding="utf-8") == "unchanged\n"
+
+
+def test_append_event_rejects_symlink_log_root(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    log_root = tmp_path / "run"
+    log_root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(TelemetryEventError, match="symbolic link"):
+        append_event(log_root, {"event_type": "workflow.completed"})
+
+
+def test_export_event_posts_otlp_payload():
+    response = mock.Mock()
+    with mock.patch("agentic_ci.telemetry.requests.post", return_value=response) as post:
+        record = export_event(
+            "http://collector:4318",
+            {"event_type": "workflow.completed", "event_id": "event-5"},
+            headers={"Authorization": "Bearer test"},
+        )
+
+    post.assert_called_once()
+    assert post.call_args.args[0] == "http://collector:4318/v1/traces"
+    assert post.call_args.kwargs["json"] == record["payload"]
+    assert post.call_args.kwargs["headers"] == {"Authorization": "Bearer test"}
+
+
+def test_export_failure_is_reported_without_swallowing():
+    with mock.patch(
+        "agentic_ci.telemetry.requests.post",
+        side_effect=RequestException("offline"),
+    ):
+        with pytest.raises(TelemetryExportError, match="offline"):
+            export_event("http://collector:4318", {"event_type": "workflow.completed"})


### PR DESCRIPTION
## Summary

- add producer-agnostic event validation and OTLP transport
- accept mappings or protocol objects without owning workflow schemas
- preserve correlation identifiers and join existing trace roots

## Validation

- 944 non-MLflow unit tests passed
- telemetry regression tests passed independently
- lint, format, mypy, and strict documentation checks passed

## Dependency boundary

The Autofix lifecycle contract is owned by AIPCC-31384 in the Autofix repository. A follow-up Autofix producer will use this transport after the contract and transport APIs land.

Jira: https://redhat.atlassian.net/browse/AIPCC-31377


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added generic event telemetry transport for recording producer events in JSONL logs or exporting them through OTLP.
  - Supports JSON-compatible event data, correlation identifiers, trace context, and configurable export destinations.
  - Reports invalid event data and transport failures to callers for handling according to their workflow requirements.

- **Documentation**
  - Added API and architecture documentation covering event validation, recording, export, and failure handling.
  - Added the telemetry module to the available module and API reference listings.

- **Tests**
  - Added coverage for validation, correlation, trace creation, local logging, successful export, and export failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->