### PR TITLE
feat(plugins): let a skill declare shared paths to install alongside it

### DIFF
--- a/docs/image/skills.md
+++ b/docs/image/skills.md
@@ -111,6 +111,55 @@ RUN git clone --depth 1 --quiet https://github.com/opendatahub-io/skills-registr
 All skills are flat in one directory — no plugin namespacing. OpenCode
 discovers them by scanning for `SKILL.md` files.
 
+Two consequences follow from that flat layout. A skill name that another
+plugin already claims is a destination collision, and the colliding plugin is
+skipped whole rather than skill by skill, so prefixing skill names keeps a
+plugin installable. And a plugin whose skills share code cannot keep that code
+above them, because only the skill directories are copied and symlinks into a
+parent are dropped. Declaring the shared paths is how a plugin brings them
+along.
+
+### Shared code between skills
+
+A skill declares the trees it needs in its frontmatter, as paths relative to
+the plugin source root:
+
+```yaml
+---
+name: docs-write
+description: Generate documentation for a code module.
+metadata:
+  x-shared-paths: lib prompts schemas
+---
+```
+
+Each declared path is copied to the same relative path inside the installed
+skill, so `lib/run/step.py` in the source repository arrives at
+`~/.config/opencode/skills/docs-write/lib/run/step.py`. A script can then reach
+it by walking up from `__file__`, and the same walk finds the repository copy
+during development.
+
+```text
+~/.config/opencode/skills/
+  docs-write/
+    SKILL.md
+    scripts/write.py
+    lib/run/step.py       # brought along, one copy per declaring skill
+    prompts/
+    schemas/
+```
+
+The source repository keeps one copy. Every skill that declares the path gets
+one, which is what makes the tree available without the plugin vendoring copies
+into its own git history.
+
+Paths are refused when they escape the source root, when they are absolute,
+when they are symlinks, and when the skill already ships a file or directory at
+that destination. A missing path warns and the install continues.
+
+The `x-` prefix follows the convention for extension fields, so an official
+`shared-paths` key with different semantics would not collide with this one.
+
 ## Codex: native plugins with legacy compatibility
 
 Codex has a native plugin and marketplace system. At build time,

--- a/src/agentic_ci/plugins.py
+++ b/src/agentic_ci/plugins.py
@@ -31,6 +31,7 @@ import tempfile
 from pathlib import Path
 
 from agentic_ci.git import clone_repo
+from agentic_ci.skill_metadata import load_skill_metadata
 
 DEFAULT_MANIFEST_PATH = "/usr/local/share/agentic-ci/plugin-skills.manifest.json"
 
@@ -75,6 +76,76 @@ def _copy_tree(src: Path, dest: Path) -> None:
             _copy_tree(item, target)
         else:
             shutil.copy2(item, target)
+
+
+def _copy_shared_paths(skill_dir: Path, source_root: Path, dest: Path) -> list[str]:
+    """Copy the trees a skill declares in ``metadata.x-shared-paths``.
+
+    Skills are installed one directory at a time, so code shared between
+    several of them has nowhere to live: a tree above the skills is left
+    behind, and a symlink into it is dropped by :func:`_copy_tree`. Declaring
+    the paths lets the installer bring them along, which keeps one copy in the
+    source repository instead of one per skill.
+
+    Each path is relative to the plugin source root and lands at the same
+    relative path inside the installed skill, so a script can reach it the same
+    way in a checkout and after an install. Paths escaping the source root are
+    rejected, and a path that would overwrite something the skill already ships
+    is skipped rather than clobbering it.
+
+    Returns the paths that were copied.
+    """
+    try:
+        metadata = load_skill_metadata(skill_dir / "SKILL.md")
+    except (OSError, UnicodeDecodeError) as exc:
+        print(f"  WARN: cannot read {skill_dir / 'SKILL.md'}: {exc}")
+        return []
+
+    copied: list[str] = []
+    for raw in metadata.shared_paths:
+        rel = raw.removeprefix("./")
+        if not rel or Path(rel).is_absolute():
+            print(f"  WARN: rejected absolute shared path: {raw}")
+            continue
+
+        declared = source_root / rel
+        # Test for a link before resolving, because resolving follows it and
+        # `_copy_tree` refuses links for the same reason: a declared path is
+        # allowed to name a tree in the repository, never a way out of it.
+        if declared.is_symlink():
+            print(f"  WARN: skipping symlinked shared path: {raw}")
+            continue
+
+        candidate = declared.resolve()
+        try:
+            candidate.relative_to(source_root.resolve())
+        except ValueError:
+            print(f"  WARN: rejected shared path outside repository: {raw}")
+            continue
+        if not candidate.exists():
+            print(f"  WARN: shared path not found: {raw}")
+            continue
+
+        target = (dest / rel).resolve()
+        try:
+            target.relative_to(dest.resolve())
+        except ValueError:
+            print(f"  WARN: rejected shared path destination outside skill: {raw}")
+            continue
+        if target.exists():
+            print(f"  WARN: {skill_dir.name} already ships {rel}; leaving it alone")
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if candidate.is_dir():
+            _copy_tree(candidate, target)
+        else:
+            shutil.copy2(candidate, target)
+        copied.append(rel)
+
+    if copied:
+        print(f"  {skill_dir.name}: brought along {', '.join(copied)}")
+    return copied
 
 
 def _check_unmatched(wanted: set[str], matched: set[str]) -> None:
@@ -250,7 +321,9 @@ def install_opencode_skills(
                 continue
 
             for skill_name, skill_dir in skill_dirs.items():
-                _copy_tree(skill_dir, skills_dir / skill_name)
+                destination = skills_dir / skill_name
+                _copy_tree(skill_dir, destination)
+                _copy_shared_paths(skill_dir, source_root, destination)
             if skill_dirs:
                 manifest[name] = sorted(skill_dirs)
 

--- a/src/agentic_ci/skill_metadata.py
+++ b/src/agentic_ci/skill_metadata.py
@@ -20,6 +20,12 @@ _NESTED_KV_RE = re.compile(r"^\s+([a-z][a-z0-9-]*)\s*:\s*(.*)", re.IGNORECASE)
 # adds an official "artifacts" key with different semantics.
 _METADATA_ARTIFACTS_KEY = "x-artifacts"
 
+# Paths, relative to the plugin source root, that a skill needs alongside it.
+# Installers that copy one skill directory at a time leave a shared tree behind;
+# declaring it here lets the installer bring it along instead of every skill
+# vendoring its own copy.
+_METADATA_SHARED_PATHS_KEY = "x-shared-paths"
+
 
 def _strip_quotes(s: str) -> str:
     if len(s) >= 2 and s[0] == s[-1] and s[0] in ('"', "'"):
@@ -100,6 +106,7 @@ class SkillMetadata:
     user_invocable: bool = False
     metadata: dict[str, str] = field(default_factory=dict)
     artifacts: list[str] = field(default_factory=list)
+    shared_paths: list[str] = field(default_factory=list)
 
 
 def load_skill_metadata(skill_md_path: Path) -> SkillMetadata:
@@ -125,6 +132,9 @@ def load_skill_metadata(skill_md_path: Path) -> SkillMetadata:
     artifacts_str = metadata.get(_METADATA_ARTIFACTS_KEY, "")
     artifacts = artifacts_str.split() if artifacts_str else []
 
+    shared_str = metadata.get(_METADATA_SHARED_PATHS_KEY, "")
+    shared_paths = shared_str.split() if shared_str else []
+
     description = data.get("description", "")
     if not isinstance(description, str):
         description = ""
@@ -136,6 +146,7 @@ def load_skill_metadata(skill_md_path: Path) -> SkillMetadata:
         user_invocable=user_invocable,
         metadata=metadata,
         artifacts=artifacts,
+        shared_paths=shared_paths,
     )
 
 

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -9,6 +9,7 @@ import pytest
 
 from agentic_ci.plugins import (
     _codex_marketplace_root,
+    _copy_shared_paths,
     _filter_codex,
     _find_skill_names,
     _run_codex_json,
@@ -878,3 +879,176 @@ def test_run_codex_json_reports_stderr(capsys):
     output = capsys.readouterr().out
     assert "exit 2" in output
     assert "plugin registry unavailable" in output
+
+
+# -- shared paths ------------------------------------------------------------
+
+
+class TestSharedPaths:
+    """``metadata.x-shared-paths`` brings a plugin's shared tree along.
+
+    Skills install one directory at a time, so code shared between several of
+    them is left behind and a symlink into it is dropped. Declaring the paths
+    keeps one copy in the source repository instead of one per skill.
+    """
+
+    def _make_repo(self, tmp_path, shared="lib", extra_skill_body=""):
+        repo = tmp_path / "mock-repo"
+        lib = repo / "lib" / "run"
+        lib.mkdir(parents=True)
+        (lib / "step.py").write_text("SHARED = 1\n")
+        (repo / "lib" / "__init__.py").write_text("")
+        (repo / "prompts").mkdir()
+        (repo / "prompts" / "write.md").write_text("prompt\n")
+
+        skill = repo / "skills" / "writer"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\n"
+            "name: writer\n"
+            "metadata:\n"
+            f"  x-shared-paths: {shared}\n"
+            "---\n"
+            f"Body\n{extra_skill_body}"
+        )
+        (skill / "scripts").mkdir()
+        (skill / "scripts" / "write.py").write_text("import lib.run.step\n")
+        return repo
+
+    def _marketplace(self, tmp_path):
+        mkt = tmp_path / "marketplace.json"
+        mkt.write_text(
+            json.dumps(
+                {
+                    "name": "test-mkt",
+                    "plugins": [
+                        {
+                            "name": "mock-writer",
+                            "version": "1.0.0",
+                            "source": {"repo": "fake/mock", "ref": "main"},
+                        }
+                    ],
+                }
+            )
+        )
+        return mkt
+
+    def _install(self, tmp_path, repo):
+        mkt = self._marketplace(tmp_path)
+        skills_dir = tmp_path / "skills"
+        manifest = tmp_path / "manifest.json"
+
+        def fake_clone(url, dest, branch=None, depth=None):
+            shutil.copytree(repo, dest)
+            return True
+
+        with mock.patch("agentic_ci.plugins.clone_repo", side_effect=fake_clone):
+            install_opencode_skills(mkt, skills_dir=skills_dir, manifest_path=manifest)
+        return skills_dir
+
+    def test_declared_tree_lands_beside_the_skill(self, tmp_path):
+        repo = self._make_repo(tmp_path, shared="lib prompts")
+        skills_dir = self._install(tmp_path, repo)
+
+        assert (skills_dir / "writer" / "SKILL.md").is_file()
+        assert (skills_dir / "writer" / "lib" / "run" / "step.py").is_file()
+        assert (skills_dir / "writer" / "prompts" / "write.md").is_file()
+
+    def test_relative_path_is_preserved(self, tmp_path):
+        """A script reaches the tree the same way installed and in a checkout."""
+        repo = tmp_path / "mock-repo"
+        nested = repo / "shared" / "lib"
+        nested.mkdir(parents=True)
+        (nested / "step.py").write_text("SHARED = 1\n")
+        skill = repo / "skills" / "writer"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(
+            "---\nname: writer\nmetadata:\n  x-shared-paths: shared/lib\n---\nBody\n"
+        )
+
+        skills_dir = self._install(tmp_path, repo)
+        assert (skills_dir / "writer" / "shared" / "lib" / "step.py").is_file()
+
+    def test_a_single_file_is_copied(self, tmp_path):
+        repo = self._make_repo(tmp_path, shared="prompts/write.md")
+        skills_dir = self._install(tmp_path, repo)
+        assert (skills_dir / "writer" / "prompts" / "write.md").is_file()
+        assert not (skills_dir / "writer" / "lib").exists()
+
+    def test_no_declaration_copies_nothing_extra(self, tmp_path):
+        repo = tmp_path / "mock-repo"
+        (repo / "lib").mkdir(parents=True)
+        (repo / "lib" / "step.py").write_text("SHARED = 1\n")
+        skill = repo / "skills" / "writer"
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text("---\nname: writer\n---\nBody\n")
+
+        skills_dir = self._install(tmp_path, repo)
+        assert (skills_dir / "writer" / "SKILL.md").is_file()
+        assert not (skills_dir / "writer" / "lib").exists()
+
+    def test_path_escaping_the_repository_is_rejected(self, tmp_path):
+        secret = tmp_path / "outside"
+        secret.mkdir()
+        (secret / "secret.txt").write_text("do not copy me\n")
+
+        repo = self._make_repo(tmp_path, shared="../outside")
+        skills_dir = self._install(tmp_path, repo)
+
+        assert not (skills_dir / "writer" / "outside").exists()
+        assert not list(skills_dir.rglob("secret.txt"))
+
+    def test_absolute_path_is_rejected(self, tmp_path):
+        repo = self._make_repo(tmp_path, shared="/etc")
+        skills_dir = self._install(tmp_path, repo)
+        assert not (skills_dir / "writer" / "etc").exists()
+
+    def test_missing_path_warns_and_continues(self, tmp_path, capsys):
+        repo = self._make_repo(tmp_path, shared="lib nope")
+        skills_dir = self._install(tmp_path, repo)
+
+        assert (skills_dir / "writer" / "lib" / "run" / "step.py").is_file()
+        assert "shared path not found: nope" in capsys.readouterr().out
+
+    def test_skill_content_is_never_overwritten(self, tmp_path, capsys):
+        repo = self._make_repo(tmp_path, shared="lib")
+        own = repo / "skills" / "writer" / "lib"
+        own.mkdir()
+        (own / "mine.py").write_text("OWN = 1\n")
+
+        skills_dir = self._install(tmp_path, repo)
+
+        assert (skills_dir / "writer" / "lib" / "mine.py").read_text() == "OWN = 1\n"
+        assert not (skills_dir / "writer" / "lib" / "run").exists()
+        assert "already ships lib" in capsys.readouterr().out
+
+    def test_symlinked_shared_path_is_skipped(self, tmp_path, capsys):
+        """A link is refused for the same reason `_copy_tree` refuses one.
+
+        Exercised against `_copy_shared_paths` directly: the fake clone these
+        tests use dereferences links on the way in, so the link would not
+        survive to reach the installer.
+        """
+        repo = self._make_repo(tmp_path, shared="linked")
+        (repo / "linked").symlink_to(repo / "lib", target_is_directory=True)
+        dest = tmp_path / "installed-writer"
+        dest.mkdir()
+
+        copied = _copy_shared_paths(repo / "skills" / "writer", repo, dest)
+
+        assert copied == []
+        assert not (dest / "linked").exists()
+        assert "skipping symlinked shared path" in capsys.readouterr().out
+
+    def test_every_skill_declaring_the_tree_gets_it(self, tmp_path):
+        """One copy in the repository, one copy per installed skill."""
+        repo = self._make_repo(tmp_path, shared="lib")
+        second = repo / "skills" / "reviewer"
+        second.mkdir(parents=True)
+        (second / "SKILL.md").write_text(
+            "---\nname: reviewer\nmetadata:\n  x-shared-paths: lib\n---\nBody\n"
+        )
+
+        skills_dir = self._install(tmp_path, repo)
+        assert (skills_dir / "writer" / "lib" / "run" / "step.py").is_file()
+        assert (skills_dir / "reviewer" / "lib" / "run" / "step.py").is_file()


### PR DESCRIPTION
## The problem

`install_opencode_skills` copies skills one directory at a time, and `_copy_tree` drops symlinks with a warning. A plugin whose skills share code therefore has nowhere to put it. A tree above the skills is left behind, and a symlink into that tree is skipped.

The workaround available today is for the plugin to vendor a copy of the shared tree into every skill directory and commit all of them. For a plugin with five skills sharing a 2,500-line library, that is five copies in git and the same diff landing in five places on every change.

## What this adds

A skill declares the paths it needs, relative to the plugin source root:

```yaml
---
name: docs-write
description: Generate documentation for a code module.
metadata:
  x-shared-paths: lib prompts schemas
---
```

Each path is copied to the same relative path inside the installed skill, so `lib/run/step.py` in the source repository arrives at `~/.config/opencode/skills/docs-write/lib/run/step.py`. A script reaches it by walking up from `__file__`, and the same walk finds the repository copy during development, so one resolution works installed and in a checkout.

The source repository keeps one copy. Each declaring skill gets one at install time.

## Safety

A declared path is refused when it escapes the source root, when it is absolute, when it is a symlink, and when the skill already ships a file or directory at that destination. A missing path warns and the install continues rather than failing the whole plugin.

The symlink test happens before resolution, since resolving follows the link. That is the same reason `_copy_tree` refuses links: a declared path may name a tree in the repository, never a way out of it.

## Scope

Native Claude Code and Codex plugin installs are unaffected. They receive the whole plugin tree, so shared paths are already present. Only `install_opencode_skills` and the Codex legacy fallback that delegates to it needed the change.

The `x-` prefix follows the convention already set by `x-artifacts` in `skill_metadata.py`, so an official `shared-paths` key with different semantics would not collide with this one.

## Verification

```
970 passed          # 11 new in TestSharedPaths
ruff check src tests    clean
```

New tests cover the copy, relative-path preservation, single files, the no-declaration case, path traversal, absolute paths, missing paths, symlinks, not overwriting the skill's own content, and two skills declaring the same tree.

## Context

Found while building a documentation generator in `opendatahub-io/docs-skills`, where six skills share a library, a prompt set, and a schema set. The workaround there was to move the shared code into a seventh skill and have the others resolve it as a flat sibling, which works but exists only to satisfy the installer.

Related: this also makes it worth noting in the docs that a destination collision skips the colliding plugin whole rather than skill by skill, so unprefixed skill names are a live risk. That behaviour is unchanged here; the docs update just says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018GUFhxYdoihvGuMMgtpiq5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Skills can now declare shared files or directories using `x-shared-paths`.
  - Declared shared content is copied into each installed skill while preserving relative paths.
  - Invalid, unsafe, or conflicting paths are rejected safely; missing paths generate warnings while installation continues.

- **Documentation**
  - Added guidance for shared code between skills, including layout requirements, supported metadata, and path-handling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->